### PR TITLE
Add basic server info broadcasting

### DIFF
--- a/VelorenPort/Server.Tests/ServerInfoTests.cs
+++ b/VelorenPort/Server.Tests/ServerInfoTests.cs
@@ -1,0 +1,17 @@
+using System;
+using VelorenPort.Server.Sys;
+using VelorenPort.Server.Settings;
+
+namespace Server.Tests;
+
+public class ServerInfoTests {
+    [Fact]
+    public void Broadcaster_Sends_Every_Sixty_Ticks() {
+        int calls = 0;
+        var broadcaster = new ServerInfoBroadcaster(_ => calls++);
+        var settings = new Settings();
+        for (ulong tick = 0; tick < 120; tick++)
+            broadcaster.Update(tick, settings, 0);
+        Assert.Equal(2, calls);
+    }
+}

--- a/VelorenPort/Server/Src/Sys/ServerInfo.cs
+++ b/VelorenPort/Server/Src/Sys/ServerInfo.cs
@@ -1,0 +1,45 @@
+using System;
+using VelorenPort.CoreEngine;
+using VelorenPort.Server.Settings;
+
+namespace VelorenPort.Server.Sys {
+    /// <summary>
+    /// Broadcasts basic server information to interested consumers every
+    /// 60 ticks. This mirrors <c>server_info.rs</c> from the Rust project in a
+    /// greatly simplified form.
+    /// </summary>
+    public record ServerInfo(uint GitHash, long GitTimestamp, ushort PlayersCount,
+        ushort PlayerCap, BattleMode BattleMode);
+
+    public static class GitInfo {
+        // TODO: Populate these from build metadata
+        public const uint Hash = 0;
+        public const long Timestamp = 0;
+    }
+
+    public class ServerInfoBroadcaster {
+        private readonly Action<ServerInfo> _send;
+        private ulong _lastTick;
+
+        public ServerInfoBroadcaster(Action<ServerInfo> send) {
+            _send = send;
+        }
+
+        /// <summary>
+        /// Call once per server tick with the current tick counter and
+        /// player count. A message will be sent every 60 ticks.
+        /// </summary>
+        public void Update(ulong tick, Settings.Settings settings, int playersCount) {
+            if (tick - _lastTick >= 60) {
+                _lastTick = tick;
+                var info = new ServerInfo(
+                    GitInfo.Hash,
+                    GitInfo.Timestamp,
+                    (ushort)Math.Clamp(playersCount, 0, ushort.MaxValue),
+                    (ushort)settings.MaxPlayers,
+                    BattleMode.PvE);
+                _send(info);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ServerInfoBroadcaster` for periodically sending server stats
- expose broadcaster inside `GameServer`
- test broadcaster behaviour

## Testing
- `dotnet test VelorenPort/Server.Tests/Server.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860033a081c8328945a2c5be6d8da32