### PR TITLE
Add Civ generator to world port

### DIFF
--- a/VelorenPort/World.Tests/CivGeneratorTests.cs
+++ b/VelorenPort/World.Tests/CivGeneratorTests.cs
@@ -1,0 +1,19 @@
+using VelorenPort.World;
+using VelorenPort.World.Civ;
+
+namespace World.Tests;
+
+public class CivGeneratorTests
+{
+    [Fact]
+    public void Generate_AddsExpectedNumberOfSites()
+    {
+        var (world, index) = World.Empty();
+        CivGenerator.Generate(world, index, 4);
+        Assert.Equal(4, index.Sites.Items.Count);
+        foreach (var (_, site) in index.Sites.Enumerate())
+        {
+            Assert.False(string.IsNullOrWhiteSpace(site.Name));
+        }
+    }
+}

--- a/VelorenPort/World/MissingFeatures.md
+++ b/VelorenPort/World/MissingFeatures.md
@@ -4,8 +4,8 @@ This document tracks notable subsystems from the original Rust `world` crate
 that are not yet implemented in the C# port. The list is not exhaustive
 but highlights major areas that still require work.
 
-- **Civilization generation**: modules under `civ` that create towns,
-  points of interest and NPC placement are only stubbed.
+- **Civilization generation**: basic site placement exists but advanced
+  town creation and NPC placement from the original `civ` module remain unported.
 - **Erosion and diffusion simulation**: advanced terrain shaping from
   `sim` is largely unported.
 - **Layer and structure systems**: dynamic layers and structures used

--- a/VelorenPort/World/Src/Civ/CivGenerator.cs
+++ b/VelorenPort/World/Src/Civ/CivGenerator.cs
@@ -1,0 +1,28 @@
+using System;
+using Unity.Mathematics;
+
+namespace VelorenPort.World.Civ
+{
+    /// <summary>
+    /// Very small scale civilisation generator. Places a number of
+    /// <see cref="Site.Site"/> objects across the world using a deterministic
+    /// random generator based on the world seed.
+    /// </summary>
+    public static class CivGenerator
+    {
+        /// <summary>Create <paramref name="count"/> sites with random names.</summary>
+        public static void Generate(World world, WorldIndex index, int count)
+        {
+            var rng = new Random((int)index.Seed);
+            int2 mapSize = TerrainChunkSize.Blocks(world.Sim.GetSize());
+
+            for (int i = 0; i < count; i++)
+            {
+                var pos = new int2(rng.Next(0, mapSize.x), rng.Next(0, mapSize.y));
+                string name = Site.NameGen.Generate(rng);
+                var site = new Site.Site { Position = pos, Name = name };
+                index.Sites.Insert(site);
+            }
+        }
+    }
+}

--- a/VelorenPort/World/Src/Lib.cs
+++ b/VelorenPort/World/Src/Lib.cs
@@ -8,6 +8,7 @@ namespace VelorenPort.World {
     public static class Lib {
         public enum WorldGenerateStage {
             WorldSimGenerate,
+            CivilizationGeneration,
             EconomySimulation,
             ErosionSimulation,
             TerrainGeneration,
@@ -29,6 +30,9 @@ namespace VelorenPort.World {
             switch (stage) {
                 case WorldGenerateStage.WorldSimGenerate:
                     // world already initialised
+                    break;
+                case WorldGenerateStage.CivilizationGeneration:
+                    Civ.CivGenerator.Generate(world, index, 3);
                     break;
                 case WorldGenerateStage.EconomySimulation:
                     EconomySim.SimulateEconomy(index, 1f);
@@ -63,6 +67,7 @@ namespace VelorenPort.World {
                     break;
                 case WorldGenerateStage.All:
                     RunStage(world, index, WorldGenerateStage.WorldSimGenerate);
+                    RunStage(world, index, WorldGenerateStage.CivilizationGeneration);
                     RunStage(world, index, WorldGenerateStage.EconomySimulation);
                     RunStage(world, index, WorldGenerateStage.ErosionSimulation);
                     RunStage(world, index, WorldGenerateStage.TerrainGeneration);


### PR DESCRIPTION
## Summary
- create CivGenerator for simple site placement
- add CivilizationGeneration stage to world lib and include it in default pipeline
- update missing features doc
- add unit test for CivGenerator

## Testing
- `dotnet test VelorenPort/VelorenPort.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68600e16f69c8328836e8ee38096c8e1