### PR TITLE
Add network utility modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,6 @@ Many thanks to:
 - Translators who have localized the game to several languages.
 - People who have provided ideas and feedback for the game.
 - Overall, our awesome community who makes this project possible.
+
+## Port to Unity
+For details about the ongoing C# port, check [VelorenPort/README.md](VelorenPort/README.md). The assemblies `CoreEngine`, `Network` and `World` incluyen estructuras base y utilidades como `Api` y `Metrics` para comenzar con la lógica compartida, la red y la generación de terreno. Se añadieron tipos de error y flujos (`Stream`) en la red para acercar la funcionalidad al crate original. El port continuará de forma gradual.

--- a/VelorenPort/Assets/README.md
+++ b/VelorenPort/Assets/README.md
@@ -1,0 +1,9 @@
+# Assets
+
+Carpeta para recursos convertidos (modelos, texturas, sonidos). Originalmente en `assets`.
+
+**Viabilidad**: Alta. Los recursos pueden importarse a Unity con pocas modificaciones, aunque se deben convertir a formatos compatibles.
+
+**Notas**:
+- Automatizar el proceso de importación de voxels y texturas.
+- Gestionar licencias de terceros al migrar.

--- a/VelorenPort/CLI/README.md
+++ b/VelorenPort/CLI/README.md
@@ -1,0 +1,8 @@
+# CLI
+
+Herramientas de consola y utilidades para el servidor (`server-cli`).
+
+**Viabilidad**: Alta. Las aplicaciones de consola son sencillas de portar a C#.
+
+**Notas**:
+- Reescribir comandos y utilidades usando .NET `System.CommandLine` o similar.

--- a/VelorenPort/Client/README.md
+++ b/VelorenPort/Client/README.md
@@ -1,0 +1,9 @@
+# Client
+
+Implementación de la interfaz y lógica de cliente (`client` y `voxygen`).
+
+**Viabilidad**: Alta. Unity reemplazará muchos subsistemas gráficos, por lo que el cliente actual en Rust (basado en wgpu y egui) será recreado con las herramientas de Unity. Gran parte de la lógica de juego se puede portar a scripts de C#.
+
+**Notas**:
+- Estudiar si ciertas utilidades (i18n, animaciones, HUD) pueden integrarse con paquetes de Unity.
+- Los recursos cargados se adaptarán al formato compatible con Unity.

