### PR TITLE
Add client state and region updates

### DIFF
--- a/VelorenPort/CoreEngine/Src/TerrainConstants.cs
+++ b/VelorenPort/CoreEngine/Src/TerrainConstants.cs
@@ -1,0 +1,29 @@
+using Unity.Mathematics;
+
+namespace VelorenPort.CoreEngine
+{
+    /// <summary>
+    /// Constants and helpers related to terrain chunk sizes.
+    /// </summary>
+    public static class TerrainConstants
+    {
+        /// <summary>
+        /// Base-two logarithm of the number of blocks along each side of a chunk.
+        /// Matches <c>TERRAIN_CHUNK_BLOCKS_LG</c> in the original project.
+        /// </summary>
+        public const int ChunkBlocksLg = 5;
+
+        /// <summary>
+        /// Size of a chunk in blocks.
+        /// </summary>
+        public static readonly int2 ChunkSize = new int2(1 << ChunkBlocksLg, 1 << ChunkBlocksLg);
+
+        /// <summary>
+        /// Convert world block coordinates to chunk coordinates.
+        /// </summary>
+        public static int2 WorldToChunk(int2 world)
+        {
+            return new int2(world.x >> ChunkBlocksLg, world.y >> ChunkBlocksLg);
+        }
+    }
+}

--- a/VelorenPort/Docs/PlanDetallado.md
+++ b/VelorenPort/Docs/PlanDetallado.md
@@ -13,6 +13,17 @@ Se suma la assembly `World` con estructuras de terreno simplificadas para inicia
 Actualmente el port incluye `Uid`, `CharacterId`, `RtSimEntity`, `Calendar`, `DayPeriod`, `Clock`, los recursos de tiempo, `Consts` y `ViewDistances`. Se sumaron `GameMode`, `PlayerEntity`, `PlayerPhysicsSettings`, `MapKind`, `BattleMode`, una versión con datos de `Actor`, `ServerConstants`, `Pos` y `EntitiesDiedLastTick`. Se agregó `Grid` para manejar datos bidimensionales, seguido de `Presence` con el enumerado `PresenceKind` y un campo opcional `CharacterId` para las variantes `LoadingCharacter` y `Character`, además de `ViewDistance` para la visibilidad. Si la presencia cambia a otra variante, este identificador se borra. Ahora se añadió `SpatialGrid` y el recurso `CachedSpatialGrid` para agilizar consultas de proximidad. También se implementaron `Path`, `AStar` y `Ray` para el cálculo de rutas y recorridos de voxels.
 Se agregó `SlowJobPool` para ejecutar trabajos costosos en paralelo sin bloquear la simulación.
 Además se añadió `Spiral` como utilería para generar coordenadas en espiral alrededor de un punto.
+Se incluyeron también las estructuras `RegionSubscription`, `RepositionOnChunkLoad`
+y `PresenceConstants` dentro de la assembly `Server` para gestionar las
+suscripciones de regiones y el reposicionamiento de entidades cuando se cargan
+chunks.
+Adicionalmente se añadieron `TerrainConstants`, `RegionConstants` y la clase
+`RegionUtils` con la función `InitializeRegionSubscription` para calcular las
+regiones iniciales de cada cliente. Se creó también `RegionSubscriptionUpdater`
+para actualizar esas suscripciones cuando los clientes se mueven o modifican su
+distancia de visión. Cada `Client` ahora almacena su posición, `Presence` y
+`RegionSubscription` al conectarse, y el `GameServer` actualiza la lista de
+regiones visible en cada tick.
 
 ## 1. CoreEngine (crate `common`)
 ### Ficheros relevantes

--- a/VelorenPort/Server/README.md
+++ b/VelorenPort/Server/README.md
@@ -7,3 +7,12 @@ Código del servidor principal (`server` y `server-cli`). Maneja sesiones de jue
 **Notas**:
 - Portar la gestión de conexiones y eventos.
 - Considerar usar `Task` y `async` de C# para las operaciones concurrentes.
+- Se añadieron las estructuras `RegionSubscription` y `RepositionOnChunkLoad`
+  junto a `PresenceConstants` para comenzar a migrar la lógica de presencia y
+  suscripciones de regiones.
+- Se definieron `RegionConstants`, `TerrainConstants` y utilidades en
+  `RegionUtils`, incluida la función `InitializeRegionSubscription`.
+- Nuevo `RegionSubscriptionUpdater` mantiene la lista de regiones
+  actualizada conforme cambian la posición o la distancia de visión.
+- Los `Client` registran posición y `Presence`; el `GameServer` actualiza
+  su `RegionSubscription` en cada ciclo.

--- a/VelorenPort/Server/Src/Client.cs
+++ b/VelorenPort/Server/Src/Client.cs
@@ -1,5 +1,8 @@
 
+using System;
+using Unity.Mathematics;
 using VelorenPort.Network;
