### PR TITLE
Improve server event infrastructure

### DIFF
--- a/VelorenPort/Server.Tests/EventManagerTests.cs
+++ b/VelorenPort/Server.Tests/EventManagerTests.cs
@@ -1,0 +1,24 @@
+using VelorenPort.Server.Events;
+using VelorenPort.CoreEngine.comp;
+using VelorenPort.Server;
+
+namespace Server.Tests;
+
+public class EventManagerTests
+{
+    [Fact]
+    public void EmitChatEvent_CollectsEvent()
+    {
+        var manager = new EventManager();
+        using (var emitter = manager.GetChatEmitter())
+        {
+            var chatType = new ChatType<Group>.World<Group>(new Uid(1));
+            var msg = new UnresolvedChatMsg(chatType, new Content.Plain("hi"));
+            emitter.Emit(new ChatEvent(msg, true));
+        }
+        var events = manager.DrainChatEvents();
+        Assert.Single(events);
+        Assert.Equal("hi", (events[0].Msg.Content as Content.Plain)!.Text);
+        Assert.True(events[0].FromClient);
+    }
+}

--- a/VelorenPort/Server/Src/Events/ChatEvent.cs
+++ b/VelorenPort/Server/Src/Events/ChatEvent.cs
@@ -1,0 +1,9 @@
+using VelorenPort.CoreEngine.comp;
+
+namespace VelorenPort.Server.Events;
+
+/// <summary>
+/// Event carrying chat message data. Mirrors `ChatEvent` from the
+/// Rust server but in simplified form.
+/// </summary>
+public readonly record struct ChatEvent(UnresolvedChatMsg Msg, bool FromClient);

--- a/VelorenPort/Server/Src/Events/EventManager.cs
+++ b/VelorenPort/Server/Src/Events/EventManager.cs
@@ -8,9 +8,12 @@ namespace VelorenPort.Server.Events {
     /// </summary>
     public class EventManager {
         private readonly EventBus<EventType> _bus = new();
+        private readonly EventBus<ChatEvent> _chatBus = new();
 
         public EventBus<EventType>.Emitter GetEmitter() => _bus.GetEmitter();
+        public EventBus<ChatEvent>.Emitter GetChatEmitter() => _chatBus.GetEmitter();
 
         public EventType[] DrainEvents() => _bus.RecvAll().ToArray();
+        public ChatEvent[] DrainChatEvents() => _chatBus.RecvAll().ToArray();
     }
 }


### PR DESCRIPTION
## Summary
- add `ChatEvent` record to represent chat messages
- extend `EventManager` with a chat event bus
- create `EventManagerTests` to validate new event flow

## Testing
- `dotnet build VelorenPort.sln` *(fails: command not found)*
- `dotnet test VelorenPort.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68600ec8407083289d5c474f6ca91994