### PR TITLE
Increase coverage in C# tests

### DIFF
--- a/VelorenPort/CoreEngine.Tests/DayPeriodUtilTests.cs
+++ b/VelorenPort/CoreEngine.Tests/DayPeriodUtilTests.cs
@@ -1,0 +1,27 @@
+using VelorenPort.CoreEngine;
+
+namespace CoreEngine.Tests;
+
+public class DayPeriodUtilTests
+{
+    [Theory]
+    [InlineData(0, DayPeriod.Night)]
+    [InlineData(7 * 3600, DayPeriod.Morning)]
+    [InlineData(12 * 3600, DayPeriod.Noon)]
+    [InlineData(18 * 3600, DayPeriod.Evening)]
+    [InlineData(22 * 3600, DayPeriod.Night)]
+    [InlineData(-1 * 3600, DayPeriod.Night)]
+    public void FromTimeOfDay_ReturnsExpectedPeriod(double seconds, DayPeriod expected)
+    {
+        Assert.Equal(expected, DayPeriodUtil.FromTimeOfDay(seconds));
+    }
+
+    [Fact]
+    public void IsDarkAndLight_WorkAsOpposites()
+    {
+        Assert.True(DayPeriod.Night.IsDark());
+        Assert.False(DayPeriod.Night.IsLight());
+        Assert.False(DayPeriod.Noon.IsDark());
+        Assert.True(DayPeriod.Noon.IsLight());
+    }
+}

--- a/VelorenPort/CoreEngine.Tests/EventBusTests.cs
+++ b/VelorenPort/CoreEngine.Tests/EventBusTests.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using VelorenPort.CoreEngine;
+
+namespace CoreEngine.Tests;
+
+public class EventBusTests
+{
+    [Fact]
+    public void EmitNow_AddsEventImmediately()
+    {
+        var bus = new EventBus<int>();
+        bus.EmitNow(5);
+        var events = bus.RecvAll();
+        Assert.Single(events, 5);
+    }
+
+    [Fact]
+    public void Emitter_BatchesEventsUntilDispose()
+    {
+        var bus = new EventBus<string>();
+        using (var emitter = bus.GetEmitter())
+        {
+            emitter.Emit("a");
+            emitter.EmitMany(new[] { "b", "c" });
+        }
+        var events = bus.RecvAll();
+        Assert.Equal(new[] { "a", "b", "c" }, events);
+    }
+
+    [Fact]
+    public void RecvAllMut_SkipsLockingAndClearsQueue()
+    {
+        var bus = new EventBus<int>();
+        bus.EmitNow(1);
+        bus.EmitNow(2);
+        var list = bus.RecvAllMut();
+        Assert.Equal(new[] {1,2}, list);
+        Assert.Empty(bus.RecvAll());
+    }
+}

--- a/VelorenPort/CoreEngine.Tests/TimeResourcesTests.cs
+++ b/VelorenPort/CoreEngine.Tests/TimeResourcesTests.cs
@@ -1,0 +1,25 @@
+using VelorenPort.CoreEngine;
+using Unity.Mathematics;
+
+namespace CoreEngine.Tests;
+
+public class TimeResourcesTests
+{
+    [Fact]
+    public void Time_AddDays_UsesCoefficient()
+    {
+        var time = new Time(0);
+        var result = time.AddDays(1, 1.0);
+        Assert.Equal(86400, result.Seconds);
+    }
+
+    [Fact]
+    public void SunDirAndMoonDir_HaveOppositeZAtMidnight()
+    {
+        var tod = new TimeOfDay(0);
+        float3 sun = tod.SunDir();
+        float3 moon = tod.MoonDir();
+        Assert.InRange(sun.z, 0.999f, 1.001f);
+        Assert.InRange(moon.z, -1.001f, -0.999f);
+    }
+}

--- a/VelorenPort/World.Tests/BlockKindTests.cs
+++ b/VelorenPort/World.Tests/BlockKindTests.cs
@@ -1,0 +1,19 @@
+using VelorenPort.CoreEngine;
+using VelorenPort.World;
+
+namespace World.Tests;
+
+public class BlockKindTests
+{
+    [Fact]
+    public void ExtensionMethods_WorkAsExpected()
+    {
+        Assert.True(BlockKind.Air.IsAir());
+        Assert.False(BlockKind.Water.IsAir());
+        Assert.True(BlockKind.Water.IsLiquid());
+        Assert.Equal(LiquidKind.Water, BlockKind.Water.LiquidKind());
+        Assert.True(BlockKind.Rock.IsFilled());
+        Assert.True(BlockKind.Rock.HasColor());
+        Assert.True(BlockKind.Grass.IsTerrain());
+    }
+}

--- a/VelorenPort/World.Tests/BlockTests.cs
+++ b/VelorenPort/World.Tests/BlockTests.cs
@@ -1,0 +1,24 @@
+using VelorenPort.World;
+
+namespace World.Tests;
+
+public class BlockTests
+{
+    [Fact]
+    public void AirBlock_IsNotFilled()
+    {
+        var air = Block.Air;
+        Assert.False(air.IsFilled);
+        Assert.Null(air.GetColor());
+    }
+
+    [Fact]
+    public void WithDataOf_PreservesKind()
+    {
+        var baseBlock = Block.Filled(BlockKind.Rock, 1, 2, 3);
+        var other = Block.Filled(BlockKind.Rock, 4, 5, 6);
+        var combined = baseBlock.WithDataOf(other);
+        Assert.Equal(BlockKind.Rock, combined.Kind);
+        Assert.Equal(other.Data, combined.Data);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for day period helpers
- exercise EventBus behaviour
- check time helper structs
- verify BlockKind extension methods
- add extra Block behaviour tests

## Testing
- `dotnet test VelorenPort/CoreEngine.Tests/CoreEngine.Tests.csproj`
- `dotnet test VelorenPort/World.Tests/World.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_685f2a9f33b083289b49ff8f3c65c79f