+using VelorenPort.CoreEngine;
 
 namespace VelorenPort.Server {
     /// <summary>
@@ -8,9 +11,19 @@ namespace VelorenPort.Server {
     /// </summary>
     public class Client {
         public Participant Participant { get; }
+        public Pos Position { get; private set; }
+        public Presence Presence { get; }
+        public RegionSubscription RegionSubscription { get; }
 
         internal Client(Participant participant) {
             Participant = participant;
+            Position = new Pos(float3.zero);
+            Presence = new Presence(new ViewDistances(8, 8), PresenceKind.Spectator);
+            RegionSubscription = RegionUtils.InitializeRegionSubscription(Position, Presence);
+        }
+
+        public void SetPosition(float3 pos) {
+            Position = new Pos(pos);
         }
     }
 }

--- a/VelorenPort/Server/Src/GameServer.cs
+++ b/VelorenPort/Server/Src/GameServer.cs
@@ -50,6 +50,13 @@ namespace VelorenPort.Server {
 
         private void UpdateWorld() {
             WorldIndex.Time += (float)Clock.Dt.TotalSeconds;
+
+            foreach (var client in _clients) {
+                RegionSubscriptionUpdater.UpdateSubscription(
+                    client.Position,
+                    client.Presence,
+                    client.RegionSubscription);
+            }
         }
     }
 }

--- a/VelorenPort/Server/Src/PresenceConstants.cs
+++ b/VelorenPort/Server/Src/PresenceConstants.cs
@@ -1,0 +1,19 @@
+namespace VelorenPort.Server
+{
+    /// <summary>
+    /// Constants used when managing region subscriptions.
+    /// </summary>
+    public static class PresenceConstants
+    {
+        /// <summary>
+        /// Distance from the stored fuzzy chunk before snapping to the
+        /// current chunk.
+        /// </summary>
+        public const uint ChunkFuzz = 2;
+
+        /// <summary>
+        /// Distance out of a region before removing it from subscriptions.
+        /// </summary>
+        public const uint RegionFuzz = 16;
+    }
+}

--- a/VelorenPort/Server/Src/RegionConstants.cs
+++ b/VelorenPort/Server/Src/RegionConstants.cs
@@ -1,0 +1,24 @@
+namespace VelorenPort.Server
+{
+    /// <summary>
+    /// Constants used by region tracking and subscriptions.
+    /// </summary>
+    public static class RegionConstants
+    {
+        /// <summary>
+        /// Bitshift between region and world coordinates. Region size is
+        /// <c>1 &lt;&lt; RegionLog2</c> blocks.
+        /// </summary>
+        public const int RegionLog2 = 9;
+
+        /// <summary>
+        /// Size of a region in blocks.
+        /// </summary>
+        public const int RegionSize = 1 << RegionLog2;
+
+        /// <summary>
+        /// Distance an entity may move outside its region before switching.
+        /// </summary>
+        public const uint TetherLength = 16;
+    }
+}

--- a/VelorenPort/Server/Src/RegionSubscription.cs
+++ b/VelorenPort/Server/Src/RegionSubscription.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using Unity.Mathematics;
+
+namespace VelorenPort.Server
+{
+    /// <summary>
+    /// Tracks which world regions a client has subscribed to. This mirrors
+    /// the server::presence::RegionSubscription struct in the original
+    /// project but uses idiomatic C# collections.
+    /// </summary>
+    public class RegionSubscription
+    {
+        /// <summary>
+        /// Chunk coordinate from which the subscription was last updated.
+        /// It is allowed to deviate by a small fuzz factor before switching
+        /// to the current chunk to avoid excessive churn.
+        /// </summary>
+        public int2 FuzzyChunk { get; set; }
+
+        /// <summary>
+        /// View distance used to determine which regions are relevant.
+        /// </summary>
+        public uint LastEntityViewDistance { get; set; }
+
+        /// <summary>
+        /// Set of region keys currently subscribed by the client.
+        /// </summary>
+        public HashSet<int2> Regions { get; } = new();
+    }
+}

--- a/VelorenPort/Server/Src/RegionSubscriptionUpdater.cs
+++ b/VelorenPort/Server/Src/RegionSubscriptionUpdater.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using Unity.Mathematics;
+using VelorenPort.CoreEngine;
+
+namespace VelorenPort.Server
+{
+    /// <summary>
+    /// Utilities to update a <see cref="RegionSubscription"/> when an entity
+    /// moves or changes view distance.
+    /// </summary>
+    public static class RegionSubscriptionUpdater
+    {
+        /// <summary>
+        /// Update the given subscription based on the entity position and
+        /// view distance. Regions that left the view are removed while new
+        /// regions are added.
+        /// </summary>
+        public static void UpdateSubscription(Pos pos, Presence presence, RegionSubscription sub)
+        {
+            uint vd = presence.EntityViewDistance.Current;
+            int2 currentChunk = RegionUtils.WorldToChunk(pos.Value);
+            int2 diff = currentChunk - sub.FuzzyChunk;
+            bool chunkChanged = math.abs(diff.x) > PresenceConstants.ChunkFuzz ||
+                                math.abs(diff.y) > PresenceConstants.ChunkFuzz;
+            bool vdChanged = sub.LastEntityViewDistance != vd;
+
+            if (!chunkChanged && !vdChanged)
+                return;
+
+            sub.FuzzyChunk = currentChunk;
+            sub.LastEntityViewDistance = vd;
+
+            float chunkSize = TerrainConstants.ChunkSize.x;
+            float radius = vd * chunkSize + (PresenceConstants.ChunkFuzz + chunkSize) * math.sqrt(2f);
+            var newRegions = RegionUtils.RegionsInViewDistance(pos.Value, radius);
+
+            var toRemove = new List<int2>();
+            foreach (var key in sub.Regions)
+                if (!newRegions.Contains(key))
+                    toRemove.Add(key);
+            foreach (var key in toRemove)
+                sub.Regions.Remove(key);
+
+            foreach (var key in newRegions)
+                sub.Regions.Add(key);
+        }
+    }
+}

