### PR TITLE
Add site name generator

### DIFF
--- a/VelorenPort/World.Tests/NameGenTests.cs
+++ b/VelorenPort/World.Tests/NameGenTests.cs
@@ -1,0 +1,23 @@
+using VelorenPort.World.Site;
+
+namespace World.Tests;
+
+public class NameGenTests
+{
+    [Fact]
+    public void Generate_ProducesNonEmptyCapitalizedName()
+    {
+        var rng = new System.Random(42);
+        string name = NameGen.Generate(rng);
+        Assert.False(string.IsNullOrWhiteSpace(name));
+        Assert.True(char.IsUpper(name[0]));
+    }
+
+    [Fact]
+    public void Generate_DifferentSeedsGiveDifferentNames()
+    {
+        var a = NameGen.Generate(new System.Random(1));
+        var b = NameGen.Generate(new System.Random(2));
+        Assert.NotEqual(a, b);
+    }
+}

--- a/VelorenPort/World/Src/Site/NameGen.cs
+++ b/VelorenPort/World/Src/Site/NameGen.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+
+namespace VelorenPort.World.Site {
+    /// <summary>
+    /// Procedural name generator roughly based on the Rust implementation.
+    /// Produces simple pseudo-English location names.
+    /// </summary>
+    public static class NameGen {
+        private static readonly string[] Cons = new[] {
+            "d","f","ph","r","st","t","s","p","sh","th","br","tr","m","k","w","y","cr","fr","dr","pl","wr","sn","g","qu","l"
+        };
+
+        private static readonly string[] Start = Cons.Concat(new[] {
+            "cr","thr","str","br","iv","est","ost","ing","kr","in","on","tr","tw","wh","eld","ar","or","ear","irr","mi","en","ed","et","ow","fr","shr","wr","gr","pr"
+        }).ToArray();
+
+        private static readonly string[] Middle = Cons.Concat(new[]{"tt"}).ToArray();
+        private static readonly string[] Vowel = new[]{"o","e","a","i","u","au","ee","ow","ay","ey","oe"};
+        private static readonly string[] End = new[] {
+            "et","ige","age","ist","en","on","og","end","ind","ock","een","edge","ist","ed","est","eed","ast","olt","ey","ean","ead","onk","ink","eon","er","ow","ot","in","on","id","ir","or","ig","en"
+        };
+
+        /// <summary>
+        /// Generate a new random location name.
+        /// </summary>
+        public static string Generate(Random rng) {
+            int syllables = rng.Next(1,4);
+            string name = Start[rng.Next(Start.Length)];
+            for (int i = 0; i < Math.Max(0, syllables - 2); i++) {
+                name += Vowel[rng.Next(Vowel.Length)];
+                name += Middle[rng.Next(Middle.Length)];
+            }
+            name += End[rng.Next(End.Length)];
+            return char.ToUpperInvariant(name[0]) + name.Substring(1);
+        }
+    }
+}

--- a/VelorenPort/World/Src/World.cs
+++ b/VelorenPort/World/Src/World.cs
@@ -55,7 +55,9 @@ namespace VelorenPort.World {
         public float[,] GetAltitudeMap(int2 cpos, int radius) => Sim.GetAltitudeMap(cpos, radius);
 
         public Site.Site CreateSite(int2 position) {
-            var site = new Site.Site { Position = position };
+            var rng = new Random((int)math.hash(position));
+            string name = Site.NameGen.Generate(rng);
+            var site = new Site.Site { Position = position, Name = name };
             Index.Sites.Insert(site);
             return site;
         }


### PR DESCRIPTION
## Summary
- implement `Site.NameGen` for procedural names
- create site names automatically when building new sites
- add tests for name generation

## Testing
- `dotnet test VelorenPort/VelorenPort.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860014248048328b576ddfae915c1a3