### PR TITLE
Expand canvas spawn logic

### DIFF
--- a/VelorenPort/World.Tests/CanvasTests.cs
+++ b/VelorenPort/World.Tests/CanvasTests.cs
@@ -1,0 +1,35 @@
+using VelorenPort.World;
+using Unity.Mathematics;
+
+namespace World.Tests;
+
+public class CanvasTests
+{
+    [Fact]
+    public void FindSpawnPos_ReturnsValidPosition()
+    {
+        var chunk = new Chunk(int2.zero, Block.Air);
+        for (int x = 0; x < Chunk.Size.x; x++)
+        for (int y = 0; y < Chunk.Size.y; y++)
+            chunk[x, y, 0] = Block.Filled(BlockKind.Rock, 1, 1, 1);
+
+        var sim = new WorldSim(0, new int2(1,1));
+        var cinfo = new CanvasInfo(int2.zero, sim, new SimChunk());
+        var canvas = new Canvas(cinfo, chunk);
+
+        var spawn = canvas.FindSpawnPos(new int3(cinfo.Wpos, 8));
+        Assert.NotNull(spawn);
+        Assert.Equal(1, spawn!.Value.z);
+    }
+
+    [Fact]
+    public void Spawn_AddsEntryToList()
+    {
+        var chunk = new Chunk(int2.zero, Block.Air);
+        var canvas = new Canvas(new CanvasInfo(int2.zero, new WorldSim(0, new int2(1,1)), new SimChunk()), chunk);
+        canvas.Spawn(new int3(1,2,3));
+        Assert.Single(canvas.Spawns);
+        Assert.Equal(new int3(1,2,3), canvas.Spawns[0]);
+    }
+}
+

--- a/VelorenPort/World.Tests/PathfindingTests.cs
+++ b/VelorenPort/World.Tests/PathfindingTests.cs
@@ -1,0 +1,17 @@
+using VelorenPort.World;
+using Unity.Mathematics;
+
+namespace World.Tests;
+
+public class PathfindingTests
+{
+    [Fact]
+    public void Searcher_FindsStraightPath()
+    {
+        var searcher = new Searcher(Land.Empty(), new SearchCfg(0f, 0f));
+        var path = searcher.Search(new int2(0,0), new int2(3,0));
+        Assert.NotNull(path);
+        Assert.Equal(new int2(0,0), path!.Start);
+        Assert.Equal(new int2(3,0), path.End);
+    }
+}

--- a/VelorenPort/World.Tests/WorldSimTests.cs
+++ b/VelorenPort/World.Tests/WorldSimTests.cs
@@ -1,0 +1,30 @@
+using VelorenPort.World;
+using Unity.Mathematics;
+
+namespace World.Tests;
+
+public class WorldSimTests
+{
+    [Fact]
+    public void ApproxChunkTerrainNormal_ReturnsNormalizedVector()
+    {
+        var sim = new WorldSim(123, new int2(8, 8));
+        var normal = sim.ApproxChunkTerrainNormal(int2.zero);
+        Assert.NotNull(normal);
+        Assert.True(math.abs(math.length(normal!.Value) - 1f) < 1e-5f);
+    }
+
+    [Fact]
+    public void GetSurfaceAltApprox_ConsidersWaterLevel()
+    {
+        var sim = new WorldSim(0, new int2(1, 1));
+        var chunk = sim.Get(int2.zero)!;
+        chunk.Alt = 5f;
+        chunk.WaterAlt = 10f;
+        sim.Set(int2.zero, chunk);
+
+        float alt = sim.GetSurfaceAltApprox(int2.zero);
+        Assert.Equal(10f, alt);
+    }
+}
+

--- a/VelorenPort/World/MissingFeatures.md
+++ b/VelorenPort/World/MissingFeatures.md
@@ -1,0 +1,20 @@
+# World Port Missing Features
+
+This document tracks notable subsystems from the original Rust `world` crate
+that are not yet implemented in the C# port. The list is not exhaustive
+but highlights major areas that still require work.
+
+- **Civilization generation**: modules under `civ` that create towns,
+  points of interest and NPC placement are only stubbed.
+- **Erosion and diffusion simulation**: advanced terrain shaping from
+  `sim` is largely unported.
+- **Layer and structure systems**: dynamic layers and structures used
+  when generating chunks are simplified.
+- **Site economy**: full trading and economic simulation has not been
+  migrated.
+- **Pathfinding**: the A*-based search is present but lacks optimisations
+  and integration with dynamic world data.
+- **Testing**: unit tests cover only a fraction of the world pipeline.
+
+The migration will continue incrementally, porting features as they
+become necessary for gameplay.

--- a/VelorenPort/World/Src/Land.cs
+++ b/VelorenPort/World/Src/Land.cs
@@ -53,6 +53,12 @@ namespace VelorenPort.World {
             return _sim.GetGradientApprox(WposChunkPos(wpos)) ?? 0f;
         }
 
+        public float3 GetChunkTerrainNormal(int2 chunkPos)
+        {
+            if (_sim == null) return new float3(0f, 0f, 1f);
+            return _sim.ApproxChunkTerrainNormal(chunkPos) ?? new float3(0f, 0f, 1f);
+        }
+
         public static int2 WposChunkPos(int2 wpos) {
             int2 sz = TerrainChunkSize.RectSize;
             return new int2(DivEuclid(wpos.x, sz.x), DivEuclid(wpos.y, sz.y));


### PR DESCRIPTION
## Summary
- add spawn and spawn search functionality to `Canvas`
- test new spawn utilities in `CanvasTests`
- calculate chunk terrain normals in `WorldSim`
- implement simple A* pathfinding
- add accessible position search to `World`
- add doc listing missing World features
- compute surface altitude using water level

## Testing
- `dotnet test VelorenPort/VelorenPort.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff69d8ab88328bac7d5b5a94d1292