--- a/VelorenPort/Server/Src/RegionUtils.cs
+++ b/VelorenPort/Server/Src/RegionUtils.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using Unity.Mathematics;
+using VelorenPort.CoreEngine;
+
+namespace VelorenPort.Server
+{
+    /// <summary>
+    /// Helper functions for region and chunk calculations.
+    /// </summary>
+    public static class RegionUtils
+    {
+        /// <summary>
+        /// Convert a world position in blocks to chunk coordinates.
+        /// </summary>
+        public static int2 WorldToChunk(float3 pos)
+        {
+            int2 w = new int2((int)math.floor(pos.x), (int)math.floor(pos.y));
+            return TerrainConstants.WorldToChunk(w);
+        }
+
+        /// <summary>
+        /// Convert a world position in blocks to region coordinates.
+        /// </summary>
+        public static int2 WorldToRegion(float3 pos)
+        {
+            int2 w = new int2((int)math.floor(pos.x), (int)math.floor(pos.y));
+            return new int2(w.x >> RegionConstants.RegionLog2, w.y >> RegionConstants.RegionLog2);
+        }
+
+        /// <summary>
+        /// Convert a region key back to world coordinates of its minimum corner.
+        /// </summary>
+        public static float2 RegionToWorld(int2 key)
+        {
+            return new float2(key.x * RegionConstants.RegionSize, key.y * RegionConstants.RegionSize);
+        }
+
+        public static bool RegionInViewDistance(int2 key, float3 pos, float vd)
+        {
+            float vdExtended = vd + RegionConstants.TetherLength * math.sqrt(2f);
+            float2 minRegionPos = RegionToWorld(key);
+            float2 diff = new float2(pos.x - minRegionPos.x, pos.y - minRegionPos.y);
+            if (diff.x < 0) diff.x += RegionConstants.RegionSize;
+            if (diff.y < 0) diff.y += RegionConstants.RegionSize;
+            return math.lengthsq(diff) < vdExtended * vdExtended;
+        }
+
+        public static HashSet<int2> RegionsInViewDistance(float3 pos, float vd)
+        {
+            var set = new HashSet<int2>();
+            float vdExtended = vd + RegionConstants.TetherLength * math.sqrt(2f);
+            int2 max = WorldToRegion(pos + new float3(vdExtended, vdExtended, 0));
+            int2 min = WorldToRegion(pos - new float3(vdExtended, vdExtended, 0));
+            for (int x = min.x; x <= max.x; x++)
+            for (int y = min.y; y <= max.y; y++)
+            {
+                var key = new int2(x, y);
+                if (RegionInViewDistance(key, pos, vd))
+                    set.Add(key);
+            }
+            return set;
+        }
+
+        /// <summary>
+        /// Create a region subscription for an entity at the given position.
+        /// </summary>
+        public static RegionSubscription InitializeRegionSubscription(Pos pos, Presence presence)
+        {
+            int2 fuzzyChunk = WorldToChunk(pos.Value);
+            float chunkSize = TerrainConstants.ChunkSize.x;
+            float radius = presence.EntityViewDistance.Current * chunkSize
+                           + (PresenceConstants.ChunkFuzz + chunkSize) * math.sqrt(2f);
+            var regions = RegionsInViewDistance(pos.Value, radius);
+            var sub = new RegionSubscription
+            {
+                FuzzyChunk = fuzzyChunk,
+                LastEntityViewDistance = presence.EntityViewDistance.Current
+            };
+            foreach (var key in regions)
+                sub.Regions.Add(key);
+            return sub;
+        }
+    }
+}

--- a/VelorenPort/Server/Src/RepositionOnChunkLoad.cs
+++ b/VelorenPort/Server/Src/RepositionOnChunkLoad.cs
@@ -1,0 +1,15 @@
+namespace VelorenPort.Server
+{
+    /// <summary>
+    /// Component indicating that an entity should be repositioned once
+    /// its target chunk has finished loading.
+    /// </summary>
+    public struct RepositionOnChunkLoad
+    {
+        /// <summary>
+        /// Whether the entity should be moved to ground level when
+        /// repositioned.
+        /// </summary>
+        public bool NeedsGround { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- extend `Client` with position, presence and region subscription
- update `GameServer` to refresh region lists each tick
- document new responsibilities for clients in plan and README

## Testing
- `dotnet build VelorenPort/VelorenPort.sln -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685b382a826c8328afa4067915c60511