### PR TITLE
Add result type for connection helper

### DIFF
--- a/VelorenPort/Client/Src/ConnectionArgs.cs
+++ b/VelorenPort/Client/Src/ConnectionArgs.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using VelorenPort.CoreEngine;
+using VelorenPort.Network;
+
+namespace VelorenPort.Client {
+    /// <summary>
+    /// Represents connection parameters for the client. Mirrors the
+    /// <c>ConnectionArgs</c> enum from the Rust implementation.
+    /// </summary>
+    [Serializable]
+    public abstract record ConnectionArgs {
+        public sealed record Quic(string Hostname, bool PreferIpv6, bool ValidateTls) : ConnectionArgs;
+        public sealed record Tcp(string Hostname, bool PreferIpv6) : ConnectionArgs;
+        public sealed record Srv(string Hostname, bool PreferIpv6, bool ValidateTls, bool UseQuic) : ConnectionArgs;
+        public sealed record Mpsc(ulong ChannelId) : ConnectionArgs;
+    }
+
+    /// <summary>
+    /// Helper methods for resolving hostnames and attempting connections.
+    /// </summary>
+    public static class ConnectionUtil {
+        private const int DefaultPort = 14004;
+
+        /// <summary>Resolve an address string to a set of socket endpoints.</summary>
+        public static async Task<List<IPEndPoint>> ResolveAsync(string address, bool preferIpv6) {
+            if (address is null)
+                throw new ArgumentNullException(nameof(address));
+
+            ParseAddress(address, out var host, out var port);
+            var addresses = await Dns.GetHostAddressesAsync(host);
+            var ordered = OrderAddresses(addresses, preferIpv6);
+            return ordered.Select(ip => new IPEndPoint(ip, port)).ToList();
+        }
+
+        /// <summary>Try connecting using each resolved address.</summary>
+        public static async Task<Result<Participant, Error>> TryConnectAsync(
+            Network.Network network,
+            string address,
+            int? overridePort,
+            bool preferIpv6,
+            Func<IPEndPoint, ConnectAddr> map)
+        {
+            if (network is null)
+                throw new ArgumentNullException(nameof(network));
+            if (address is null)
+                throw new ArgumentNullException(nameof(address));
+            if (map is null)
+                throw new ArgumentNullException(nameof(map));
+
+            var endpoints = await ResolveAsync(address, preferIpv6);
+            Error? lastError = null;
+            foreach (var ep in endpoints) {
+                var finalEp = overridePort.HasValue ? new IPEndPoint(ep.Address, overridePort.Value) : ep;
+                try {
+                    var participant = await network.ConnectAsync(map(finalEp));
+                    return Result<Participant, Error>.Ok(participant);
+                } catch (NetworkError ne) {
+                    lastError = new Error.NetworkErr(ne);
+                } catch (Exception ex) {
+                    lastError = new Error.Other(ex.Message);
+                }
+            }
+            return Result<Participant, Error>.Err(lastError ?? new Error.Other("No Ip Addr provided"));
+        }
+
+        private static void ParseAddress(string address, out string host, out int port) {
+            host = address;
+            port = DefaultPort;
+
+            if (address.StartsWith("[") && address.Contains("]")) {
+                var end = address.IndexOf(']');
+                host = address.Substring(1, end - 1);
+                var rest = address[(end + 1)..];
+                if (rest.StartsWith(":"))
+                    int.TryParse(rest[1..], out port);
+                return;
+            }
+
+            var lastColon = address.LastIndexOf(':');
+            if (lastColon > 0 && int.TryParse(address[(lastColon + 1)..], out var parsed)) {
+                host = address[..lastColon];
+                port = parsed;
+            }
+        }
+
+        private static IEnumerable<IPAddress> OrderAddresses(IEnumerable<IPAddress> addrs, bool preferIpv6) {
+            var first = new List<IPAddress>();
+            var second = new List<IPAddress>();
+            foreach (var ip in addrs) {
+                if ((ip.AddressFamily == AddressFamily.InterNetworkV6) == preferIpv6)
+                    first.Add(ip);
+                else
+                    second.Add(ip);
+            }
+            return first.Concat(second);
+        }
+    }
+}

