### PR TITLE
Document missing Network features

### DIFF
--- a/VelorenPort/Docs/Interoperabilidad.md
+++ b/VelorenPort/Docs/Interoperabilidad.md
@@ -2,4 +2,19 @@
 
 Este documento recogerá pruebas para integrar módulos existentes en Rust mediante FFI o Wasm, en caso de que ciertos subsistemas se mantengan en Rust.
 
-Pendiente de investigación.
+## Estado actual
+
+Aún no se ha realizado ningún experimento de interoperabilidad. El código en C#
+no expone bindings ni define la ABI necesaria para enlazar con bibliotecas
+compiladas en Rust.
+
+## Tareas pendientes
+
+- Evaluar el uso de `DllImport` para cargar funciones compiladas en Rust con
+  `extern "C"`.
+- Considerar una capa Wasm para aprovechar la portabilidad y la seguridad del
+  entorno sandbox.
+- Definir un protocolo de comunicación estable entre ambos entornos (tipos,
+  codificación de mensajes y gestión de memoria).
+- Crear ejemplos mínimos que demuestren intercambio de datos entre C# y Rust.
+- Documentar la configuración del proyecto y los pasos de compilación cruzada.

--- a/VelorenPort/Docs/PlanDetallado.md
+++ b/VelorenPort/Docs/PlanDetallado.md
@@ -101,6 +101,17 @@ regiones visible en cada tick.
 
 - Evaluar si es viable migrar todo el crate de una sola vez o abordar el port por fases, priorizando primero la mensajería básica y la compatibilidad con el servidor en Rust.
 
+#### Características pendientes respecto a la versión de Rust
+
+- Falta una capa avanzada de fiabilidad y priorización de streams.
+- No se han portado todas las estructuras de `network-protocol`.
+- El handshake se reduce a un intercambio de versión sin los pasos intermedios de la implementación original.
+- Las métricas de red sólo cubren contadores básicos.
+- El planificador carece de balanceo dinámico de tareas y reintentos inteligentes.
+- Todavía no existe comunicación real con el servidor escrito en Rust.
+- La interoperabilidad mediante FFI o Wasm está sin investigar.
+- Las pruebas sólo contemplan el transporte local MPSC.
+
 ## 3. World (crate `world`)
 ### Ficheros relevantes
 - all.rs

--- a/VelorenPort/MigrationStatus.md
+++ b/VelorenPort/MigrationStatus.md
@@ -8,7 +8,7 @@ This document tracks progress of the Rust to C# port. Percentages reflect curren
 |---------|-----------:|
 | CoreEngine | 100% |
 
-| Network | 100% |
+| Network | 75% |
 | World | 99% |
 | Server | 90% |
 | Client | 66% |
@@ -140,6 +140,17 @@ This document tracks progress of the Rust to C# port. Percentages reflect curren
 | Stream.cs | 100% |
 | StreamError.cs | 100% |
 | StreamParams.cs | 100% |
+
+#### Pending features in `Network`
+
+- Advanced stream prioritization and congestion handling
+- Complete reliability layer for UDP and QUIC
+- Comprehensive Prometheus metrics
+- Scheduler parity with the Rust implementation
+- Real communication with the original Rust server
+- Extended handshake steps and protocol negotiation
+- Extensive unit and integration tests
+- Investigation of FFI or Wasm interoperability
 
 ### World
 

--- a/VelorenPort/Network/README.md
+++ b/VelorenPort/Network/README.md
@@ -25,51 +25,50 @@ Rust gracias a los métodos `IsValidForRole`, `CanSpectate` y similares.
 
 ## Analysis of Remaining Migration Tasks
 
-Despite the `100%` mark in `MigrationStatus.md`, the current C# module still
-mirrors only a subset of the original Rust crate. Important areas remain
-partially implemented or entirely missing:
+Despite the `100%` mark that appears in older documents, the current C# module
+mirrors only a subset of the original Rust crate. Several areas remain
+incomplete or entirely missing:
 
 
 ### Advanced Stream Management
 
-Rust uses channels, priority queues and reliability layers. The `Stream` class
-now includes optional bandwidth throttling when `StreamParams` sets
-`GuaranteedBandwidth`, limiting the amount of bytes written per second.
-Additionally, when the `Promises.GuaranteedDelivery` flag is present the stream
-implements a basic reliability layer with acknowledgments and automatic
-retransmission. Sophisticated prioritization is still pending.
+The Rust crate implements multiple queues with priority levels and a robust
+reliability layer. The C# `Stream` class only contains a basic retransmission
+system. Congestion control and message prioritization are not implemented.
+Handshake negotiation is simplified and does not cover the full state machine
+used in Rust.
 
 ### Metrics and Monitoring
 
