### PR TITLE
Fix LinkHandle generic arguments

### DIFF
--- a/VelorenPort/CoreEngine/Src/Link.cs
+++ b/VelorenPort/CoreEngine/Src/Link.cs
@@ -5,10 +5,12 @@ namespace VelorenPort.CoreEngine {
     /// Generic link interface for relationships between entities.
     /// Mirrors the behaviour of Rust's <c>Link</c> trait in a simplified form.
     /// </summary>
-    public interface ILink<TError, TCreateData, TPersistData, TDeleteData> {
-        TError Create(LinkHandle<TError, TCreateData, TPersistData, TDeleteData> handle, ref TCreateData data);
-        bool Persist(LinkHandle<TError, TCreateData, TPersistData, TDeleteData> handle, ref TPersistData data);
-        void Delete(LinkHandle<TError, TCreateData, TPersistData, TDeleteData> handle, ref TDeleteData data);
+    public interface ILink<L, TError, TCreateData, TPersistData, TDeleteData>
+        where L : class, ILink<L, TError, TCreateData, TPersistData, TDeleteData>
+    {
+        TError Create(LinkHandle<L, TError, TCreateData, TPersistData, TDeleteData> handle, ref TCreateData data);
+        bool Persist(LinkHandle<L, TError, TCreateData, TPersistData, TDeleteData> handle, ref TPersistData data);
+        void Delete(LinkHandle<L, TError, TCreateData, TPersistData, TDeleteData> handle, ref TDeleteData data);
     }
 
     /// <summary>
@@ -21,7 +23,7 @@ namespace VelorenPort.CoreEngine {
     /// </summary>
     [Serializable]
     public class Is<R, L, TError, TCreateData, TPersistData, TDeleteData> : ICloneable
-        where L : class, ILink<TError, TCreateData, TPersistData, TDeleteData>
+        where L : class, ILink<L, TError, TCreateData, TPersistData, TDeleteData>
         where R : IRole<L>
     {
         private readonly LinkHandle<L, TError, TCreateData, TPersistData, TDeleteData> _link;
@@ -50,7 +52,7 @@ namespace VelorenPort.CoreEngine {
     public class LinkHandle<L, TError, TCreateData, TPersistData, TDeleteData> :
         IEquatable<LinkHandle<L, TError, TCreateData, TPersistData, TDeleteData>>,
         ICloneable
-        where L : class, ILink<TError, TCreateData, TPersistData, TDeleteData>
+        where L : class, ILink<L, TError, TCreateData, TPersistData, TDeleteData>
     {
         private readonly L _link;
         public LinkHandle(L link) { _link = link; }
@@ -81,7 +83,7 @@ namespace VelorenPort.CoreEngine {
     public class WeakLinkHandle<L, TError, TCreateData, TPersistData, TDeleteData> :
         IEquatable<WeakLinkHandle<L, TError, TCreateData, TPersistData, TDeleteData>>,
         ICloneable
-        where L : class, ILink<TError, TCreateData, TPersistData, TDeleteData>
+        where L : class, ILink<L, TError, TCreateData, TPersistData, TDeleteData>
     {
         private readonly WeakReference<L> _link;
         public WeakLinkHandle(L link) { _link = new WeakReference<L>(link); }
@@ -124,7 +126,7 @@ namespace VelorenPort.CoreEngine {
         internal DynWeakLinkHandle(WeakReference<object> inner) { _inner = inner; }
 
         internal static DynWeakLinkHandle FromWeakReference<L, TError, TCreateData, TPersistData, TDeleteData>(WeakReference<L> link)
-            where L : class, ILink<TError, TCreateData, TPersistData, TDeleteData>
+            where L : class, ILink<L, TError, TCreateData, TPersistData, TDeleteData>
         {
             var target = link.TryGetTarget(out var t) ? (object)t : null;
             return new DynWeakLinkHandle(new WeakReference<object>(target));
@@ -133,7 +135,7 @@ namespace VelorenPort.CoreEngine {
         public bool Exists => _inner.TryGetTarget(out _);
 
         public bool IsLink<L, TError, TCreateData, TPersistData, TDeleteData>(LinkHandle<L, TError, TCreateData, TPersistData, TDeleteData> link)
-            where L : class, ILink<TError, TCreateData, TPersistData, TDeleteData>
+            where L : class, ILink<L, TError, TCreateData, TPersistData, TDeleteData>
         {
             return _inner.TryGetTarget(out var t) && ReferenceEquals(t, link.Value);
         }

--- a/VelorenPort/CoreEngine/Src/Tether.cs
+++ b/VelorenPort/CoreEngine/Src/Tether.cs
@@ -18,7 +18,7 @@ namespace VelorenPort.CoreEngine {
     /// Ported from <c>tether.rs</c>.
     /// </summary>
     [Serializable]
-    public class Tethered : ILink<TetherError, Tethered.CreateData, Tethered.PersistData, Tethered.DeleteData> {
+    public class Tethered : ILink<Tethered, TetherError, Tethered.CreateData, Tethered.PersistData, Tethered.DeleteData> {
         public Uid Leader { get; set; }
         public Uid Follower { get; set; }
         public float TetherLength { get; set; }
@@ -54,7 +54,7 @@ namespace VelorenPort.CoreEngine {
             public GenericWriteStorage<Is<Follower>> Followers;
         }
 
-        public TetherError Create(LinkHandle<TetherError, CreateData, PersistData, DeleteData> handle, ref CreateData data) {
+        public TetherError Create(LinkHandle<Tethered, TetherError, CreateData, PersistData, DeleteData> handle, ref CreateData data) {
             var leaderEntity = data.IdMaps.GetEntity(Leader);
             var followerEntity = data.IdMaps.GetEntity(Follower);
             if (Leader.Equals(Follower)) {
@@ -74,7 +74,7 @@ namespace VelorenPort.CoreEngine {
             return TetherError.NoSuchEntity;
         }
 
-        public bool Persist(LinkHandle<TetherError, CreateData, PersistData, DeleteData> handle, ref PersistData data) {
+        public bool Persist(LinkHandle<Tethered, TetherError, CreateData, PersistData, DeleteData> handle, ref PersistData data) {
             var leaderEntity = data.IdMaps.GetEntity(Leader);
             var followerEntity = data.IdMaps.GetEntity(Follower);
             if (leaderEntity.HasValue && followerEntity.HasValue) {
@@ -87,7 +87,7 @@ namespace VelorenPort.CoreEngine {
             return false;
         }
 
-        public void Delete(LinkHandle<TetherError, CreateData, PersistData, DeleteData> handle, ref DeleteData data) {
+        public void Delete(LinkHandle<Tethered, TetherError, CreateData, PersistData, DeleteData> handle, ref DeleteData data) {
             var leaderEntity = data.IdMaps.GetEntity(Leader);
             var followerEntity = data.IdMaps.GetEntity(Follower);
             if (leaderEntity.HasValue) data.Leaders.Remove(leaderEntity.Value);


### PR DESCRIPTION
## Summary
- fix generic type parameter mismatch between `ILink` and `LinkHandle`
- update `Tethered` implementation to use the new interface
- adjust constraints for `Is`, `LinkHandle`, `WeakLinkHandle`, and `DynWeakLinkHandle`

## Testing
- `dotnet test VelorenPort/CoreEngine.Tests/CoreEngine.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685f318544148328bcc702fa388a08b8