### PR TITLE
Expand world simulation features

### DIFF
--- a/VelorenPort/Server/Src/Lod.cs
+++ b/VelorenPort/Server/Src/Lod.cs
@@ -20,7 +20,7 @@ namespace VelorenPort.Server {
             for (int i = 0; i < zoneSz.x; i++)
             for (int j = 0; j < zoneSz.y; j++) {
                 var zonePos = new int2(i, j);
-                zones[zonePos] = world.GetLodZone(zonePos, index.AsIndexRef());
+                zones[zonePos] = world.GetLodZone(zonePos);
             }
             var lod = new Lod();
             foreach (var kv in zones) lod.Zones[kv.Key] = kv.Value;

--- a/VelorenPort/World/MissingFeatures.md
+++ b/VelorenPort/World/MissingFeatures.md
@@ -10,6 +10,10 @@ but highlights major areas that still require work.
   `sim` is largely unported.
 - **Layer and structure systems**: dynamic layers and structures used
   when generating chunks are simplified.
+- **Region events**: entity tracking across regions lacks persistence
+  and removal logic for inactive areas.
+- **Chunk resources**: the rich resource system of the original world
+  is represented by placeholders only.
 - **Site economy**: full trading and economic simulation has not been
   migrated.
 - **Pathfinding**: the A*-based search is present but lacks optimisations

--- a/VelorenPort/World/Src/BlockGen.cs
+++ b/VelorenPort/World/Src/BlockGen.cs
@@ -1,0 +1,36 @@
+using System;
+using Unity.Mathematics;
+
+namespace VelorenPort.World {
+    /// <summary>
+    /// Simplified block generator that derives basic terrain blocks from
+    /// <see cref="ColumnGen"/> samples. This only approximates the complex logic
+    /// of the original Rust <c>BlockGen</c> implementation.
+    /// </summary>
+    [Serializable]
+    public class BlockGen {
+        private readonly ColumnGen _columnGen;
+
+        public BlockGen(ColumnGen columnGen) {
+            _columnGen = columnGen;
+        }
+
+        public ZCache? GetZCache(int2 wpos, WorldIndex index) {
+            var sample = _columnGen.Get((wpos, (object)index, (object?)null));
+            return sample == null ? null : new ZCache(sample);
+        }
+
+        public Block? GetWithZCache(int3 wpos, ZCache? cache) {
+            if (cache == null) return null;
+            var sample = cache.Sample;
+            return wpos.z <= sample.Alt ? new Block(BlockKind.Earth) : (Block?)null;
+        }
+
+        public readonly struct ZCache {
+            public readonly ColumnSample Sample;
+            public ZCache(ColumnSample sample) {
+                Sample = sample;
+            }
+        }
+    }
+}

--- a/VelorenPort/World/Src/Lib.cs
+++ b/VelorenPort/World/Src/Lib.cs
@@ -9,6 +9,7 @@ namespace VelorenPort.World {
         public enum WorldGenerateStage {
             WorldSimGenerate,
             EconomySimulation,
+            ErosionSimulation,
             TerrainGeneration,
             SpotGeneration,
             RegionGeneration,
@@ -31,6 +32,9 @@ namespace VelorenPort.World {
                     break;
                 case WorldGenerateStage.EconomySimulation:
                     EconomySim.SimulateEconomy(index, 1f);
+                    break;
+                case WorldGenerateStage.ErosionSimulation:
+                    Sim.Erosion.Apply(world.Sim);
                     break;
                 case WorldGenerateStage.TerrainGeneration:
                     foreach (var cpos in world.Sim.LoadedChunks)
@@ -60,6 +64,7 @@ namespace VelorenPort.World {
                 case WorldGenerateStage.All:
                     RunStage(world, index, WorldGenerateStage.WorldSimGenerate);
                     RunStage(world, index, WorldGenerateStage.EconomySimulation);
+                    RunStage(world, index, WorldGenerateStage.ErosionSimulation);
                     RunStage(world, index, WorldGenerateStage.TerrainGeneration);
                     RunStage(world, index, WorldGenerateStage.SpotGeneration);
                     RunStage(world, index, WorldGenerateStage.RegionGeneration);

--- a/VelorenPort/World/Src/Sim/Erosion.cs
+++ b/VelorenPort/World/Src/Sim/Erosion.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using Unity.Mathematics;
+
+namespace VelorenPort.World.Sim {
+    /// <summary>
+    /// Extremely simplified erosion routine. It computes a downhill
+    /// vector for every loaded chunk and slightly lowers the altitude
+    /// towards that neighbour. This is only a placeholder until the
+    /// full erosion model is ported from Rust.
+    /// </summary>
+    public static class Erosion {
+        public static void Apply(WorldSim sim) {
+            var edits = new List<(int2 pos, float alt, int2? downhill)>();
+            foreach (var (pos, chunk) in sim.Chunks) {
+                float bestAlt = chunk.Alt;
+                int2? downhill = null;
+                foreach (var off in WorldUtil.NEIGHBORS) {
+                    var n = sim.Get(pos + off);
+                    if (n == null) continue;
+                    if (n.Alt < bestAlt) {
+                        bestAlt = n.Alt;
+                        downhill = TerrainChunkSize.CposToWpos(pos + off);
+                    }
+                }
+                edits.Add((pos, math.lerp(chunk.Alt, bestAlt, 0.05f), downhill));
+            }
+            foreach (var (pos, alt, downhill) in edits) {
+                var chunk = sim.Get(pos);
+                if (chunk == null) continue;
+                chunk.Alt = alt;
+                chunk.Downhill = downhill;
+            }
+        }
+    }
+}

--- a/VelorenPort/World/Src/WorldMapMsg.cs
+++ b/VelorenPort/World/Src/WorldMapMsg.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using Unity.Mathematics;
+
+namespace VelorenPort.World {
+    /// <summary>
+    /// Light-weight representation of world map information.
+    /// This is far less detailed than the Rust version but provides
+    /// enough data for debugging and basic clients.
+    /// </summary>
+    [Serializable]
+    public class WorldMapMsg {
+        public int2 Dimensions { get; set; }
+        public float MaxHeight { get; set; }
+        public List<Marker> Sites { get; } = new();
+        public List<PoiInfo> Pois { get; } = new();
+    }
+
+    [Serializable]
+    public struct Marker {
+        public string Name;
+        public int2 Position;
+    }
+
+    [Serializable]
+    public struct PoiInfo {
+        public string Name;
+        public int2 Position;
+    }
+}

--- a/VelorenPort/World/Src/WorldSim.cs
+++ b/VelorenPort/World/Src/WorldSim.cs
@@ -22,6 +22,8 @@ namespace VelorenPort.World {
             _structureGen = new StructureGen2d(seed, 24, 10);
         }
 
+        public static WorldSim Empty() => new WorldSim(0, int2.zero);
+
         public int2 GetSize() => _size;
 
         public T GetInterpolated<T>(int2 wpos, Func<SimChunk, T> f) where T : struct {
@@ -130,6 +132,18 @@ namespace VelorenPort.World {
                 map[dx + radius, dy + radius] = Get(pos)?.Alt ?? 0f;
             }
             return map;
+        }
+
+        /// <summary>
+        /// Enumerate all loaded chunks with their coordinates.
+        /// </summary>
+        public IEnumerable<(int2 pos, SimChunk chunk)> Chunks
+        {
+            get
+            {
+                foreach (var kv in _chunks)
+                    yield return (kv.Key, kv.Value);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add `World.Empty` for creating a minimal world instance
- expose loaded chunk enumeration in `WorldSim`
- implement a basic erosion routine and stage
- support erosion stage in world generation flow
- document further missing features in the port

## Testing
- `dotnet test VelorenPort/VelorenPort.sln --no-build` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_686003a275d08328a3e3594221af42cd