### PR TITLE
Add math operations and fix build

### DIFF
--- a/VelorenPort/CoreEngine/Src/EventBus.cs
+++ b/VelorenPort/CoreEngine/Src/EventBus.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace VelorenPort.CoreEngine {
+    /// <summary>
+    /// Generic event bus that stores events until they are consumed.
+    /// This mirrors the behaviour of the EventBus type in the Rust code.
+    /// </summary>
+    public class EventBus<T>
+    {
+        private readonly Queue<T> _queue = new();
+        private readonly object _lock = new();
+        private byte _recvCount;
+
+        public EventBus() { }
+
+        /// <summary>
+        /// Create a disposable emitter that collects events and
+        /// pushes them onto the bus when disposed.
+        /// </summary>
+        public Emitter GetEmitter() => new Emitter(this);
+
+        /// <summary>Emit an event immediately.</summary>
+        public void EmitNow(T ev) {
+            lock (_lock) {
+                _queue.Enqueue(ev);
+            }
+        }
+
+        /// <summary>
+        /// Retrieve all pending events. The returned list has a fixed
+        /// size and the bus is cleared afterwards.
+        /// </summary>
+        public List<T> RecvAll() {
+            lock (_lock) {
+                var list = new List<T>(_queue);
+                _queue.Clear();
+                if (_recvCount < byte.MaxValue)
+                    _recvCount++;
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// Retrieve all pending events assuming exclusive access. This
+        /// avoids locking and mirrors <c>recv_all_mut</c> from Rust.
+        /// </summary>
+        public List<T> RecvAllMut() {
+            var list = new List<T>(_queue);
+            _queue.Clear();
+            if (_recvCount < byte.MaxValue)
+                _recvCount++;
+            return list;
+        }
+
+        /// <summary>
+        /// Internal method used by <see cref="Emitter"/> to append events.
+        /// </summary>
+        internal void AppendRange(IEnumerable<T> events) {
+            lock (_lock) {
+                foreach (var ev in events)
+                    _queue.Enqueue(ev);
+            }
+        }
+
+        /// <summary>Number of times events have been received (debug only).</summary>
+        public byte RecvCount {
+            get { lock (_lock) { return _recvCount; } }
+        }
+
+        /// <summary>
+        /// Disposable emitter that batches events and appends them to the bus
+        /// when disposed, replicating the RAII drop behaviour of Rust.
+        /// </summary>
+        public sealed class Emitter : IEmitExt<T>, IDisposable {
+            private readonly EventBus<T> _bus;
+            private readonly List<T> _events = new();
+            private int _disposed;
+
+            internal Emitter(EventBus<T> bus) { _bus = bus; }
+
+            public void Emit(T ev) => _events.Add(ev);
+
+            public void EmitMany(IEnumerable<T> evs) => _events.AddRange(evs);
+
+            public void Append(ref List<T> events) {
+                if (events.Count == 0) return;
+                _events.AddRange(events);
+                events.Clear();
+            }
+
+            public void AppendList(List<T> list) {
+                if (_events.Count == 0) {
+                    _events.AddRange(list);
+                } else {
+                    _events.AddRange(list);
+                }
+            }
+
+            public void Dispose() {
+                if (Interlocked.Exchange(ref _disposed, 1) == 0 && _events.Count > 0)
+                    _bus.AppendRange(_events);
+            }
+        }
+    }
+
+    /// <summary>Interface implemented by types that can emit events.</summary>
+    public interface IEmitExt<in T> {
+        void Emit(T ev);
+        void EmitMany(IEnumerable<T> events);
+    }
+}

--- a/VelorenPort/CoreEngine/Src/UnityMathematicsStub.cs
+++ b/VelorenPort/CoreEngine/Src/UnityMathematicsStub.cs
@@ -15,8 +15,13 @@ namespace Unity.Mathematics {
         public static float3 operator -(float3 v) => new float3(-v.x, -v.y, -v.z);
         public static float3 operator *(float3 a, float3 b) => new float3(a.x * b.x, a.y * b.y, a.z * b.z);
         public static float3 operator *(float3 a, float b) => new float3(a.x * b, a.y * b, a.z * b);
+        public static float3 operator *(float b, float3 a) => a * b;
+        public static float3 operator +(float3 a, float b) => new float3(a.x + b, a.y + b, a.z + b);
+        public static float3 operator +(float b, float3 a) => a + b;
+        public static float3 operator -(float3 a, float b) => new float3(a.x - b, a.y - b, a.z - b);
         public static float3 operator /(float3 a, float3 b) => new float3(a.x / b.x, a.y / b.y, a.z / b.z);
         public static float3 operator /(float3 a, float b) => new float3(a.x / b, a.y / b, a.z / b);
+        public static float3 operator /(float b, float3 a) => new float3(b / a.x, b / a.y, b / a.z);
         public static bool3 operator >(float3 lhs, float rhs) => new bool3(lhs.x > rhs, lhs.y > rhs, lhs.z > rhs);
         public static bool3 operator <(float3 lhs, float rhs) => new bool3(lhs.x < rhs, lhs.y < rhs, lhs.z < rhs);
     }
@@ -27,6 +32,14 @@ namespace Unity.Mathematics {
         public static float4 operator +(float4 a, float4 b) => new float4(a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w);
         public static float4 operator -(float4 a, float4 b) => new float4(a.x - b.x, a.y - b.y, a.z - b.z, a.w - b.w);
         public static float4 operator *(float4 a, float b) => new float4(a.x * b, a.y * b, a.z * b, a.w * b);
+        public static float4 operator *(float b, float4 a) => a * b;
+        public static float4 operator *(float4 a, float4 b) => new float4(a.x * b.x, a.y * b.y, a.z * b.z, a.w * b.w);
+        public static float4 operator /(float4 a, float4 b) => new float4(a.x / b.x, a.y / b.y, a.z / b.z, a.w / b.w);
+        public static float4 operator /(float4 a, float b) => new float4(a.x / b, a.y / b, a.z / b, a.w / b);
+        public static float4 operator -(float4 v) => new float4(-v.x, -v.y, -v.z, -v.w);
+        public static float4 operator +(float4 a, float b) => new float4(a.x + b, a.y + b, a.z + b, a.w + b);
+        public static float4 operator +(float b, float4 a) => new float4(a.x + b, a.y + b, a.z + b, a.w + b);
+        public static float4 operator -(float b, float4 a) => new float4(b - a.x, b - a.y, b - a.z, b - a.w);
     }
 
     public struct int3 {

--- a/VelorenPort/Network/Network.csproj
+++ b/VelorenPort/Network/Network.csproj
@@ -6,5 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Src/**/*.cs" />
+    <ProjectReference Include="../CoreEngine/CoreEngine.csproj" />
   </ItemGroup>
 </Project>

--- a/VelorenPort/Network/Src/ClientMessages.cs
+++ b/VelorenPort/Network/Src/ClientMessages.cs
@@ -15,7 +15,7 @@ namespace VelorenPort.Network {
 
         public bool IsValidForRole(AdminRole? role) => this switch {
             SilentSpectator => role.HasValue,
-            Bot var b => !b.Privileged || role.HasValue,
+            Bot { Privileged: var p } => !p || role.HasValue,
             _ => true,
         };
 

--- a/VelorenPort/Network/Src/NetworkConnectError.cs
+++ b/VelorenPort/Network/Src/NetworkConnectError.cs
@@ -1,3 +1,4 @@
+using System;
 namespace VelorenPort.Network {
     /// <summary>
     /// Errors thrown during connection establishment. Mirrors the

--- a/VelorenPort/Network/Src/NetworkError.cs
+++ b/VelorenPort/Network/Src/NetworkError.cs
@@ -1,3 +1,4 @@
+using System;
 namespace VelorenPort.Network {
     /// <summary>
     /// Errors thrown by <see cref="Network"/> methods. This replicates the

--- a/VelorenPort/Network/Src/StreamError.cs
+++ b/VelorenPort/Network/Src/StreamError.cs
@@ -1,3 +1,4 @@
+using System;
 namespace VelorenPort.Network {
     /// <summary>
     /// Errors thrown by Stream operations. In Rust these variants often carry

--- a/VelorenPort/Server/Src/Client.cs
+++ b/VelorenPort/Server/Src/Client.cs
@@ -18,7 +18,7 @@ namespace VelorenPort.Server {
         internal Client(Participant participant) {
             Participant = participant;
             Position = new Pos(float3.zero);
-            Presence = new Presence(new ViewDistances(8, 8), PresenceKind.Spectator);
+            Presence = new Presence(new ViewDistances(8, 8), new PresenceKind.Spectator());
             RegionSubscription = RegionUtils.InitializeRegionSubscription(Position, Presence);
         }
 

--- a/VelorenPort/World/Src/BlockKind.cs
+++ b/VelorenPort/World/Src/BlockKind.cs
@@ -31,8 +31,8 @@ namespace VelorenPort.World {
         public static bool IsFluid(this BlockKind kind) => ((byte)kind & 0xF0) == 0x00;
         public static bool IsLiquid(this BlockKind kind) => kind.IsFluid() && !kind.IsAir();
         public static LiquidKind? LiquidKind(this BlockKind kind) => kind switch {
-            BlockKind.Water => LiquidKind.Water,
-            BlockKind.Lava => LiquidKind.Lava,
+            BlockKind.Water => CoreEngine.LiquidKind.Water,
+            BlockKind.Lava => CoreEngine.LiquidKind.Lava,
             _ => null,
         };
         public static bool IsFilled(this BlockKind kind) => !kind.IsFluid();


### PR DESCRIPTION
## Summary
- add scalar arithmetic overloads to `UnityMathematicsStub`
- allow Network assembly to reference CoreEngine
- tweak client type logic and fix using directives
- instantiate default presence properly
- fix `BlockKind` liquid mapping

## Testing
- `dotnet build VelorenPort/VelorenPort.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685be0c3bff88328b51008365ed64b1e