### PR TITLE
Add metrics instrumentation to network port

### DIFF
--- a/VelorenPort/Network/README.md
+++ b/VelorenPort/Network/README.md
@@ -40,7 +40,10 @@ control.
 
 Ahora se exponen contadores Prometheus usando la librería `prometheus-net`, de
 modo que pueden consultarse desde herramientas externas. La cobertura de eventos
-es todavía limitada respecto al crate original.
+es todavía limitada respecto al crate original. Desde esta versión el envío y
+recepción de mensajes, así como la apertura y cierre de `Streams` y
+`Participants`, incrementan contadores automáticamente para facilitar la
+observación durante las pruebas.
 
 ### Scheduler and Concurrency
 

--- a/VelorenPort/Network/Src/Metrics.cs
+++ b/VelorenPort/Network/Src/Metrics.cs
@@ -12,11 +12,35 @@ namespace VelorenPort.Network {
         private readonly Counter _recvBytesCounter = MetricsCreator.CreateCounter("network_recv_bytes", "Total bytes received");
         private readonly Counter _sentMessagesCounter = MetricsCreator.CreateCounter("network_sent_messages", "Total messages sent");
         private readonly Counter _recvMessagesCounter = MetricsCreator.CreateCounter("network_recv_messages", "Total messages received");
+        private readonly Counter _participantsConnectedCounter = MetricsCreator.CreateCounter("network_participants_connected", "Participants connected");
+        private readonly Counter _participantsDisconnectedCounter = MetricsCreator.CreateCounter("network_participants_disconnected", "Participants disconnected");
+        private readonly Counter _streamsOpenedCounter = MetricsCreator.CreateCounter("network_streams_opened", "Streams opened");
+        private readonly Counter _streamsClosedCounter = MetricsCreator.CreateCounter("network_streams_closed", "Streams closed");
 
         private long _sentBytes;
         private long _recvBytes;
         private long _sentMessages;
         private long _recvMessages;
+
+        public void ParticipantConnected()
+        {
+            _participantsConnectedCounter.Inc();
+        }
+
+        public void ParticipantDisconnected()
+        {
+            _participantsDisconnectedCounter.Inc();
+        }
+
+        public void StreamOpened()
+        {
+            _streamsOpenedCounter.Inc();
+        }
+
+        public void StreamClosed()
+        {
+            _streamsClosedCounter.Inc();
+        }
 
         public void CountSent(int bytes) {
             Interlocked.Add(ref _sentBytes, bytes);


### PR DESCRIPTION
## Summary
- augment metrics collector with participant and stream counters
- expose metrics control on `Network`
- track metrics in `Participant` and `Stream`
- document metrics instrumentation in README

## Testing
- `dotnet build VelorenPort/Network/Network.csproj -v q` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860037c30388328a22b932ee15034ca