### PR TITLE
Add rtsim data load/save helpers

### DIFF
--- a/VelorenPort/CoreEngine/Src/Npc.cs
+++ b/VelorenPort/CoreEngine/Src/Npc.cs
@@ -9,6 +9,7 @@ namespace VelorenPort.CoreEngine {
         public Uid Id { get; }
         public string Name { get; set; } = "NPC";
         public float Health { get; private set; } = 100f;
+        public VelorenPort.Simulation.SiteId? Home { get; set; }
 
         public Npc(Uid id) {
             Id = id;

--- a/VelorenPort/MigrationStatus.md
+++ b/VelorenPort/MigrationStatus.md
@@ -12,7 +12,7 @@ This document tracks progress of the Rust to C# port. Percentages reflect curren
 | World | 98% |
 | Server | 82% |
 | Client | 66% |
-| Simulation | 0% |
+| Simulation | 65% |
 | CLI | 100% |
 | Plugin | 0% |
 
@@ -226,7 +226,15 @@ This document tracks progress of the Rust to C# port. Percentages reflect curren
 
 | Archivo | Porcentaje |
 |---------|-----------:|
-| Placeholder.cs | 0% |
+| Events.cs | 100% |
+| Unit.cs | 100% |
+| NpcSystemData.cs | 100% |
+| Data.cs | 55% |
+| RtState.cs | 55% |
+| Rule.cs | 50% |
+| Npcs.cs | 50% |
+| Site.cs | 50% |
+| Sites.cs | 50% |
 
 ### CLI
 

--- a/VelorenPort/Simulation/Src/Data.cs
+++ b/VelorenPort/Simulation/Src/Data.cs
@@ -1,0 +1,82 @@
+using System;
+using VelorenPort.CoreEngine;
+
+namespace VelorenPort.Simulation {
+    /// <summary>
+    /// Core rtsim data resource. Implements the minimum set of fields
+    /// required for event routing and ticking. Additional fields from the
+    /// original Rust version will be introduced as their dependencies are
+    /// ported.
+    /// </summary>
+    [Serializable]
+    public class Data {
+        public const uint CURRENT_VERSION = 9;
+
+        /// <summary>
+        /// The version number of the serialized data format.
+        /// </summary>
+        public uint Version { get; set; } = CURRENT_VERSION;
+
+        public ulong Tick { get; set; }
+        public TimeOfDay TimeOfDay { get; set; }
+
+        public Npcs Npcs { get; } = new();
+        public Sites Sites { get; } = new();
+
+        /// <summary>
+        /// If <c>true</c>, rtsim data will be ignored and regenerated on load.
+        /// </summary>
+        public bool ShouldPurge { get; set; }
+
+        public enum ReadError
+        {
+            None,
+            Load,
+            VersionMismatch,
+        }
+
+        /// <summary>
+        /// Attempt to load rtsim data from a stream. If the version does not
+        /// match <see cref="CURRENT_VERSION"/>, the partially deserialized data
+        /// is returned alongside a <see cref="ReadError.VersionMismatch"/> code.
+        /// </summary>
+        public static (Data? Data, ReadError Error) ReadFrom(System.IO.Stream stream)
+        {
+            try
+            {
+                var data = System.Text.Json.JsonSerializer.Deserialize<Data>(stream);
+                if (data == null)
+                    return (null, ReadError.Load);
+                return data.Version == CURRENT_VERSION
+                    ? (data, ReadError.None)
+                    : (data, ReadError.VersionMismatch);
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                return (null, ReadError.Load);
+            }
+        }
+
+        /// <summary>
+        /// Write the data to a stream using JSON serialization.
+        /// </summary>
+        public void WriteTo(System.IO.Stream stream)
+        {
+            System.Text.Json.JsonSerializer.Serialize(stream, this);
+        }
+
+        /// <summary>
+        /// Add an NPC to the simulation, registering them with their home site i
+        /// if provided.
+        /// </summary>
+        public NpcId SpawnNpc(Npc npc)
+        {
+            var id = Npcs.CreateNpc(npc);
+            if (npc.Home is SiteId home)
+            {
+                Sites.Get(home)?.Population.Add(id);
+            }
+            return id;
+        }
+    }
+}

--- a/VelorenPort/Simulation/Src/Events.cs
+++ b/VelorenPort/Simulation/Src/Events.cs
@@ -1,0 +1,61 @@
+using System;
+using Unity.Mathematics;
+using VelorenPort.CoreEngine;
+using VelorenPort.World;
+
+namespace VelorenPort.Simulation {
+    // Simple numeric identifiers matching the slotmap keys in Rust
+    public readonly record struct NpcId(int Value);
+    public readonly record struct SiteId(uint Value);
+
+    public enum VolumeKind { Terrain, Entity }
+    public readonly struct VolumePos<T> {
+        public VolumeKind Kind { get; }
+        public int3 Pos { get; }
+        public T? Entity { get; }
+        public VolumePos(int3 pos) { Kind = VolumeKind.Terrain; Pos = pos; Entity = default; }
+        public VolumePos(int3 pos, T entity) { Kind = VolumeKind.Entity; Pos = pos; Entity = entity; }
+    }
+
+    /// <summary>
+    /// Marker interface for simulation events. Each event specifies the system
+    /// data that handlers require in order to process the event.
+    /// </summary>
+    public interface IEvent<TSystemData> { }
+
+    /// <summary>
+    /// Context passed to rule callbacks when an event is emitted.
+    /// </summary>
+    public sealed class EventCtx<R, E, D> where R : IRule where E : IEvent<D> {
+        public RtState State { get; }
+        public R Rule { get; }
+        public E Event { get; }
+        public World.World World { get; }
+        public TestWorld.IndexRef Index { get; }
+        public D SystemData { get; }
+
+        public EventCtx(RtState state, R rule, E e, World.World world, TestWorld.IndexRef index, D data) {
+            State = state;
+            Rule = rule;
+            Event = e;
+            World = world;
+            Index = index;
+            SystemData = data;
+        }
+    }
+
+    public sealed record OnSetup() : IEvent<Unit>;
+
+    public sealed record OnTick(TimeOfDay TimeOfDay, Time Time, ulong Tick, float Dt) : IEvent<NpcSystemData>;
+
+    public sealed record OnDeath(Actor Actor, float3? Wpos, Actor? Killer) : IEvent<Unit>;
+
+    public sealed record OnHelped(Actor Actor, Actor? Saver) : IEvent<Unit>;
+
+    public sealed record OnHealthChange(Actor Actor, Actor? Cause, float NewHealthFraction, float Change) : IEvent<Unit>;
+
+    public sealed record OnTheft(Actor Actor, int3 Wpos, SpriteKind Sprite, SiteId? Site) : IEvent<Unit>;
+
+    public sealed record OnMountVolume(Actor Actor, VolumePos<NpcId> Pos) : IEvent<Unit>;
+
+}

--- a/VelorenPort/Simulation/Src/NpcSystemData.cs
+++ b/VelorenPort/Simulation/Src/NpcSystemData.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using Unity.Entities;
+using VelorenPort.CoreEngine;
+
+namespace VelorenPort.Simulation {
+    /// <summary>
+    /// Data accessed by NPC related systems when processing simulation events.
+    /// Mirrors the `NpcSystemData` struct from rtsim.
+    /// </summary>
+    [Serializable]
+    public class NpcSystemData {
+        public IReadOnlyDictionary<Entity, Pos> Positions { get; }
+        public IdMaps IdMaps { get; }
+        public ServerConstants ServerConstants { get; }
+
+        public NpcSystemData(
+            IReadOnlyDictionary<Entity, Pos> positions,
+            IdMaps idMaps,
+            ServerConstants serverConstants)
+        {
+            Positions = positions;
+            IdMaps = idMaps;
+            ServerConstants = serverConstants;
+        }
+    }
+}

--- a/VelorenPort/Simulation/Src/Npcs.cs
+++ b/VelorenPort/Simulation/Src/Npcs.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using VelorenPort.CoreEngine;
+
+namespace VelorenPort.Simulation {
+    /// <summary>
+    /// Simplified store for NPCs. Provides creation and lookup by identifier.
+    /// </summary>
+    [Serializable]
+    public class Npcs {
+        private int _counter;
+        private readonly Dictionary<NpcId, Npc> _npcs = new();
+
+        public NpcId CreateNpc(Npc npc) {
+            var id = new NpcId(_counter++);
+            _npcs[id] = npc;
+            return id;
+        }
+
+        public bool Remove(NpcId id) => _npcs.Remove(id);
+
+        public Npc? Get(NpcId id) => _npcs.TryGetValue(id, out var npc) ? npc : null;
+
+        public IEnumerable<KeyValuePair<NpcId, Npc>> All => _npcs;
+    }
+}

--- a/VelorenPort/Simulation/Src/Placeholder.cs
+++ b/VelorenPort/Simulation/Src/Placeholder.cs
@@ -1,3 +1,0 @@
-namespace VelorenPort.Simulation {
-    internal static class Placeholder { }
-}

--- a/VelorenPort/Simulation/Src/RtState.cs
+++ b/VelorenPort/Simulation/Src/RtState.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using VelorenPort.CoreEngine;
+using VelorenPort.Server;
+using VelorenPort.World;
+
+namespace VelorenPort.Simulation {
+    /// <summary>
+    /// Central dispatcher for rtsim events. Provides minimal event routing
+    /// capabilities mirroring the original Rust implementation.
+    /// </summary>
+    [Serializable]
+    public class RtState {
+        private readonly Dictionary<Type, object> _resources = new();
+        private readonly Dictionary<Type, IRule> _rules = new();
+        private readonly Dictionary<Type, List<IEventHandler>> _handlers = new();
+
+        public void AddResource<T>(T resource) where T : class =>
+            _resources[typeof(T)] = resource;
+
+        public T GetResource<T>() where T : class =>
+            (T)_resources[typeof(T)];
+
+        public void AddRule<R>(R rule) where R : IRule
+        {
+            _rules[typeof(R)] = rule;
+            rule.Start(this);
+        }
+
+        public void StartRule<R>() where R : IRule, new()
+        {
+            var rule = new R();
+            AddRule(rule);
+        }
+
+        public R GetRule<R>() where R : IRule
+        {
+            if (_rules.TryGetValue(typeof(R), out var rule))
+                return (R)rule;
+            throw new InvalidOperationException($"Rule '{typeof(R).Name}' does not exist");
+        }
+
+        public void Bind<R, E, D>(Action<EventCtx<R, E, D>> handler)
+            where R : IRule
+            where E : IEvent<D>
+        {
+            if (!_handlers.TryGetValue(typeof(E), out var list)) {
+                list = new List<IEventHandler>();
+                _handlers[typeof(E)] = list;
+            }
+            list.Add(new EventHandler<R, E, D>(handler));
+        }
+
+        public void Emit<E, D>(E evt, D data, World world, TestWorld.IndexRef index)
+            where E : IEvent<D>
+        {
+            if (_handlers.TryGetValue(typeof(E), out var list)) {
+                foreach (var h in list)
+                    h.Invoke(this, world, index, evt!, data!);
+            }
+        }
+
+        public void Tick(
+            NpcSystemData systemData,
+            World world,
+            TestWorld.IndexRef index,
+            TimeOfDay timeOfDay,
+            Time time,
+            float dt)
+        {
+            var data = GetResource<Data>();
+            data.TimeOfDay = timeOfDay;
+            data.Tick++;
+            var evt = new OnTick(timeOfDay, time, data.Tick, dt);
+            Emit(evt, systemData, world, index);
+        }
+
+        private interface IEventHandler {
+            void Invoke(RtState state, World world, TestWorld.IndexRef index, object evt, object data);
+        }
+
+        private sealed class EventHandler<R, E, D> : IEventHandler
+            where R : IRule
+            where E : IEvent<D>
+        {
+            private readonly Action<EventCtx<R, E, D>> _handler;
+            public EventHandler(Action<EventCtx<R, E, D>> handler) => _handler = handler;
+
+            public void Invoke(RtState state, World world, TestWorld.IndexRef index, object evt, object data)
+            {
+                var rule = state.GetRule<R>();
+                var ctx = new EventCtx<R, E, D>(state, rule, (E)evt, world, index, (D)data);
+                _handler(ctx);
+            }
+        }
+    }
+}

--- a/VelorenPort/Simulation/Src/Rule.cs
+++ b/VelorenPort/Simulation/Src/Rule.cs
@@ -1,0 +1,29 @@
+namespace VelorenPort.Simulation {
+    /// <summary>
+    /// Marker interface for rtsim rules. Concrete rule implementations
+    /// are expected to register their event handlers during <see cref="Start"/>.
+    /// </summary>
+    public interface IRule
+    {
+        /// <summary>
+        /// Called when the rule is started by <see cref="RtState"/>. Rules
+        /// should bind all event handlers here and perform any required
+        /// initialisation.
+        /// </summary>
+        /// <param name="state">The simulation state starting this rule.</param>
+        void Start(RtState state);
+    }
+
+    /// <summary>
+    /// Errors that may occur while starting a rule.
+    /// Currently only used for parity with the Rust implementation.
+    /// </summary>
+    public enum RuleError
+    {
+        /// <summary>No specific error.</summary>
+        None,
+
+        /// <summary>The requested rule does not exist.</summary>
+        NoSuchRule,
+    }
+}

--- a/VelorenPort/Simulation/Src/Site.cs
+++ b/VelorenPort/Simulation/Src/Site.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+
+namespace VelorenPort.Simulation {
+    /// <summary>
+    /// Minimal representation of a site used for NPC population tracking.
+    /// </summary>
+    [Serializable]
+    public class Site {
+        public HashSet<NpcId> Population { get; } = new();
+    }
+}

--- a/VelorenPort/Simulation/Src/Sites.cs
+++ b/VelorenPort/Simulation/Src/Sites.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+
+namespace VelorenPort.Simulation {
+    /// <summary>
+    /// Collection of sites indexed by identifier.
+    /// </summary>
+    [Serializable]
+    public class Sites {
+        private readonly Dictionary<SiteId, Site> _sites = new();
+        private uint _counter;
+
+        public SiteId Create(Site site) {
+            var id = new SiteId(_counter++);
+            _sites[id] = site;
+            return id;
+        }
+
+        public bool Remove(SiteId id) => _sites.Remove(id);
+
+        public Site? Get(SiteId id) => _sites.TryGetValue(id, out var site) ? site : null;
+
+        public IEnumerable<KeyValuePair<SiteId, Site>> All => _sites;
+    }
+}

--- a/VelorenPort/Simulation/Src/Unit.cs
+++ b/VelorenPort/Simulation/Src/Unit.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace VelorenPort.Simulation {
+    /// <summary>
+    /// Equivalent to Rust's unit type `()`.
+    /// Useful for events that do not require additional system data.
+    /// </summary>
+    [Serializable]
+    public readonly struct Unit { }
+}


### PR DESCRIPTION
## Summary
- implement read/write helpers for rtsim `Data`
- expose removal and enumeration helpers on `Npcs` and `Sites`
- update migration progress for Simulation subsystem

## Testing
- `dotnet format --verify-no-changes` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f078e74d48328a841a1a6fb2d3805