-Ahora se exponen contadores Prometheus usando la librería `prometheus-net`, de
-modo que pueden consultarse desde herramientas externas. La cobertura de eventos
-es todavía limitada respecto al crate original. Desde esta versión el envío y
-recepción de mensajes, así como la apertura y cierre de `Streams` y
-`Participants`, incrementan contadores automáticamente para facilitar la
-observación durante las pruebas.
+`Metrics` integrates the `prometheus-net` package to expose counters. Only a
+subset of the events from the Rust version are tracked. Several network
+statistics, like per-channel congestion and scheduler load, are still missing.
 
 ### Scheduler and Concurrency
 
-El planificador ha sido actualizado para ejecutar tareas en paralelo de forma
-segura e incluye un método de cierre ordenado similar al `Scheduler` original.
-
-Desde esta revisión `Network` expone los métodos `DisconnectAsync` y
-`ShutdownAsync` para finalizar conexiones y detener los escuchas de forma
-segura. Esto permite limpiar correctamente los participantes activos durante las
-pruebas.
+The scheduler executes queued tasks and provides `DisconnectAsync` and
+`ShutdownAsync` helpers. It lacks the advanced task prioritization and dynamic
+load balancing present in the Rust implementation. Graceful shutdown of pending
+operations is still limited.
 
 ### Protocol Coverage
 
-Se añadió soporte experimental para UDP además de TCP y QUIC. Todavía faltan las
-capas de fiabilidad y priorización presentes en el proyecto original.
+UDP transport is experimental and lacks the reliability and prioritization
+layers provided by the Rust crate. Only basic QUIC configuration options are
+supported.
 
 ### Compatibility with Existing Rust Server
 
-While a compatibility layer is mentioned, the server code currently logs events
-instead of performing real communication, so behaviour differs from the Rust
-version.
+The current C# server logs connection attempts but does not exchange real
+messages with the Rust server. Protocol negotiation, authentication and
+encryption steps from the original project are not replicated.
 
 ### FFI/Interop Considerations
 
-`Docs/Interoperabilidad.md` notes that integration of Rust modules through FFI
-or Wasm is still *pendiente de investigación*.
+`Docs/Interoperabilidad.md` notes that integration with Rust code via FFI or
+Wasm is still under investigation. No interop layer has been implemented.
+
+### Testing Status
+
+Only a handful of tests cover the local MPSC transport. End-to-end integration
+tests comparable to the Rust suite are missing.

--- a/VelorenPort/README.md
+++ b/VelorenPort/README.md
@@ -27,6 +27,14 @@ Además se añadieron uniones discriminadas de error (`NetworkError`, `NetworkCo
 La clase `Stream` mantiene la API similar a la del crate original.
 `Participant` incluye funciones para abrir y recibir `Stream` de forma asíncrona y lleva un registro simple del ancho de banda.
 
+### Limitaciones actuales del módulo `Network`
+
+- Las colas de prioridad y el sistema avanzado de fiabilidad aún no se han implementado.
+- Faltan muchas estructuras del subcrate `network-protocol`.
+- La conexión con el servidor original en Rust está reducida a registros de prueba.
+- El planificador carece de balanceo dinámico y las métricas solo abarcan algunos contadores básicos.
+- Las pruebas unitarias se limitan al transporte local MPSC.
+
 Se creó además la assembly `World` con definiciones básicas de terreno (`Block`, `BlockKind`) e índices (`WorldIndex`) para comenzar el traslado de la lógica de generación procedimental. Dicho índice expone un generador `Noise` basado en `Unity.Mathematics` que produce valores deterministas en 3D. También se implementó `TerrainGenerator` y la clase `Chunk` como primer paso para construir el mundo. Posteriormente se añadió `WorldMap` para almacenar los chunks generados en memoria. El `GameServer` utiliza este mapa para poblar el terreno alrededor de cada cliente. El enum `BlockKind` se ha completado con todos los valores del proyecto original.
 Para suplir la falta del paquete `Unity.Mathematics` en este entorno, `CoreEngine` incluye un stub con funciones básicas y la constante `math.PI`. Dicho stub ahora implementa un algoritmo de ruido Simplex en 3D, por lo que los generadores de terreno producen patrones más cercanos al proyecto original.
 


### PR DESCRIPTION
## Summary
- update Network README with missing features and testing status
- list incomplete tasks in MigrationStatus
- expand PlanDetallado and Interoperabilidad docs
- note Network limitations in the main README

## Testing
- `dotnet build VelorenPort/VelorenPort.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68601251ca488328b24cd6749339c267