--- a/VelorenPort/Client/Src/Error.cs
+++ b/VelorenPort/Client/Src/Error.cs
@@ -1,0 +1,50 @@
+using System;
+using VelorenPort.Network;
+
+namespace VelorenPort.Client {
+    /// <summary>
+    /// Error types returned by the client API. Mirrors <c>error.rs</c> from the
+    /// Rust implementation.
+    /// </summary>
+    [Serializable]
+    public abstract record Error {
+        public sealed record Kicked(string Reason) : Error;
+        public sealed record NetworkErr(NetworkError Error) : Error;
+        public sealed record ParticipantErr(ParticipantError Error) : Error;
+        public sealed record StreamErr(StreamError Error) : Error;
+        public sealed record ServerTimeout : Error;
+        public sealed record ServerShutdown : Error;
+        public sealed record TooManyPlayers : Error;
+        public sealed record NotOnWhitelist : Error;
+        public sealed record AuthErr(string Message) : Error;
+        public sealed record AuthClientError(Exception Error) : Error;
+        public sealed record AuthServerUrlInvalid(string Url) : Error;
+        public sealed record AuthServerNotTrusted : Error;
+        public sealed record HostnameLookupFailed(Exception Error) : Error;
+        public sealed record Banned(BanInfo Info) : Error;
+        public sealed record InvalidCharacter : Error;
+        public sealed record Other(string Message) : Error;
+        public sealed record SpecsErr(Exception Error) : Error;
+
+        public override string ToString() => this switch {
+            Kicked k => $"Kicked: {k.Reason}",
+            NetworkErr n => $"Network Error: {n.Error}",
+            ParticipantErr p => $"Participant Error: {p.Error}",
+            StreamErr s => $"Stream Error: {s.Error}",
+            ServerTimeout => "Server timeout",
+            ServerShutdown => "Server shutdown",
+            TooManyPlayers => "Too many players",
+            NotOnWhitelist => "Not on whitelist",
+            AuthErr a => $"Authentication error: {a.Message}",
+            AuthClientError ac => $"Auth client error: {ac.Error}",
+            AuthServerUrlInvalid u => $"Invalid auth server url: {u.Url}",
+            AuthServerNotTrusted => "Auth server not trusted",
+            HostnameLookupFailed e => $"Hostname lookup failed: {e.Error.Message}",
+            Banned b => $"Banned: {b.Info.Reason}",
+            InvalidCharacter => "Invalid character",
+            Other o => o.Message,
+            SpecsErr se => $"Specs error: {se.Error}",
+            _ => base.ToString()
+        };
+    }
+}

--- a/VelorenPort/CoreEngine/Src/Result.cs
+++ b/VelorenPort/CoreEngine/Src/Result.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace VelorenPort.CoreEngine {
+    /// <summary>
+    /// Generic result type replicating Rust's <c>Result&lt;T, E&gt;</c> pattern.
+    /// </summary>
+    public readonly struct Result<T, E> {
+        private readonly T _ok;
+        private readonly E _err;
+        public bool IsOk { get; }
+        public T Ok => IsOk ? _ok : throw new InvalidOperationException();
+        public E Err => !IsOk ? _err : throw new InvalidOperationException();
+        private Result(T ok, E err, bool isOk) { _ok = ok; _err = err; IsOk = isOk; }
+        public static Result<T, E> Ok(T val) => new(val, default!, true);
+        public static Result<T, E> Err(E err) => new(default!, err, false);
+    }
+}

--- a/VelorenPort/MigrationStatus.md
+++ b/VelorenPort/MigrationStatus.md
@@ -11,7 +11,7 @@ This document tracks progress of the Rust to C# port. Percentages reflect curren
 | Network | 100% |
 | World | 98% |
 | Server | 68% |
-| Client | 0% |
+| Client | 66% |
 | Simulation | 0% |
 | CLI | 100% |
 | Plugin | 0% |
@@ -98,6 +98,7 @@ This document tracks progress of the Rust to C# port. Percentages reflect curren
 | comp/Player.cs | 100% |
 | comp/item/Reagent.cs | 100% |
 | comp/item/ToolKind.cs | 100% |
+| Result.cs | 100% |
 
 ### Network
 
@@ -216,6 +217,8 @@ This document tracks progress of the Rust to C# port. Percentages reflect curren
 
 | Archivo | Porcentaje |
 |---------|-----------:|
+| ConnectionArgs.cs | 100% |
+| Error.cs | 100% |
 | Placeholder.cs | 0% |
 
 ### Simulation


### PR DESCRIPTION
## Summary
- add generic Result struct to CoreEngine
- return `Result<Participant, Error>` from connection attempts
- document Result.cs in migration status

## Testing
- `dotnet build VelorenPort/Client/Client.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eaf97e40c832898ac0cdcba0064c4