### PR TITLE
Fix compile errors in CoreEngine

### DIFF
--- a/VelorenPort/CoreEngine/Src/Effect.cs
+++ b/VelorenPort/CoreEngine/Src/Effect.cs
@@ -81,7 +81,9 @@ namespace VelorenPort.CoreEngine {
                     d.Damage.InterpolateDamage(modifier, 0f);
                     break;
                 case Buff b:
-                    b.Effect.Data.Strength *= modifier;
+                    var data = b.Effect.Data;
+                    data.Strength *= modifier;
+                    b.Effect.Data = data;
                     break;
                 case Permanent:
                     break;

--- a/VelorenPort/CoreEngine/Src/RtSim.cs
+++ b/VelorenPort/CoreEngine/Src/RtSim.cs
@@ -111,7 +111,7 @@ namespace VelorenPort.CoreEngine {
         public sealed record Attack(Actor Target) : NpcAction;
 
         [Serializable]
-        public sealed record Dialogue(Actor Target, Dialogue Message) : NpcAction;
+        public sealed record Dialogue(Actor Target, global::VelorenPort.CoreEngine.Dialogue Message) : NpcAction;
     }
 
     [Serializable]
@@ -121,7 +121,7 @@ namespace VelorenPort.CoreEngine {
         [Serializable]
         public sealed record Interaction(Actor Target) : NpcInput;
         [Serializable]
-        public sealed record Dialogue(Actor Target, Dialogue Message) : NpcInput;
+        public sealed record Dialogue(Actor Target, global::VelorenPort.CoreEngine.Dialogue Message) : NpcInput;
     }
 
     /// <summary>Traits describing an NPC's personality.</summary>


### PR DESCRIPTION
## Summary
- fix struct property mutation in `Effect.ModifyStrength`
- disambiguate `Dialogue` parameter in `RtSim`

## Testing
- `dotnet build VelorenPort/CoreEngine/CoreEngine.csproj`
- `dotnet test VelorenPort/CoreEngine.Tests/CoreEngine.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_686005f461e083288cea73cd0606fb8c