### PR TITLE
Fix CLI class braces

### DIFF
--- a/VelorenPort/CLI/Src/Cli.cs
+++ b/VelorenPort/CLI/Src/Cli.cs
@@ -162,9 +162,6 @@ namespace VelorenPort.CLI {
                 }
             }
             return new BenchParams(view, dur);
-        }
-    }
-}
 
         /// <summary>
         /// Parses a command string as entered in the TUI and sends the resulting


### PR DESCRIPTION
## Summary
- fix misplaced closing braces in Cli.cs

## Testing
- `dotnet build` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685f2f70d24c8328b5bd07915d672451