### PR TITLE
Improve admin role logic

### DIFF
--- a/VelorenPort/CoreEngine/README.md
+++ b/VelorenPort/CoreEngine/README.md
@@ -21,6 +21,10 @@ Contiene los crates bajo `common` que agrupan la lógica compartida: ECS, defini
 - `ServerConstants` para configurar el ciclo día/noche en servidor.
 - `Pos` y `EntitiesDiedLastTick` como utilidades básicas de simulación.
 - `DisconnectReason` enumera los motivos de desconexión del jugador.
+- `AdminRole` define los niveles de privilegios y el componente `Admin` almacena
+  el rol de cada jugador. Incluye utilidades `AdminRoleHelper` para convertir de
+  cadena a rol y viceversa, equivalente a los métodos `FromStr` y `ToString` en
+  Rust.
 - `Grid` para contenedores bidimensionales genericos.
  - `Presence` define un enumerado `PresenceKind` y almacena un `CharacterId` opcional cuando el tipo es `LoadingCharacter` o `Character`. La estructura `ViewDistance` regula la visibilidad y el estado de sincronización de cada entidad. Si se cambia a otra variante, el identificador se descarta automáticamente.
 - `SpatialGrid` y `CachedSpatialGrid` aceleran la consulta de entidades en un área.

--- a/VelorenPort/CoreEngine/Src/AdminRole.cs
+++ b/VelorenPort/CoreEngine/Src/AdminRole.cs
@@ -1,0 +1,57 @@
+namespace VelorenPort.CoreEngine;
+
+/// <summary>
+/// Administrative role assigned to a player. Mirrors `AdminRole` from
+/// `common/src/comp/admin.rs`.
+/// </summary>
+public enum AdminRole {
+    Moderator = 0,
+    Admin = 1,
+}
+
+/// <summary>
+/// Helper utilities to convert to and from strings just like the Rust
+/// implementation which provides <c>FromStr</c> and <c>ToString</c>.
+/// </summary>
+public static class AdminRoleHelper {
+    /// <summary>
+    /// Parse a role from string. Accepts "mod", "moderator" or "admin".
+    /// Returns <c>false</c> if the value could not be parsed.
+    /// </summary>
+    public static bool TryParse(string? value, out AdminRole role) {
+        role = default;
+        if (string.IsNullOrWhiteSpace(value)) {
+            return false;
+        }
+        value = value.Trim().ToLowerInvariant();
+        switch (value) {
+            case "mod":
+            case "moderator":
+                role = AdminRole.Moderator;
+                return true;
+            case "admin":
+                role = AdminRole.Admin;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Convert an <see cref="AdminRole"/> into the canonical string used in
+    /// configuration files. Mirrors <c>ToString</c> from Rust.
+    /// </summary>
+    public static string ToRoleString(this AdminRole role) => role switch {
+        AdminRole.Moderator => "moderator",
+        AdminRole.Admin => "admin",
+        _ => role.ToString().ToLowerInvariant(),
+    };
+}
+
+/// <summary>
+/// Helper component storing a player's administrative role.
+/// </summary>
+public struct Admin {
+    public AdminRole Role { get; set; }
+    public Admin(AdminRole role) { Role = role; }
+}

--- a/VelorenPort/Network/README.md
+++ b/VelorenPort/Network/README.md
@@ -16,3 +16,7 @@ El módulo ahora incluye utilidades y estructura de soporte:
 
 Se recomienda avanzar por fases, migrando primero las definiciones de mensajes y manteniendo una capa de compatibilidad con el servidor en Rust. El resto de la lógica de networking puede portarse gradualmente para facilitar las pruebas.
 Se añadió igualmente un esqueleto `Network` con métodos asíncronos de `ListenAsync` y `ConnectAsync` para orquestar las conexiones.
+Además se implementó `ClientType` junto con la estructura `ClientRegister` para
+describir el tipo de cliente y los datos iniciales de registro que requiere el
+servidor. La lógica de validación de roles y permisos sigue la misma que en
+Rust gracias a los métodos `IsValidForRole`, `CanSpectate` y similares.

--- a/VelorenPort/Network/Src/ClientMessages.cs
+++ b/VelorenPort/Network/Src/ClientMessages.cs
@@ -1,0 +1,40 @@
+using System;
+using VelorenPort.CoreEngine;
+
+namespace VelorenPort.Network {
+    /// <summary>
+    /// Type of client connecting to the server. Mirrors the enum in
+    /// `common/net/src/msg/client.rs`.
+    /// </summary>
+    [Serializable]
+    public abstract record ClientType {
+        public sealed record Game : ClientType;
+        public sealed record ChatOnly : ClientType;
+        public sealed record SilentSpectator : ClientType;
+        public sealed record Bot(bool Privileged) : ClientType;
+
+        public bool IsValidForRole(AdminRole? role) => this switch {
+            SilentSpectator => role.HasValue,
+            Bot var b => !b.Privileged || role.HasValue,
+            _ => true,
+        };
+
+        public bool EmitLoginEvents() => this is not SilentSpectator;
+        public bool CanSpectate() => this is Game || this is SilentSpectator;
+        public bool CanEnterCharacter() => this is Game;
+        public bool CanSendMessage() => this is not SilentSpectator;
+    }
+
+    /// <summary>
+    /// Data provided when registering a client connection.
+    /// </summary>
+    [Serializable]
+    public struct ClientRegister {
+        public string TokenOrUsername { get; set; }
+        public string? Locale { get; set; }
+        public ClientRegister(string tokenOrUsername, string? locale) {
+            TokenOrUsername = tokenOrUsername;
+            Locale = locale;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `AdminRoleHelper` to parse and format admin roles like the Rust version
- document the helper methods in the CoreEngine README
- clarify `ClientType` permission checks in the Network README

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet build VelorenPort/CoreEngine/CoreEngine.csproj -nologo` *(fails: command not found)*
- `dotnet build VelorenPort/VelorenPort.sln -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bdd0fc12083289e6dfb375b34d5f3