### PR TITLE
Add missing identifiers to CoreEngine

### DIFF
--- a/VelorenPort/CoreEngine/Src/FactionId.cs
+++ b/VelorenPort/CoreEngine/Src/FactionId.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace VelorenPort.CoreEngine
+{
+    /// <summary>
+    /// Identifier for factions used by rtsim entities.
+    /// </summary>
+    [Serializable]
+    public readonly record struct FactionId(uint Value);
+}

--- a/VelorenPort/CoreEngine/Src/NpcId.cs
+++ b/VelorenPort/CoreEngine/Src/NpcId.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace VelorenPort.CoreEngine
+{
+    /// <summary>
+    /// Identifier used for NPC entities. Mirrors the NpcId slotmap key in Rust.
+    /// </summary>
+    [Serializable]
+    public readonly record struct NpcId(int Value);
+}

--- a/VelorenPort/CoreEngine/Src/ReportId.cs
+++ b/VelorenPort/CoreEngine/Src/ReportId.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace VelorenPort.CoreEngine
+{
+    /// <summary>
+    /// Identifier for status or behavior reports.
+    /// </summary>
+    [Serializable]
+    public readonly record struct ReportId(uint Value);
+}

--- a/VelorenPort/CoreEngine/Src/RtSimEntity.cs
+++ b/VelorenPort/CoreEngine/Src/RtSimEntity.cs
@@ -4,14 +4,19 @@ namespace VelorenPort.CoreEngine {
     [Serializable]
     public struct RtSimEntity : IEquatable<RtSimEntity>
     {
-        public int Value; // Placeholder for NpcId
-        public RtSimEntity(int value) { Value = value; }
-        public bool Equals(RtSimEntity other) => Value == other.Value;
-        public override bool Equals(object obj) => obj is RtSimEntity other && Equals(other);
+        public NpcId Value;
+
+        public RtSimEntity(NpcId value) { Value = value; }
+
+        public bool Equals(RtSimEntity other) => Value.Equals(other.Value);
+        public override bool Equals(object? obj) => obj is RtSimEntity other && Equals(other);
         public override int GetHashCode() => Value.GetHashCode();
-        public override string ToString() => Value.ToString();
-        public static implicit operator int(RtSimEntity id) => id.Value;
-        public static implicit operator RtSimEntity(int value) => new RtSimEntity(value);
+        public override string ToString() => Value.Value.ToString();
+
+        public static implicit operator NpcId(RtSimEntity id) => id.Value;
+        public static implicit operator RtSimEntity(NpcId value) => new(value);
+        public static explicit operator int(RtSimEntity id) => id.Value.Value;
+        public static explicit operator RtSimEntity(int value) => new(new NpcId(value));
     }
 
 }

--- a/VelorenPort/Simulation/Src/Events.cs
+++ b/VelorenPort/Simulation/Src/Events.cs
@@ -7,8 +7,6 @@ using VelorenPort.CoreEngine.comp.terrain;
 
 namespace VelorenPort.Simulation {
     // Simple numeric identifiers matching the slotmap keys in Rust
-    public readonly record struct NpcId(int Value);
-    public readonly record struct SiteId(uint Value);
 
     public enum VolumeKind { Terrain, Entity }
     public readonly struct VolumePos<T> {

--- a/VelorenPort/Simulation/Src/Sites.cs
+++ b/VelorenPort/Simulation/Src/Sites.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using VelorenPort.CoreEngine;
 
 namespace VelorenPort.Simulation {
     /// <summary>


### PR DESCRIPTION
## Summary
- add `NpcId`, `FactionId`, and `ReportId` structs
- update `RtSimEntity` to wrap new `NpcId`
- remove duplicate identifier types from simulation events
- include CoreEngine namespace in `Sites.cs`

## Testing
- `dotnet test VelorenPort/CoreEngine.Tests/CoreEngine.Tests.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68600cff48388328914f9ff0e0b86456