--- a/VelorenPort/CoreEngine/CoreEngine.asmdef
+++ b/VelorenPort/CoreEngine/CoreEngine.asmdef
@@ -1,0 +1,13 @@
+{
+  "name": "CoreEngine",
+  "references": [],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/VelorenPort/CoreEngine/README.md
+++ b/VelorenPort/CoreEngine/README.md
@@ -1,0 +1,8 @@
+# CoreEngine
+
+Contiene los crates bajo `common` que agrupan la lógica compartida: ECS, definiciones de componentes, utilidades de red y estado.
+
+**Viabilidad**: Media. Estos módulos usan conceptos avanzados de Rust como traits genéricos y macros. En C# se pueden recrear usando patrones de composición y generics, pero requiere reescribir gran parte del código.
+
+**Notas**:
+- Revisar cada submódulo (`ecs`, `base`, `state`, `systems`) y mapear a sistemas de Unity (ej. utilizar `ECS` de Unity si se desea, o implementar estructura propia).

--- a/VelorenPort/CoreEngine/Src/CharacterId.cs
+++ b/VelorenPort/CoreEngine/Src/CharacterId.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace VelorenPort.CoreEngine {
+    [Serializable]
+    public struct CharacterId : IEquatable<CharacterId>
+    {
+        public long Value;
+        public CharacterId(long value) { Value = value; }
+        public bool Equals(CharacterId other) => Value == other.Value;
+        public override bool Equals(object obj) => obj is CharacterId other && Equals(other);
+        public override int GetHashCode() => Value.GetHashCode();
+        public override string ToString() => Value.ToString();
+        public static implicit operator long(CharacterId id) => id.Value;
+        public static implicit operator CharacterId(long value) => new CharacterId(value);
+    }
+}

--- a/VelorenPort/CoreEngine/Src/RtSimEntity.cs
+++ b/VelorenPort/CoreEngine/Src/RtSimEntity.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace VelorenPort.CoreEngine {
+    [Serializable]
+    public struct RtSimEntity : IEquatable<RtSimEntity>
+    {
+        public int Value; // Placeholder for NpcId
+        public RtSimEntity(int value) { Value = value; }
+        public bool Equals(RtSimEntity other) => Value == other.Value;
+        public override bool Equals(object obj) => obj is RtSimEntity other && Equals(other);
+        public override int GetHashCode() => Value.GetHashCode();
+        public override string ToString() => Value.ToString();
+        public static implicit operator int(RtSimEntity id) => id.Value;
+        public static implicit operator RtSimEntity(int value) => new RtSimEntity(value);
+    }
+
+    public enum Actor
+    {
+        Npc,
+        Character
+    }
+}

--- a/VelorenPort/CoreEngine/Src/Uid.cs
+++ b/VelorenPort/CoreEngine/Src/Uid.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using Unity.Entities;
+
+namespace VelorenPort.CoreEngine {
+    [Serializable]
+    public struct Uid : IEquatable<Uid> {
+        public ulong Value;
+        public Uid(ulong value) { Value = value; }
+        public bool Equals(Uid other) => Value == other.Value;
+        public override bool Equals(object obj) => obj is Uid other && Equals(other);
+        public override int GetHashCode() => Value.GetHashCode();
+        public override string ToString() => Value.ToString();
+        public static implicit operator ulong(Uid id) => id.Value;
+        public static implicit operator Uid(ulong value) => new Uid(value);
+    }
+
+    internal class UidAllocator {
+        private ulong _nextUid = 0;
+        public Uid Allocate() => new Uid(_nextUid++);
+    }
+
+    /// <summary>
+    /// Mapping from various IDs to ECS entities.
+    /// </summary>
+    public class IdMaps {
+        private readonly Dictionary<Uid, Entity> _uidMapping = new();
+        private readonly Dictionary<CharacterId, Entity> _characterToEcs = new();
+        private readonly Dictionary<RtSimEntity, Entity> _rtsimToEcs = new();
+        private readonly UidAllocator _allocator = new();
+
+        public Entity? GetEntity(Uid uid) => _uidMapping.TryGetValue(uid, out var e) ? e : (Entity?)null;
+        public Entity? GetEntity(CharacterId id) => _characterToEcs.TryGetValue(id, out var e) ? e : (Entity?)null;
+        public Entity? GetEntity(RtSimEntity id) => _rtsimToEcs.TryGetValue(id, out var e) ? e : (Entity?)null;
+
+        public void AddEntity(Uid uid, Entity entity) => _uidMapping[uid] = entity;
+        public void AddCharacter(CharacterId id, Entity entity) => _characterToEcs[id] = entity;
+        public void AddRtSim(RtSimEntity id, Entity entity) => _rtsimToEcs[id] = entity;
+
+        public Uid Allocate(Entity entity) {
+            var uid = _allocator.Allocate();
+            _uidMapping[uid] = entity;
+            return uid;
+        }
+
+        public void RemapEntity(Uid uid, Entity newEntity) => _uidMapping[uid] = newEntity;
+
+        public Entity? RemoveEntity(Uid uid) {
+            if (_uidMapping.TryGetValue(uid, out var entity)) {
+                _uidMapping.Remove(uid);
+                return entity;
+            }
+            return null;
+        }
+    }
+}

--- a/VelorenPort/Docs/Interoperabilidad.md
+++ b/VelorenPort/Docs/Interoperabilidad.md
@@ -1,0 +1,5 @@
+# Interoperabilidad con código Rust
+
+Este documento recogerá pruebas para integrar módulos existentes en Rust mediante FFI o Wasm, en caso de que ciertos subsistemas se mantengan en Rust.
+
+Pendiente de investigación.

--- a/VelorenPort/Docs/Plan.md
+++ b/VelorenPort/Docs/Plan.md
@@ -1,0 +1,34 @@
+# Plan de acción para el port a C#
+Para un desglose completo de ficheros y tareas consulte [PlanDetallado.md](PlanDetallado.md).
+
+
+1. **Análisis profundo del código**
+   - Revisar cada crate de Rust para identificar dependencias y responsabilidades.
+   - Documentar en `Docs` cualquier hallazgo relevante.
+
+2. **Diseño de arquitectura en Unity**
+   - Definir cómo se mapeará la estructura actual a proyectos de Unity (assemblies por sistema).
+   - Evaluar uso de `ECS` de Unity o implementación propia.
+
+3. **Portar sistema de redes**
+   - Crear módulos C# que reproduzcan el comportamiento de `veloren-network`.
+   - Se añadieron utilidades iniciales (`Metrics`, `Scheduler`, `Util` y un `Api` de alto nivel) junto a `Network`.
+   - Se incorporó una pequeña jerarquía de errores (`NetworkError`, `NetworkConnectError`, `ParticipantError`, `StreamError`) y la clase `Stream` para continuar la equivalencia con Rust.
+   - Probar comunicación cliente-servidor básica dentro de Unity.
+   - Evaluar si conviene migrar todo el crate de una vez o avanzar por partes, comenzando por las estructuras de mensajes.
+
+4. **Portar lógica de mundo y simulación**
+   - Se comenzó con una assembly `World` que contiene bloques y un Índice básicos.
+   - Adaptar generador de mundo y datos persistentes.
+   - Decidir si `rtsim` se reescribe o se mantiene en Rust mediante FFI.
+
+5. **Migrar interfaz y cliente**
+   - Reemplazar `voxygen` con escenas y UI de Unity.
+   - Integrar sistemas de animación y controladores.
+
+6. **Herramientas y CLI**
+   - Reescribir scripts de servidor y utilidades.
+
+7. **Pruebas y validación**
+   - Implementar pruebas unitarias y de integración en C#.
+   - Verificar compatibilidad multiplataforma.

--- a/VelorenPort/Docs/PlanDetallado.md
+++ b/VelorenPort/Docs/PlanDetallado.md
@@ -1,0 +1,204 @@
+# Plan de Acción Detallado
+
+Este documento describe paso a paso el port del código de Veloren a C# y Unity. Se listan los ficheros fuente principales de cada sistema y se sugieren tareas iniciales para la migración. La idea es usar este plan como referencia continua durante todo el proceso.
+
+## Estructura general
+- Cada sistema de Rust se convertirá en una **Assembly Definition** en Unity.
+- Se respetará la jerarquía de carpetas actual para mantener la organización.
+- Las pruebas unitarias se reescribirán usando el framework de pruebas de Unity.
+
+Hasta ahora se han creado las assemblies `CoreEngine` y `Network`, con sus primeros archivos de código en C#, incluyendo direcciones, eventos e identificadores de red. El módulo de red incorpora un esqueleto de clase `Network` con participantes y canales simulados para comenzar a probar conexiones. Se añadieron además módulos auxiliares (`Metrics`, `Scheduler`, `Util` y un `Api` público) para preparar la funcionalidad completa. Recientemente se añadieron los enums de error (`NetworkError`, `NetworkConnectError`, `ParticipantError`, `StreamError`) y la clase `Stream` para cubrir la señalización básica de fallos y el flujo de mensajes.
+Se suma la assembly `World` con estructuras de terreno simplificadas para iniciar el port del crate `world`.
+## 1. CoreEngine (crate `common`)
+### Ficheros relevantes
+- astar.rs
+- cached_spatial_grid.rs
+- calendar.rs
+- character.rs
+- clock.rs
+- cmd.rs
+- combat.rs
+- consts.rs
+- depot.rs
+- effect.rs
+- event.rs
+- explosion.rs
+- generation.rs
+- grid.rs
+- interaction.rs
+- lib.rs
+- link.rs
+- lod.rs
+- lottery.rs
+- mounting.rs
+- npc.rs
+- outcome.rs
+- path.rs
+- ray.rs
+- recipe.rs
+- region.rs
+- resources.rs
+- rtsim.rs
+- shared_server_config.rs
+- skillset_builder.rs
+- slowjob.rs
+- spiral.rs
+- spot.rs
+- store.rs
+- tether.rs
+- time.rs
+- trade.rs
+- typed.rs
+- uid.rs
+- view_distances.rs
+- vol.rs
+- weather.rs
+
+### Pasos recomendados
+1. Crear un proyecto de biblioteca en Unity llamado **CoreEngine**.
+2. Convertir cada módulo en un espacio de nombres de C# manteniendo la funcionalidad.
+3. Reemplazar macros y rasgos genéricos por clases base y composición.
+4. Utilizar `Unity.Mathematics` para operaciones de vectores y matrices.
+5. Implementar pruebas de comportamiento equivalentes en el entorno de Unity.
+
+## 2. Network (crate `network`)
+### Ficheros relevantes
+- api.rs
+- channel.rs
+- lib.rs
+- message.rs
+- metrics.rs
+- participant.rs
+- scheduler.rs
+- util.rs
+
+### Pasos recomendados
+1. Crear la **assembly** `Network` en Unity.
+2. Definir estructuras de mensajes en C# (clases serializables).
+3. Usar `System.Net.Sockets` o una librería QUIC para las conexiones.
+4. Implementar un sistema de serialización eficiente (por ejemplo `System.Text.Json`).
+5. Mantener la arquitectura asíncrona mediante `async`/`await`.
+- Evaluar si es viable migrar todo el crate de una sola vez o abordar el port por fases, priorizando primero la mensajería básica y la compatibilidad con el servidor en Rust.
+
+## 3. World (crate `world`)
+### Ficheros relevantes
+- all.rs
+- block.rs
+- canvas.rs
+- column.rs
+- config.rs
+- index.rs
+- land.rs
+- lib.rs
+- pathfinding.rs
+- sim2.rs
+- directorios: `civ/`, `layer/`, `sim/`, `site/`, `util/`
+
+### Pasos recomendados
+1. Crear la **assembly** `World`.
+2. Mapear las estructuras de terreno y generación procedural a clases C#.
+3. Aprovechar `Burst` y `Jobs` de Unity para cálculos de terreno intensivos.
+4. Revisar dependencias de crates externos y buscar equivalentes en C#.
+5. Asegurar la compatibilidad con el sistema de guardado de Unity.
+
+## 4. Server (crate `server`)
+### Ficheros relevantes
+- automod.rs
+- character_creator.rs
+- chat.rs
+- chunk_generator.rs
+- chunk_serialize.rs
+- client.rs
+- cmd.rs
+- connection_handler.rs
+- data_dir.rs
+- error.rs
+- input.rs
+- lib.rs
+- location.rs
+- lod.rs
+- login_provider.rs
+- metrics.rs
+- pet.rs
+- presence.rs
+- state_ext.rs
+- terrain_persistence.rs
+- test_world.rs
+- wiring.rs
+- directorios: `events/`, `migrations/`, `persistence/`, `rtsim/`, `settings/`, `sys/`, `weather/`
+
+### Pasos recomendados
+1. Implementar la **assembly** `Server` y separar lógica de juego del código de red.
+2. Traducir los sistemas ECS de Rust a componentes de Unity o un framework ECS propio.
+3. Portar scripts de migración y persistencia utilizando bases de datos compatibles con C# (por ejemplo SQLite).
+4. Integrar el servidor con el cliente Unity a través del módulo de red creado previamente.
+5. Automatizar pruebas de carga para validar el rendimiento en C#.
+
+## 5. Client (crates `client` y `voxygen`)
+### Ficheros relevantes
+- client/addr.rs
+- client/error.rs
+- client/lib.rs
+- voxygen/cli.rs
+- voxygen/cmd.rs
+- voxygen/controller.rs
+- voxygen/credits.rs
+- voxygen/discord.rs
+- voxygen/error.rs
+- voxygen/game_input.rs
+- voxygen/key_state.rs
+- voxygen/lib.rs
+- voxygen/main.rs
+- voxygen/panic_handler.rs
+- voxygen/profile.rs
+- voxygen/run.rs
+- voxygen/window.rs
+- directorios: `client/src/bin/`
+
+### Pasos recomendados
+1. Crear la **assembly** `Client` y migrar la lógica de entrada y UI usando el sistema de escenas de Unity.
+2. Utilizar el Input System de Unity para reemplazar `game_input.rs` y `key_state.rs`.
+3. Reescribir la ventana y el ciclo principal con `MonoBehaviour` y escenas.
+4. Portar el renderizado y shaders a la tubería de render de Unity (URP o HDRP).
+5. Integrar Discord y perfiles mediante plugins C# específicos.
+
+## 6. Simulation (crate `rtsim`)
+### Ficheros relevantes
+- event.rs
+- lib.rs
+- directorios: `ai/`, `data/`, `gen/`, `rule/`
+
+### Pasos recomendados
+1. Evaluar si es viable reescribir todo el simulador en C# o mantenerlo como biblioteca Rust vía FFI.
+2. En caso de portarlo, crear una **assembly** `Simulation` en Unity.
+3. Traducir los sistemas de IA y generación al Job System de Unity para paralelizar.
+4. Asegurar que las reglas se puedan modificar fácilmente desde C#.
+
+## 7. CLI (crate `server-cli`)
+### Ficheros relevantes
+- cli.rs
+- main.rs
+- settings.rs
+- shutdown_coordinator.rs
+- tui_runner.rs
+- tuilog.rs
+
+### Pasos recomendados
+1. Reescribir las herramientas de línea de comandos usando `System.CommandLine` en C#.
+2. Mantener la misma estructura de comandos para no romper scripts existentes.
+3. Permitir la ejecución del servidor en modo headless desde la CLI de Unity.
+
+## 8. Plugins
+### Ficheros relevantes
+- plugin/wit/veloren.wit
+
+### Pasos recomendados
+1. Diseñar un sistema de carga de plugins en C# compatible con `wasmtime` o con el sistema de paquetes de Unity.
+2. Generar bindings a partir del archivo `veloren.wit` para exponer las APIs a los plugins.
+3. Documentar cómo crear y compilar plugins externos.
+
+## 9. Assets
+Aunque no requieren conversión de código, se deben migrar los recursos a los formatos soportados por Unity y reorganizar las rutas.
+
+---
+Con este listado exhaustivo de ficheros y pasos, se puede iniciar la migración siguiendo buenas prácticas de C# y Unity. Cada módulo debe probarse de forma independiente antes de integrarse con el resto del proyecto.

--- a/VelorenPort/Docs/README.md
+++ b/VelorenPort/Docs/README.md
@@ -1,0 +1,15 @@
+# Documentación
+
+En esta carpeta se recopilan guías y decisiones de diseño tomadas durante el proceso de port.
+
+Archivos previstos:
+- `PlanDetallado.md`: Detalle completo de ficheros a migrar y pasos específicos.
+- `Plan.md`: Plan de acción y tareas iniciales.
+- `Interoperabilidad.md`: Experimentos para comunicar código Rust existente con Unity.
+Tambien se documentará el progreso de cada sistema portado. El primero en migrarse es `CoreEngine`, con sus definiciones base en `../CoreEngine/Src`.
+
+El sistema `Network` ya cuenta con una assembly y tipos básicos de dirección en `../Network/Src`.
+Ahora se incluyen también estructuras para mensajes (`Message`), parámetros de stream (`StreamParams`) y flags (`Promises`). Se añadieron `Channel` y `Participant` para simular el envío de mensajes.
+Se sumaron `Metrics`, `Scheduler`, `Util` y un `Api` de alto nivel para gestionar tareas de red.
+La clase `Network` sirve como punto de entrada para las conexiones durante las primeras pruebas. Se añadieron `Stream` y las enumeraciones de error para mantener una API parecida a la del crate original.
+También se añadió una assembly `World` que empieza a definir tipos simplificados de terreno, sirviendo como base para portar el generador procedural.

--- a/VelorenPort/Network/Network.asmdef
+++ b/VelorenPort/Network/Network.asmdef
@@ -1,0 +1,13 @@
+{
+  "name": "Network",
+  "references": [],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/VelorenPort/Network/README.md
+++ b/VelorenPort/Network/README.md
@@ -1,0 +1,17 @@
+# Network
+
+Corresponde al crate `network` que implementa la capa de comunicación utilizando QUIC y serialización.
+
+**Viabilidad**: Alta. Existe soporte en C# para networking asíncrono (sockets, QUIC mediante librerías externas). Será necesario portar los mensajes y protocolos definiendo estructuras equivalentes.
+
+**Notas**:
+- Traducir las estructuras de mensajes definidas con `serde` a clases C# usando `System.Text.Json` o similar.
+- Evaluar uso de bibliotecas de QUIC en C# o migrar a WebSockets si es más conveniente para Unity.
+
+Se añadieron las clases `ConnectAddr`, `ListenAddr` y `ParticipantEvent` en `Src/` junto con la definición de la assembly `Network`.
+Se agregaron también `Pid`, `Sid`, `Promises`, `StreamParams` y `Message` para comenzar a manejar identificadores y serialización de mensajes de forma básica.
+Se sumaron las estructuras `Channel` y `Participant` para gestionar colas de mensajes simuladas. También se añadieron las enumeraciones `NetworkError`, `NetworkConnectError`, `ParticipantError` y `StreamError` junto a la clase `Stream` para cubrir los mensajes de error básicos y el flujo de comunicación.
+El módulo ahora incluye utilidades y estructura de soporte:
+`Metrics` para contar tráfico de red, `Scheduler` para tareas asincrónicas, `Util` con funciones auxiliares y `Api` como punto de entrada de alto nivel.
+Se recomienda avanzar por fases, migrando primero las definiciones de mensajes y manteniendo una capa de compatibilidad con el servidor en Rust. El resto de la lógica de networking puede portarse gradualmente para facilitar las pruebas.
+Se añadió igualmente un esqueleto `Network` con métodos asíncronos de `ListenAsync` y `ConnectAsync` para orquestar las conexiones.

--- a/VelorenPort/Network/Src/Api.cs
+++ b/VelorenPort/Network/Src/Api.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+
+namespace VelorenPort.Network {
+    /// <summary>
+    /// High level API exposing network functionality for the Unity client.
+    /// Wraps Network and scheduler usage.
+    /// </summary>
+    public class Api {
+        private readonly Network _network;
+        private readonly Scheduler _scheduler = new();
+
+        public Api(Pid pid) {
+            _network = new Network(pid);
+        }
+
+        public Task ListenAsync(ListenAddr addr) => _network.ListenAsync(addr);
+
+        public Task<Participant> ConnectAsync(ConnectAddr addr) => _network.ConnectAsync(addr);
+
+        public void Schedule(Func<Task> task) => _scheduler.Schedule(task);
+    }
+}

--- a/VelorenPort/Network/Src/Channel.cs
+++ b/VelorenPort/Network/Src/Channel.cs
@@ -1,0 +1,30 @@
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+namespace VelorenPort.Network {
+    /// <summary>
+    /// Simple message channel for testing. Backed by concurrent queues.
+    /// </summary>
+    public class Channel {
+        public Sid Id { get; }
+        private readonly ConcurrentQueue<Message> _incoming = new();
+        private readonly ConcurrentQueue<Message> _outgoing = new();
+
+        internal Channel(Sid id) {
+            Id = id;
+        }
+
+        public Task SendAsync(Message msg) {
+            _outgoing.Enqueue(msg);
+            return Task.CompletedTask;
+        }
+
+        public Task<Message?> ReceiveAsync() {
+            _incoming.TryDequeue(out var msg);
+            return Task.FromResult(msg);
+        }
+
+        internal void PushIncoming(Message msg) => _incoming.Enqueue(msg);
+        internal bool TryGetOutgoing(out Message msg) => _outgoing.TryDequeue(out msg);
+    }
+}

--- a/VelorenPort/Network/Src/ConnectAddr.cs
+++ b/VelorenPort/Network/Src/ConnectAddr.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Net;
+
+namespace VelorenPort.Network {
+    public enum AddrType {
+        Tcp,
+        Udp,
+        Quic,
+        Mpsc
+    }
+
+    [Serializable]
+    public class ConnectAddr {
+        public AddrType Type { get; private set; }
+        public IPEndPoint? EndPoint { get; private set; }
+        public ulong ChannelId { get; private set; }
+
+        private ConnectAddr(AddrType type, IPEndPoint? endPoint, ulong channelId) {
+            Type = type;
+            EndPoint = endPoint;
+            ChannelId = channelId;
+        }
+
+        public static ConnectAddr Tcp(IPEndPoint ep) => new ConnectAddr(AddrType.Tcp, ep, 0);
+        public static ConnectAddr Udp(IPEndPoint ep) => new ConnectAddr(AddrType.Udp, ep, 0);
+        public static ConnectAddr Quic(IPEndPoint ep) => new ConnectAddr(AddrType.Quic, ep, 0);
+        public static ConnectAddr Mpsc(ulong id) => new ConnectAddr(AddrType.Mpsc, null, id);
+
+        public override string ToString() => Type switch {
+            AddrType.Mpsc => $"Mpsc({ChannelId})",
+            _ => $"{Type}({EndPoint})"
+        };
+    }
+}

--- a/VelorenPort/Network/Src/ListenAddr.cs
+++ b/VelorenPort/Network/Src/ListenAddr.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Net;
+
+namespace VelorenPort.Network {
+    [Serializable]
+    public class ListenAddr {
+        public AddrType Type { get; private set; }
+        public IPEndPoint? EndPoint { get; private set; }
+        public ulong ChannelId { get; private set; }
+
+        private ListenAddr(AddrType type, IPEndPoint? endPoint, ulong channelId) {
+            Type = type;
+            EndPoint = endPoint;
+            ChannelId = channelId;
+        }
+
+        public static ListenAddr Tcp(IPEndPoint ep) => new ListenAddr(AddrType.Tcp, ep, 0);
+        public static ListenAddr Udp(IPEndPoint ep) => new ListenAddr(AddrType.Udp, ep, 0);
+        public static ListenAddr Quic(IPEndPoint ep) => new ListenAddr(AddrType.Quic, ep, 0);
+        public static ListenAddr Mpsc(ulong id) => new ListenAddr(AddrType.Mpsc, null, id);
+
+        public override string ToString() => Type switch {
+            AddrType.Mpsc => $"Mpsc({ChannelId})",
+            _ => $"{Type}({EndPoint})"
+        };
+    }
+}

--- a/VelorenPort/Network/Src/Message.cs
+++ b/VelorenPort/Network/Src/Message.cs
@@ -1,0 +1,53 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace VelorenPort.Network {
+    /// <summary>
+    /// Serializable message container similar to the Rust implementation.
+    /// </summary>
+    [Serializable]
+    public class Message {
+        public byte[] Data { get; private set; }
+        public bool Compressed { get; private set; }
+
+        private Message(byte[] data, bool compressed) {
+            Data = data;
+            Compressed = compressed;
+        }
+
+        public static Message Serialize(object payload, StreamParams parameters) {
+            using var ms = new MemoryStream();
+            var formatter = new BinaryFormatter();
+            formatter.Serialize(ms, payload);
+            var bytes = ms.ToArray();
+
+            if (parameters.Promises.HasFlag(Promises.Compressed)) {
+                using var msOut = new MemoryStream();
+                using (var gzip = new GZipStream(msOut, CompressionLevel.Fastest)) {
+                    gzip.Write(bytes, 0, bytes.Length);
+                }
+                bytes = msOut.ToArray();
+                return new Message(bytes, true);
+            }
+
+            return new Message(bytes, false);
+        }
+
+        public T Deserialize<T>() {
+            byte[] data = Data;
+            if (Compressed) {
+                using var msIn = new MemoryStream(Data);
+                using var msOut = new MemoryStream();
+                using (var gzip = new GZipStream(msIn, CompressionMode.Decompress)) {
+                    gzip.CopyTo(msOut);
+                }
+                data = msOut.ToArray();
+            }
+            using var ms = new MemoryStream(data);
+            var formatter = new BinaryFormatter();
+            return (T)formatter.Deserialize(ms);
+        }
+    }
+}

--- a/VelorenPort/Network/Src/Metrics.cs
+++ b/VelorenPort/Network/Src/Metrics.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading;
+
+namespace VelorenPort.Network {
+    /// <summary>
+    /// Simple network metrics collector similar to the Rust crate.
+    /// Tracks sent and received bytes and message counts.
+    /// </summary>
+    public class Metrics {
+        private long _sentBytes;
+        private long _recvBytes;
+        private long _sentMessages;
+        private long _recvMessages;
+
+        public void CountSent(int bytes) {
+            Interlocked.Add(ref _sentBytes, bytes);
+            Interlocked.Increment(ref _sentMessages);
+        }
+
+        public void CountReceived(int bytes) {
+            Interlocked.Add(ref _recvBytes, bytes);
+            Interlocked.Increment(ref _recvMessages);
+        }
+
+        public (long sentBytes, long recvBytes, long sentMessages, long recvMessages) Snapshot()
+            => (Interlocked.Read(ref _sentBytes), Interlocked.Read(ref _recvBytes),
+                Interlocked.Read(ref _sentMessages), Interlocked.Read(ref _recvMessages));
+    }
+}

--- a/VelorenPort/Network/Src/Network.cs
+++ b/VelorenPort/Network/Src/Network.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Concurrent;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace VelorenPort.Network {
+    /// <summary>
+    /// Esqueleto de manejador de red para Unity. Por ahora solo simula
+    /// conexiones TCP y mantiene la cola de participantes conectados.
+    /// </summary>
+    public class Network {
+        public Pid LocalPid { get; }
+        private readonly ConcurrentQueue<Participant> _pending = new();
+        private readonly ConcurrentDictionary<Pid, Participant> _participants = new();
+
+        public Network(Pid pid) {
+            LocalPid = pid;
+        }
+
+        public Task ListenAsync(ListenAddr addr) {
+            // TODO: implementar sockets reales. Por ahora no hace nada.
+            return Task.CompletedTask;
+        }
+
+        public Task<Participant> ConnectAsync(ConnectAddr addr) {
+            // Simula una conexion inmediata y retorna un participante nuevo
+            var remote = new Participant(Pid.NewPid());
+            _participants[remote.Id] = remote;
+            _pending.Enqueue(remote);
+            return Task.FromResult(remote);
+        }
+
+        public Task<Participant?> ConnectedAsync() {
+            _pending.TryDequeue(out var participant);
+            return Task.FromResult(participant);
+        }
+
+        public bool TryGetParticipant(Pid id, out Participant participant)
+            => _participants.TryGetValue(id, out participant);
+    }
+}

--- a/VelorenPort/Network/Src/NetworkConnectError.cs
+++ b/VelorenPort/Network/Src/NetworkConnectError.cs
@@ -1,0 +1,10 @@
+namespace VelorenPort.Network {
+    /// <summary>
+    /// Errors thrown during connection establishment.
+    /// </summary>
+    public enum NetworkConnectError {
+        InvalidSecret,
+        Handshake,
+        Io
+    }
+}

--- a/VelorenPort/Network/Src/NetworkError.cs
+++ b/VelorenPort/Network/Src/NetworkError.cs
@@ -1,0 +1,11 @@
+namespace VelorenPort.Network {
+    /// <summary>
+    /// Errors thrown by Network methods.
+    /// Mirrors the Rust NetworkError enum.
+    /// </summary>
+    public enum NetworkError {
+        NetworkClosed,
+        ListenFailed,
+        ConnectFailed
+    }
+}

--- a/VelorenPort/Network/Src/Participant.cs
+++ b/VelorenPort/Network/Src/Participant.cs
@@ -1,0 +1,24 @@
+using System.Collections.Concurrent;
+
+namespace VelorenPort.Network {
+    /// <summary>
+    /// Represents a remote participant with multiple channels.
+    /// </summary>
+    public class Participant {
+        public Pid Id { get; }
+        private readonly ConcurrentDictionary<Sid, Channel> _channels = new();
+
+        internal Participant(Pid id) {
+            Id = id;
+        }
+
+        public Channel OpenChannel(Sid id, StreamParams parameters) {
+            var ch = new Channel(id);
+            _channels[id] = ch;
+            return ch;
+        }
+
+        public bool TryGetChannel(Sid id, out Channel channel) => _channels.TryGetValue(id, out channel);
+        internal void CloseChannel(Sid id) => _channels.TryRemove(id, out _);
+    }
+}

--- a/VelorenPort/Network/Src/ParticipantError.cs
+++ b/VelorenPort/Network/Src/ParticipantError.cs
@@ -1,0 +1,9 @@
+namespace VelorenPort.Network {
+    /// <summary>
+    /// Errors thrown by Participant operations.
+    /// </summary>
+    public enum ParticipantError {
+        ParticipantDisconnected,
+        ProtocolFailedUnrecoverable
+    }
+}

--- a/VelorenPort/Network/Src/ParticipantEvent.cs
+++ b/VelorenPort/Network/Src/ParticipantEvent.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace VelorenPort.Network {
+    [Serializable]
+    public class ParticipantEvent {
+        public enum EventType {
+            ChannelCreated,
+            ChannelDeleted
+        }
+
+        public EventType Type { get; private set; }
+        public ConnectAddr Address { get; private set; }
+
+        private ParticipantEvent(EventType type, ConnectAddr addr) {
+            Type = type;
+            Address = addr;
+        }
+
+        public static ParticipantEvent ChannelCreated(ConnectAddr addr) => new ParticipantEvent(EventType.ChannelCreated, addr);
+        public static ParticipantEvent ChannelDeleted(ConnectAddr addr) => new ParticipantEvent(EventType.ChannelDeleted, addr);
+    }
+}

--- a/VelorenPort/Network/Src/Pid.cs
+++ b/VelorenPort/Network/Src/Pid.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace VelorenPort.Network {
+    /// <summary>
+    /// Unique identifier for a network participant. Mirrors Pid from the Rust crate.
+    /// </summary>
+    [Serializable]
+    public struct Pid : IEquatable<Pid> {
+        private readonly Guid _value;
+
+        public Pid(Guid value) {
+            _value = value;
+        }
+
+        public static Pid NewPid() => new Pid(Guid.NewGuid());
+
+        public override string ToString() => _value.ToString("N");
+
+        public bool Equals(Pid other) => _value.Equals(other._value);
+        public override bool Equals(object obj) => obj is Pid other && Equals(other);
+        public override int GetHashCode() => _value.GetHashCode();
+    }
+}

--- a/VelorenPort/Network/Src/Promises.cs
+++ b/VelorenPort/Network/Src/Promises.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace VelorenPort.Network {
+    /// <summary>
+    /// Flags that modify Stream behaviour.
+    /// Mirrors the Promises bitflags from Rust.
+    /// </summary>
+    [Flags]
+    public enum Promises : byte {
+        Ordered = 1 << 0,
+        Consistency = 1 << 1,
+        GuaranteedDelivery = 1 << 2,
+        Compressed = 1 << 3,
+        Encrypted = 1 << 4,
+    }
+}

--- a/VelorenPort/Network/Src/Scheduler.cs
+++ b/VelorenPort/Network/Src/Scheduler.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace VelorenPort.Network {
+    /// <summary>
+    /// Very small task scheduler for network operations.
+    /// Used to queue work on a single thread to mimic Rust's scheduler.
+    /// </summary>
+    public class Scheduler {
+        private readonly Queue<Func<Task>> _tasks = new();
+        private bool _running;
+
+        public void Schedule(Func<Task> task) {
+            _tasks.Enqueue(task);
+            if (!_running) _ = RunAsync();
+        }
+
+        private async Task RunAsync() {
+            _running = true;
+            while (_tasks.Count > 0) {
+                var t = _tasks.Dequeue();
+                await t();
+            }
+            _running = false;
+        }
+    }
+}

--- a/VelorenPort/Network/Src/Sid.cs
+++ b/VelorenPort/Network/Src/Sid.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace VelorenPort.Network {
+    /// <summary>
+    /// Stream identifier used to differentiate channels.
+    /// </summary>
+    [Serializable]
+    public struct Sid : IEquatable<Sid>, IComparable<Sid> {
+        public ulong Value { get; private set; }
+
+        public Sid(ulong value) {
+            Value = value;
+        }
+
+        public bool Equals(Sid other) => Value == other.Value;
+        public override bool Equals(object obj) => obj is Sid other && Equals(other);
+        public override int GetHashCode() => Value.GetHashCode();
+        public int CompareTo(Sid other) => Value.CompareTo(other.Value);
+        public override string ToString() => Value.ToString();
+    }
+}

--- a/VelorenPort/Network/Src/Stream.cs
+++ b/VelorenPort/Network/Src/Stream.cs
@@ -1,0 +1,32 @@
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+namespace VelorenPort.Network {
+    /// <summary>
+    /// Represents a unidirectional stream between two participants.
+    /// </summary>
+    public class Stream {
+        public Sid Id { get; }
+        public Promises Promises { get; }
+        private readonly ConcurrentQueue<Message> _rx = new();
+        private readonly ConcurrentQueue<Message> _tx = new();
+
+        internal Stream(Sid id, Promises promises) {
+            Id = id;
+            Promises = promises;
+        }
+
+        public Task SendAsync(Message msg) {
+            _tx.Enqueue(msg);
+            return Task.CompletedTask;
+        }
+
+        public Task<Message?> RecvAsync() {
+            _rx.TryDequeue(out var msg);
+            return Task.FromResult(msg);
+        }
+
+        internal void PushIncoming(Message msg) => _rx.Enqueue(msg);
+        internal bool TryDequeueOutgoing(out Message msg) => _tx.TryDequeue(out msg);
+    }
+}

--- a/VelorenPort/Network/Src/StreamError.cs
+++ b/VelorenPort/Network/Src/StreamError.cs
@@ -1,0 +1,10 @@
+namespace VelorenPort.Network {
+    /// <summary>
+    /// Errors thrown by Stream operations.
+    /// </summary>
+    public enum StreamError {
+        StreamClosed,
+        Compression,
+        Deserialize
+    }
+}

--- a/VelorenPort/Network/Src/StreamParams.cs
+++ b/VelorenPort/Network/Src/StreamParams.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace VelorenPort.Network {
+    /// <summary>
+    /// Parameters used when creating a Stream. Currently only promises.
+    /// </summary>
+    [Serializable]
+    public struct StreamParams {
+        public Promises Promises { get; private set; }
+
+        public StreamParams(Promises promises) {
+            Promises = promises;
+        }
+    }
+}

--- a/VelorenPort/Network/Src/Util.cs
+++ b/VelorenPort/Network/Src/Util.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace VelorenPort.Network {
+    /// <summary>
+    /// Helper utilities used across the network subsystem.
+    /// </summary>
+    public static class Util {
+        public static byte[] HexStringToBytes(string hex) {
+            if (hex.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                hex = hex[2..];
+            int length = hex.Length / 2;
+            byte[] bytes = new byte[length];
+            for (int i = 0; i < length; i++) {
+                bytes[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+            }
+            return bytes;
+        }
+
+        public static string BytesToHexString(ReadOnlySpan<byte> bytes) {
+            return BitConverter.ToString(bytes.ToArray()).Replace("-", "");
+        }
+    }
+}

--- a/VelorenPort/Plugin/README.md
+++ b/VelorenPort/Plugin/README.md
@@ -1,0 +1,9 @@
+# Plugin
+
+Sistema de plugins escrito en Rust que utiliza WebAssembly (`plugin`).
+
+**Viabilidad**: Media. Unity soporta C# nativo y tiene sistemas de paquetes y scripting. El soporte actual en Rust se basa en WASM y puede mantenerse mediante interoperabilidad o reescribirse como API de C#.
+
+**Notas**:
+- Considerar mantener la compatibilidad con WASM para scripts ligeros.
+- Revisar cómo exponer la API de juego a otros desarrolladores.

--- a/VelorenPort/README.md
+++ b/VelorenPort/README.md
@@ -1,0 +1,27 @@
+# VelorenPort
+
+Este directorio contiene la planeación inicial para portar el proyecto [Veloren](https://gitlab.com/veloren/veloren) escrito en Rust a C# para integrarlo con el motor Unity.
+
+La estructura se organiza por sistemas principales y cada subcarpeta describe brevemente su función y el grado de dificultad estimada para la conversión a C#.
+
+Los sistemas identificados son:
+
+- **CoreEngine**: componentes compartidos, ECS y utilidades generales.
+- **Network**: manejo de protocolos y mensajes.
+- **World**: generación y persistencia del mundo.
+- **Server**: lógica de servidor y control de partidas.
+- **Client**: interfaz de usuario y representación visual (Voxygen).
+- **Simulation**: subsistema `rtsim` de simulación a gran escala.
+- **Plugin**: soporte de plugins mediante WebAssembly.
+- **CLI**: herramientas de servidor y línea de comandos.
+- **Assets**: recursos de arte y datos.
+
+Para detalles de cada archivo y pasos a seguir consulte `Docs/PlanDetallado.md`.
+En la carpeta `Docs` se irán añadiendo guías y notas de migración.
+
+El sistema `Network` cuenta ahora con una clase `Network` minimal y tipos para `Participant` y `Channel` que
+sirven como esqueleto para futuras implementaciones de sockets y gestión de participantes.
+Además se añadieron los enums de error (`NetworkError`, `NetworkConnectError`, `ParticipantError`, `StreamError`)
+y la clase `Stream` para mantener la API similar a la del crate original.
+
+Se creó además la assembly `World` con definiciones básicas de terreno (`Block`, `BlockKind`) e índices (`WorldIndex`) para comenzar el traslado de la lógica de generación procedimental.

--- a/VelorenPort/Server/README.md
+++ b/VelorenPort/Server/README.md
@@ -1,0 +1,9 @@
+# Server
+
+Código del servidor principal (`server` y `server-cli`). Maneja sesiones de juego, IA de NPC y persistencia.
+
+**Viabilidad**: Media-Alta. Unity puede ejecutar servidores en C#, pero será necesario reescribir la lógica de concurrencia y manejo de ECS.
+
+**Notas**:
+- Portar la gestión de conexiones y eventos.
+- Considerar usar `Task` y `async` de C# para las operaciones concurrentes.

--- a/VelorenPort/Simulation/README.md
+++ b/VelorenPort/Simulation/README.md
@@ -1,0 +1,8 @@
+# Simulation
+
+Contiene `rtsim`, un simulador global que ejecuta comportamientos del mundo y de poblaciones.
+
+**Viabilidad**: Baja-Media. Esta parte hace uso intensivo de estructuras de datos en Rust y macros. Se puede portar a C#, pero podría implicar reescribir gran parte de la lógica. Tal vez se implemente como un servicio externo o en Rust interop.
+
+**Notas**:
+- Evaluar si realmente es necesario portar este subsistema completo o mantenerlo como módulo Rust separado usando interop (por ejemplo, a través de FFI o WebAssembly).

--- a/VelorenPort/World/README.md
+++ b/VelorenPort/World/README.md
@@ -1,0 +1,11 @@
+# World
+
+Incluye la lógica de generación de mundo procedimental y estructuras de terreno (crate `world`).
+
+**Viabilidad**: Media. El algoritmo utiliza intensivamente características de Rust y puede depender de crates específicos. Se puede portar la lógica a C#, pero puede requerir optimización para funcionar con Unity.
+
+**Notas**:
+- Analizar dependencias externas como `image`, `noise` o `simd` para buscar equivalentes en C#.
+- Valorar si parte de la lógica puede migrarse a librerías de Unity (por ejemplo `Unity.Mathematics`).
+
+Se añadió la assembly `World` con clases iniciales `Block`, `BlockKind` y `WorldIndex` como base para comenzar a portar la generación de terreno. Estas estructuras son simplificadas respecto al código de Rust pero permiten experimentar con la lógica en Unity.

--- a/VelorenPort/World/Src/Block.cs
+++ b/VelorenPort/World/Src/Block.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace VelorenPort.World {
+    /// <summary>
+    /// Representa un bloque simple dentro del terreno.
+    /// </summary>
+    [Serializable]
+    public struct Block {
+        public BlockKind Kind { get; private set; }
+
+        public Block(BlockKind kind) {
+            Kind = kind;
+        }
+
+        public static Block Air => new Block(BlockKind.Air);
+    }
+}

--- a/VelorenPort/World/Src/BlockKind.cs
+++ b/VelorenPort/World/Src/BlockKind.cs
@@ -1,0 +1,12 @@
+namespace VelorenPort.World {
+    /// <summary>
+    /// Tipos basicos de bloque utilizados en el mundo.
+    /// Solo una pequeña muestra respecto al sistema original.
+    /// </summary>
+    public enum BlockKind {
+        Air,
+        Dirt,
+        Rock,
+        Water
+    }
+}

--- a/VelorenPort/World/Src/WorldIndex.cs
+++ b/VelorenPort/World/Src/WorldIndex.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace VelorenPort.World {
+    /// <summary>
+    /// Indice reducido que mantiene el estado general del mundo.
+    /// Sirve como punto de partida para la logica de generacion procedural.
+    /// </summary>
+    [Serializable]
+    public class WorldIndex {
+        public uint Seed { get; private set; }
+        public float Time { get; set; }
+
+        public WorldIndex(uint seed) {
+            Seed = seed;
+        }
+    }
+}

--- a/VelorenPort/World/World.asmdef
+++ b/VelorenPort/World/World.asmdef
@@ -1,0 +1,13 @@
+{
+  "name": "World",
+  "references": [],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}


### PR DESCRIPTION
## Summary
- add network helper modules (`Api`, `Metrics`, `Scheduler`, `Util`)
- reference new utilities in documentation and plan files
- update README notes on the Unity port
- add Stream and error enums to networking port

## Testing
- `cargo --version`
- `timeout 5 cargo check -p network` *(failed: network fetch aborted)*
- `tree -L 2 VelorenPort | head`
- `tree -L 2 VelorenPort | sed -n '10,40p'`
- `tree VelorenPort/Network/Src | head`
- `tree VelorenPort/Network/Src | sed -n '10,40p'`

------
https://chatgpt.com/codex/tasks/task_e_685a8668f05c83288374807117f2f676