### PR TITLE
Document missing modules in port

### DIFF
--- a/VelorenPort/MigrationStatus.md
+++ b/VelorenPort/MigrationStatus.md
@@ -1,20 +1,29 @@
 # Migration Status
 
-This document tracks progress of the Rust to C# port. Percentages reflect current implementation.
+This document tracks progress of the Rust to C# port. Las cifras previas no reflejaban la realidad y se han actualizado de forma aproximada.
 
 ## Overall progress
 
 | Sistema | Porcentaje |
 |---------|-----------:|
-| CoreEngine | 100% |
+| CoreEngine | 30% |
+| Network | 25% |
+| World | 20% |
+| Server | 15% |
+| Client | 10% |
+| Simulation | 5% |
+| CLI | 5% |
+| Plugin | 5% |
 
-| Network | 100% |
-| World | 99% |
-| Server | 90% |
-| Client | 66% |
-| Simulation | 100% |
-| CLI | 100% |
-| Plugin | 100% |
+## Modulos faltantes
+
+Aunque el port cuenta con varios ficheros iniciales, muchos subsistemas del crate `common` no se han migrado o solo estan presentes como stubs:
+- `states` para comportamientos de combate y movimiento.
+- `terrain` y `volumes` con utilidades de bloques.
+- gran parte de `util` (colores, proyecciones, compresion, etc.).
+- la mayoria de componentes en `comp`, salvo unos pocos como `BuffKind` o `Player`.
+- modulo `weather` solo con una version minima.
+- otros submodulos como `slowjob`, `store`, `trade`, `figure` y `bin`.
 
 ## Per-file progress
 

--- a/VelorenPort/README.md
+++ b/VelorenPort/README.md
@@ -43,3 +43,16 @@ Además se crearon `Client` y `ConnectionHandler` para registrar las conexiones 
 
 ## Proyectos de C#
 Se añadieron archivos `*.csproj` en cada carpeta de sistema (CoreEngine, Network, World, Server, Client, CLI, Plugin y Simulation). Todos ellos se agrupan en la solución `VelorenPort.sln` para poder abrir y compilar el proyecto desde herramientas de .NET o Visual Studio.
+
+## Limitaciones actuales y módulos pendientes
+
+A pesar de contar con varios archivos clave, el port a C# todavía está lejos de cubrir todo el crate `common` de Rust. Los siguientes subsistemas no se han migrado o sólo existen como stubs muy básicos:
+
+- **`states`**: faltan todos los archivos de lógica de combate y movimiento.
+- **`terrain` y `volumes`**: sólo se incluyó `TerrainConstants`; el manejo completo de biomas, bloques y volúmenes sigue pendiente.
+- **`util`**: aparte de `MathUtil` no se han migrado las utilidades de color, proyección ni compresión.
+- **Componentes (`comp`)**: en Rust existen decenas de componentes (inventario, habilidades, físicas, etc.); aquí solo se implementaron `BuffKind`, `Chat`, `Group`, `Player` y varios stubs.
+- **`weather`**: el port actual es un stub sin la lógica de interpolación ni compresión presentes en Rust.
+- **Otros módulos**: no hay traslados de `slowjob`, `store`, `trade`, `figure`, ni del submódulo `bin`.
+
+Estas ausencias muestran que la funcionalidad en C# es aún limitada y queda trabajo considerable para alcanzar la paridad con el código original.


### PR DESCRIPTION
## Summary
- document incomplete modules in `VelorenPort/README.md`
- update progress numbers and add missing-module notes in `VelorenPort/MigrationStatus.md`

## Testing
- `dotnet test VelorenPort/VelorenPort.sln -c Release -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860125a7fc08328bf7f3acb34c2e5b6