### PR TITLE
Implement basic figure module

### DIFF
--- a/VelorenPort/CoreEngine/Src/ChunkResource.cs
+++ b/VelorenPort/CoreEngine/Src/ChunkResource.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace VelorenPort.CoreEngine {
+    /// <summary>
+    /// Resources that can spawn within a chunk. Mirrors <c>ChunkResource</c>
+    /// from <c>rtsim.rs</c>.
+    /// </summary>
+    [Serializable]
+    public enum ChunkResource {
+        Grass,
+        Flower,
+        Fruit,
+        Vegetable,
+        Mushroom,
+        Loot,
+        Plant,
+        Stone,
+        Wood,
+        Gem,
+        Ore
+    }
+}

--- a/VelorenPort/CoreEngine/Src/RtSim.cs
+++ b/VelorenPort/CoreEngine/Src/RtSim.cs
@@ -79,7 +79,7 @@ namespace VelorenPort.CoreEngine {
             Dictionary<ushort, Response> Responses) : DialogueKind;
 
         [Serializable]
-        public sealed record Response(uint Tag, Response Response, ushort ResponseId) : DialogueKind;
+        public sealed record ResponseOption(uint Tag, Response Response, ushort ResponseId) : DialogueKind;
 
         [Serializable]
         public sealed record Marker(int2 Wpos, Content Name) : DialogueKind;

--- a/VelorenPort/CoreEngine/Src/figure/Cell.cs
+++ b/VelorenPort/CoreEngine/Src/figure/Cell.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace VelorenPort.CoreEngine.figure
+{
+    /// <summary>
+    /// Metadata for a single voxel. Only stores colour and simple flags.
+    /// </summary>
+    [Serializable]
+    public struct CellData
+    {
+        public Rgb8 Color;
+        public bool Glowy;
+        public bool Shiny;
+        public bool Hollow;
+
+        public CellData(Rgb8 color, bool glowy, bool shiny, bool hollow)
+        {
+            Color = color;
+            Glowy = glowy;
+            Shiny = shiny;
+            Hollow = hollow;
+        }
+    }
+
+    /// <summary>
+    /// Represents a voxel in a figure. When <see cref="Data"/> is null the cell
+    /// is considered empty.
+    /// </summary>
+    [Serializable]
+    public struct Cell
+    {
+        public CellData? Data;
+
+        public bool IsEmpty => Data == null;
+        public bool IsGlowy => Data?.Glowy == true;
+        public bool IsShiny => Data?.Shiny == true;
+        public bool IsHollow => Data?.Hollow == true;
+
+        public Cell(Rgb8 color, bool glowy = false, bool shiny = false, bool hollow = false)
+        {
+            Data = new CellData(color, glowy, shiny, hollow);
+        }
+
+        public static Cell Empty => new Cell { Data = null };
+    }
+}

--- a/VelorenPort/CoreEngine/Src/figure/MatCell.cs
+++ b/VelorenPort/CoreEngine/Src/figure/MatCell.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace VelorenPort.CoreEngine.figure
+{
+    /// <summary>
+    /// Cell that stores either a reference to a material or explicit voxel data.
+    /// </summary>
+    [Serializable]
+    public struct MatCell
+    {
+        public enum Kind { None, Mat, Normal }
+        public Kind CellKind;
+        public Material Material;
+        public CellData Data;
+
+        public static MatCell None => new MatCell { CellKind = Kind.None };
+        public static MatCell FromMaterial(Material mat) => new MatCell { CellKind = Kind.Mat, Material = mat };
+        public static MatCell FromData(CellData data) => new MatCell { CellKind = Kind.Normal, Data = data };
+
+        public bool IsFilled => CellKind != Kind.None;
+    }
+}

--- a/VelorenPort/CoreEngine/Src/figure/Material.cs
+++ b/VelorenPort/CoreEngine/Src/figure/Material.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace VelorenPort.CoreEngine.figure
+{
+    /// <summary>
+    /// Basic material types used by figure voxels.
+    /// This mirrors the Material enum in the original Rust project but
+    /// only includes a minimal subset required by other modules.
+    /// </summary>
+    [Serializable]
+    public enum Material
+    {
+        Skin,
+        SkinDark,
+        SkinLight,
+        Hair,
+        EyeDark,
+        EyeLight,
+        EyeWhite,
+    }
+}

--- a/VelorenPort/CoreEngine/Src/figure/Segment.cs
+++ b/VelorenPort/CoreEngine/Src/figure/Segment.cs
@@ -1,0 +1,23 @@
+using System;
+using Unity.Mathematics;
+
+namespace VelorenPort.CoreEngine.figure
+{
+    /// <summary>
+    /// A volume of <see cref="MatCell"/> used to represent characters or other
+    /// figures. This is a simplified version of the Rust implementation and
+    /// merely wraps <see cref="Vol{T}"/> with a few helpers.
+    /// </summary>
+    [Serializable]
+    public class Segment : Vol<MatCell>
+    {
+        public Segment(int3 size) : base(size) { }
+
+        public static Segment Filled(int3 size, MatCell value)
+        {
+            var seg = new Segment(size);
+            seg.Fill(value);
+            return seg;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add minimal `figure` module with Cell, Material, MatCell, and Segment
- copy `ChunkResource` into CoreEngine for rtsim use
- fix naming for dialogue response variant

## Testing
- `dotnet test --verbosity minimal` *(fails: CS1612 and other compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_6860030c91c8832880319e8015c1efbf