### PR TITLE
Implement socket-based networking

### DIFF
--- a/VelorenPort/Network/Src/Network.cs
+++ b/VelorenPort/Network/Src/Network.cs
@@ -1,6 +1,11 @@
 using System;
 using System.Collections.Concurrent;
+using System.Net;
 using System.Net.Sockets;
+using System.Net.Quic;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace VelorenPort.Network {
@@ -12,23 +17,73 @@ namespace VelorenPort.Network {
         public Pid LocalPid { get; }
         private readonly ConcurrentQueue<Participant> _pending = new();
         private readonly ConcurrentDictionary<Pid, Participant> _participants = new();
+        private TcpListener? _tcpListener;
+        private QuicListener? _quicListener;
+        private CancellationTokenSource? _listenCts;
 
         public Network(Pid pid) {
             LocalPid = pid;
         }
 
         public Task ListenAsync(ListenAddr addr) {
-            // Actual socket handling will be plugged in here.
+            _listenCts?.Cancel();
+            _listenCts = new CancellationTokenSource();
+
+            switch (addr) {
+                case ListenAddr.Tcp tcp:
+                    _tcpListener = new TcpListener(tcp.EndPoint);
+                    _tcpListener.Start();
+                    _ = AcceptTcpAsync(_listenCts.Token);
+                    break;
+                case ListenAddr.Quic quic:
+                    var options = new QuicListenerOptions {
+                        ListenEndPoint = quic.EndPoint,
+                        ApplicationProtocols = new[] { new SslApplicationProtocol("veloren") },
+                        ConnectionOptionsCallback = (_, _) => new ValueTask<QuicServerConnectionOptions>(
+                            new QuicServerConnectionOptions {
+                                DefaultStreamErrorCode = 0,
+                                ServerAuthenticationOptions = new SslServerAuthenticationOptions {
+                                    ServerCertificate = new X509Certificate2(quic.Config.CertificatePath, quic.Config.PrivateKeyPath)
+                                }
+                            })
+                    };
+                    _quicListener = new QuicListener(options);
+                    _quicListener.Start();
+                    _ = AcceptQuicAsync(_listenCts.Token);
+                    break;
+                default:
+                    throw new NotSupportedException("Unsupported listen address");
+            }
+
             return Task.CompletedTask;
         }
 
-        public Task<Participant> ConnectAsync(ConnectAddr addr) {
-            // Crea la conexion y devuelve un participante asociado. En futuras
-            // revisiones se integrará el uso de sockets reales.
-            var remote = new Participant(Pid.NewPid(), addr);
-            _participants[remote.Id] = remote;
-            _pending.Enqueue(remote);
-            return Task.FromResult(remote);
+        public async Task<Participant> ConnectAsync(ConnectAddr addr) {
+            switch (addr) {
+                case ConnectAddr.Tcp tcp:
+                    var client = new TcpClient();
+                    await client.ConnectAsync(tcp.EndPoint.Address, tcp.EndPoint.Port);
+                    var p = new Participant(Pid.NewPid(), addr, client);
+                    _participants[p.Id] = p;
+                    _pending.Enqueue(p);
+                    return p;
+                case ConnectAddr.Quic quic:
+                    var options = new QuicClientConnectionOptions {
+                        RemoteEndPoint = quic.EndPoint,
+                        ClientAuthenticationOptions = new SslClientAuthenticationOptions {
+                            RemoteCertificateValidationCallback = (s, c, ch, e) => quic.Config.InsecureSkipVerify || e == SslPolicyErrors.None,
+                            ApplicationProtocols = new[] { new SslApplicationProtocol(quic.Name) }
+                        }
+                    };
+                    var conn = new QuicConnection(options);
+                    await conn.ConnectAsync();
+                    var qp = new Participant(Pid.NewPid(), addr, null, conn);
+                    _participants[qp.Id] = qp;
+                    _pending.Enqueue(qp);
+                    return qp;
+                default:
+                    throw new NotSupportedException("Unsupported connect address");
+            }
         }
 
         public Task<Participant?> ConnectedAsync() {
@@ -38,5 +93,27 @@ namespace VelorenPort.Network {
 
         public bool TryGetParticipant(Pid id, out Participant participant)
             => _participants.TryGetValue(id, out participant);
+
+        private async Task AcceptTcpAsync(CancellationToken token) {
+            if (_tcpListener == null) return;
+            while (!token.IsCancellationRequested) {
+                var client = await _tcpListener.AcceptTcpClientAsync(token);
+                var ep = (IPEndPoint)client.Client.RemoteEndPoint!;
+                var participant = new Participant(Pid.NewPid(), new ConnectAddr.Tcp(ep), client);
+                _participants[participant.Id] = participant;
+                _pending.Enqueue(participant);
+            }
+        }
+
+        private async Task AcceptQuicAsync(CancellationToken token) {
+            if (_quicListener == null) return;
+            while (!token.IsCancellationRequested) {
+                var connection = await _quicListener.AcceptConnectionAsync(token);
+                var ep = connection.RemoteEndPoint as IPEndPoint ?? new IPEndPoint(IPAddress.Any, 0);
+                var participant = new Participant(Pid.NewPid(), new ConnectAddr.Quic(ep, new QuicClientConfig(), "quic"), null, connection);
+                _participants[participant.Id] = participant;
+                _pending.Enqueue(participant);
+            }
+        }
     }
 }

--- a/VelorenPort/Network/Src/Stream.cs
+++ b/VelorenPort/Network/Src/Stream.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Concurrent;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace VelorenPort.Network {
@@ -10,20 +12,48 @@ namespace VelorenPort.Network {
         public Promises Promises { get; }
         private readonly ConcurrentQueue<Message> _rx = new();
         private readonly ConcurrentQueue<Message> _tx = new();
+        private readonly System.IO.Stream? _transport;
 
-        internal Stream(Sid id, Promises promises) {
+        internal Stream(Sid id, Promises promises, System.IO.Stream? transport = null) {
             Id = id;
             Promises = promises;
+            _transport = transport;
         }
 
-        public Task SendAsync(Message msg) {
-            _tx.Enqueue(msg);
-            return Task.CompletedTask;
+        public async Task SendAsync(Message msg) {
+            if (_transport != null) {
+                var length = BitConverter.GetBytes(msg.Data.Length);
+                await _transport.WriteAsync(length, 0, length.Length);
+                await _transport.WriteAsync(msg.Data, 0, msg.Data.Length);
+                await _transport.FlushAsync();
+            } else {
+                _tx.Enqueue(msg);
+            }
         }
 
-        public Task<Message?> RecvAsync() {
+        public async Task<Message?> RecvAsync() {
+            if (_transport != null) {
+                var lenBuf = new byte[4];
+                if (await ReadExactAsync(_transport, lenBuf, 4) == 0)
+                    return null;
+                int len = BitConverter.ToInt32(lenBuf, 0);
+                var buf = new byte[len];
+                if (await ReadExactAsync(_transport, buf, len) == 0)
+                    return null;
+                return new Message(buf, false);
+            }
             _rx.TryDequeue(out var msg);
-            return Task.FromResult(msg);
+            return msg;
+        }
+
+        private static async Task<int> ReadExactAsync(System.IO.Stream stream, byte[] buffer, int len) {
+            int read = 0;
+            while (read < len) {
+                int r = await stream.ReadAsync(buffer, read, len - read);
+                if (r == 0) return read;
+                read += r;
+            }
+            return read;
         }
 
         internal void PushIncoming(Message msg) => _rx.Enqueue(msg);


### PR DESCRIPTION
## Summary
- add TCP and QUIC listeners in the Network layer
- create `Participant` objects backed by real `TcpClient` or `QuicConnection`
- allow streams to transmit bytes over network streams

## Testing
- `dotnet test VelorenPort/VelorenPort.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685feaf1a43c83289ce367399ffba2c4