### PR TITLE
Implement additional world utilities

### DIFF
--- a/VelorenPort/CoreEngine/Src/Aabb.cs
+++ b/VelorenPort/CoreEngine/Src/Aabb.cs
@@ -1,0 +1,21 @@
+using System;
+using Unity.Mathematics;
+
+namespace VelorenPort.CoreEngine
+{
+    /// <summary>
+    /// Axis-aligned bounding box of integer coordinates.
+    /// </summary>
+    [Serializable]
+    public struct Aabb
+    {
+        public int3 Min;
+        public int3 Max;
+
+        public Aabb(int3 min, int3 max)
+        {
+            Min = min;
+            Max = max;
+        }
+    }
+}

--- a/VelorenPort/CoreEngine/Src/Actor.cs
+++ b/VelorenPort/CoreEngine/Src/Actor.cs
@@ -7,10 +7,10 @@ namespace VelorenPort.CoreEngine {
     /// </summary>
     [Serializable]
     public abstract record Actor {
-        public sealed record Npc(int Id) : Actor;
+        public sealed record Npc(NpcId Id) : Actor;
         public sealed record Character(CharacterId Id) : Actor;
 
-        public static implicit operator Actor(int npcId) => new Npc(npcId);
+        public static implicit operator Actor(NpcId npcId) => new Npc(npcId);
         public static implicit operator Actor(CharacterId id) => new Character(id);
     }
 }

--- a/VelorenPort/CoreEngine/Src/RandomPerm.cs
+++ b/VelorenPort/CoreEngine/Src/RandomPerm.cs
@@ -1,0 +1,43 @@
+using System;
+using Unity.Mathematics;
+
+namespace VelorenPort.CoreEngine
+{
+    /// <summary>
+    /// Simple deterministic permutation RNG similar to RandomPerm in the Rust code.
+    /// </summary>
+    [Serializable]
+    public struct RandomPerm
+    {
+        public uint Seed { get; private set; }
+
+        public RandomPerm(uint seed)
+        {
+            Seed = seed;
+        }
+
+        public uint Get(uint perm)
+        {
+            Span<uint> vals = stackalloc uint[2] { Seed, perm };
+            return SeedExpan.DiffuseMult(vals);
+        }
+
+        public bool Chance(uint perm, float chance)
+        {
+            return (Get(perm) % (1u << 16)) / (float)(1u << 16) < chance;
+        }
+
+        public uint NextU32()
+        {
+            Seed = Get(Seed) ^ 0xA7535839u;
+            return Seed;
+        }
+
+        public ulong NextU64()
+        {
+            uint a = NextU32();
+            uint b = NextU32();
+            return ((ulong)a << 32) | b;
+        }
+    }
+}

--- a/VelorenPort/CoreEngine/Src/SeedExpan.cs
+++ b/VelorenPort/CoreEngine/Src/SeedExpan.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace VelorenPort.CoreEngine
+{
+    /// <summary>
+    /// Utilities for deterministic seed diffusion. Mirrors functions in
+    /// world/src/util/seed_expan.rs.
+    /// </summary>
+    public static class SeedExpan
+    {
+        /// <summary>Simple non-cryptographic diffusion function.</summary>
+        public static uint Diffuse(uint a)
+        {
+            a ^= a.RotateRight(23);
+            return a * 2654435761u;
+        }
+
+        /// <summary>Diffuse but takes multiple values as input.</summary>
+        public static uint DiffuseMult(ReadOnlySpan<uint> values)
+        {
+            uint state = (1u << 31) - 1u;
+            foreach (var v in values)
+            {
+                state = Diffuse(state ^ v);
+            }
+            return state;
+        }
+
+        /// Helper to rotate bits to the right.
+        private static uint RotateRight(this uint value, int bits)
+        {
+            return (value >> bits) | (value << (32 - bits));
+        }
+    }
+}

--- a/VelorenPort/World.Tests/DirTests.cs
+++ b/VelorenPort/World.Tests/DirTests.cs
@@ -1,0 +1,21 @@
+using VelorenPort.World.Site.Util;
+using Unity.Mathematics;
+
+namespace World.Tests;
+
+public class DirTests
+{
+    [Fact]
+    public void ToMat3_RotatesCorrectly()
+    {
+        float3 v = math.mul(Dir.NegX.ToMat3(), new float3(1, 0, 0));
+        Assert.Equal(new float3(-1, 0, 0), v);
+    }
+
+    [Fact]
+    public void RotateAxisCw_RotatesAroundZ()
+    {
+        var dir = Dir3.X.RotateAxisCw(Dir3.Z);
+        Assert.Equal(Dir3.Y, dir);
+    }
+}

--- a/VelorenPort/World.Tests/GradientTests.cs
+++ b/VelorenPort/World.Tests/GradientTests.cs
@@ -1,0 +1,25 @@
+using VelorenPort.World.Site.Util;
+using VelorenPort.CoreEngine;
+using Unity.Mathematics;
+
+namespace World.Tests;
+
+public class GradientTests
+{
+    [Fact]
+    public void Sample_ReturnsInterpolatedColor()
+    {
+        var g = new Gradient(float3.zero, 10f, Shape.Point, (new Rgb8(0,0,0), new Rgb8(100,0,0)));
+        var col = g.Sample(new float3(5f, 0f, 0f));
+        Assert.Equal((byte)50, col.R);
+    }
+
+    [Fact]
+    public void Repeat_WrapsDistance()
+    {
+        var g = new Gradient(float3.zero, 10f, Shape.Point, (new Rgb8(0,0,0), new Rgb8(100,0,0))).WithRepeat(WrapMode.Repeat);
+        var col = g.Sample(new float3(25f, 0f, 0f));
+        Assert.Equal((byte)50, col.R);
+    }
+}
+

--- a/VelorenPort/World.Tests/PathTests.cs
+++ b/VelorenPort/World.Tests/PathTests.cs
@@ -1,0 +1,28 @@
+using VelorenPort.World.Sim;
+using VelorenPort.CoreEngine;
+using Unity.Mathematics;
+
+namespace World.Tests;
+
+public class PathTests
+{
+    [Fact]
+    public void HeadSpace_ComputesExpected()
+    {
+        var path = Path.Default;
+        Assert.Equal(8, path.HeadSpace(0f));
+        Assert.Equal(1, path.HeadSpace(10f));
+    }
+
+    [Fact]
+    public void SurfaceColor_AddsNoise()
+    {
+        var path = Path.Default;
+        var col = new Rgb8(100, 0, 0);
+        var wpos = new int3(3, 6, 9);
+        var res = path.SurfaceColor(col, wpos);
+        Assert.Equal((byte)77, res.R);
+        Assert.Equal((byte)7, res.G);
+        Assert.Equal((byte)7, res.B);
+    }
+}

--- a/VelorenPort/World.Tests/RandomPermTests.cs
+++ b/VelorenPort/World.Tests/RandomPermTests.cs
@@ -1,0 +1,23 @@
+using VelorenPort.CoreEngine;
+using Xunit;
+
+namespace World.Tests;
+
+public class RandomPermTests
+{
+    [Fact]
+    public void Get_ReturnsExpectedValue()
+    {
+        var rp = new RandomPerm(12345);
+        uint v = rp.Get(42);
+        Assert.Equal(2745238656u, v);
+    }
+
+    [Fact]
+    public void NextU32_UpdatesSeed()
+    {
+        var rp = new RandomPerm(12345);
+        uint next = rp.NextU32();
+        Assert.Equal(0x9315E29Au, next);
+    }
+}

--- a/VelorenPort/World.Tests/SimUtilTests.cs
+++ b/VelorenPort/World.Tests/SimUtilTests.cs
@@ -1,0 +1,36 @@
+using VelorenPort.World;
+using VelorenPort.World.Sim;
+using Unity.Mathematics;
+
+namespace World.Tests;
+
+public class SimUtilTests
+{
+    [Fact]
+    public void MapEdgeFactor_CenterIsOne()
+    {
+        var size = new MapSizeLg(new int2(4,4));
+        int centerIdx = size.Vec2AsUniformIdx(size.Chunks / 2);
+        float f = Util.MapEdgeFactor(size, centerIdx);
+        Assert.True(f > 0.9f);
+    }
+
+    [Fact]
+    public void MapEdgeFactor_EdgeIsZero()
+    {
+        var size = new MapSizeLg(new int2(4,4));
+        int idx = size.Vec2AsUniformIdx(int2.zero);
+        float f = Util.MapEdgeFactor(size, idx);
+        Assert.Equal(0f, f);
+    }
+
+    [Fact]
+    public void CdfIrwinHall_TwoUniform()
+    {
+        float[] w = {1f,1f};
+        float[] s = {0.5f,0.5f};
+        float v = Util.CdfIrwinHall(w, s);
+        Assert.True(math.abs(v - 0.5f) < 1e-4);
+    }
+}
+

--- a/VelorenPort/World.Tests/WorldUtilTests.cs
+++ b/VelorenPort/World.Tests/WorldUtilTests.cs
@@ -1,0 +1,14 @@
+using VelorenPort.World;
+using Unity.Mathematics;
+
+namespace World.Tests;
+
+public class WorldUtilTests
+{
+    [Fact]
+    public void WithinDistance_Works()
+    {
+        Assert.True(WorldUtil.WithinDistance(int2.zero, new int2(3,4), 5));
+        Assert.False(WorldUtil.WithinDistance(int2.zero, new int2(5,5), 5));
+    }
+}

--- a/VelorenPort/World/MissingFeatures.md
+++ b/VelorenPort/World/MissingFeatures.md
@@ -9,14 +9,20 @@ expands on all the components identificados hasta la fecha.
   la asignación de NPCs y eventos.
 - **Capas dinámicas** (`layer`): cuevas, dispersión de objetos, arbustos,
   árboles y fauna no cuentan con implementaciones reales.
-- **Simulación detallada** (`sim`): módulos de difusión, mapa de humedad,
-  utilidades de localización y la erosión iterativa están ausentes.
+- **Simulación detallada** (`sim`): continúan faltando los módulos de difusión,
+  el mapa de humedad y la erosión iterativa. Ya se ha incorporado una versión
+  inicial de `sim/location` para nombrar lugares. Se añadieron utilidades
+  básicas en `sim/util` como `MapEdgeFactor` y `cdf_irwin_hall`, junto al módulo
+  `sim/way` y la clase `RandomPerm` para apoyar futuros caminos y
+  aleatoriedad determinista.
 - **Conjunto de sitios** (`site/gen` y `site/plot`): no se han portado los
   generadores de poblados ni la gran variedad de edificaciones y decoraciones.
 - **Economía compleja** (`site/economy`): carecemos de mercados, oferta y
   demanda y rutas de caravanas.
-- **Tiles y utilidades** (`site/tile`, `site/util`): sólo existen stubs para
-  nombrar lugares y datos mínimos de paisajes.
+- **Tiles y utilidades** (`site/tile`, `site/util`): se incorporaron las
+  enumeraciones de dirección (`Dir`, `Dir3`) con utilidades de matrices de
+  orientación y un módulo básico de gradientes, pero siguen faltando sprites y
+  la lógica de baldosas.
 - **Eventos de regiones** y políticas de descarte de entidades: la gestión de
   miembros de región se mantiene simple y sin persistencia histórica.
 - **Recursos de chunk** (`ChunkResource` y asociadas) apenas se reflejan en la

--- a/VelorenPort/World/README.md
+++ b/VelorenPort/World/README.md
@@ -18,8 +18,13 @@ relevantes destacan:
 
 - Sistemas de **capas** (`layer`) para cuevas, vegetación, fauna y otros
   elementos dinámicos.
-- Módulos de **simulación** avanzados (`sim/diffusion`, `sim/location`,
-  `sim/util`, etc.) y el modelo completo de erosión de ríos.
+- Módulos de **simulación** avanzados (`sim/diffusion`, `sim/util`, etc.) y el
+  modelo completo de erosión de ríos. El submódulo `sim/location` ya cuenta con
+  una versión básica para generar nombres de lugares. Se añadieron funciones de
+  `sim/util` como `MapEdgeFactor` y `cdf_irwin_hall`, junto a nuevas utilidades
+  de caminos (`sim/way`) y el generador determinista `RandomPerm`. Además se
+  incorporó `site/util` con enumeraciones de dirección, matrices de orientación
+  y un sistema de gradientes para futuros módulos.
 - **Generación de civilizaciones** y poblados complejos definida en `civ` y
   `site/gen`.
 - El catálogo de **edificaciones** de `site/plot` y la lógica de baldosas de

--- a/VelorenPort/World/Src/MapSizeLg.cs
+++ b/VelorenPort/World/Src/MapSizeLg.cs
@@ -36,5 +36,16 @@ namespace VelorenPort.World
                    (chunkPos.x & (size.x - 1)) == chunkPos.x &&
                    (chunkPos.y & (size.y - 1)) == chunkPos.y;
         }
+
+        public int2 UniformIdxAsVec2(int idx)
+        {
+            int xMask = (1 << Value.x) - 1;
+            return new int2(idx & xMask, idx >> Value.x);
+        }
+
+        public int Vec2AsUniformIdx(int2 pos)
+        {
+            return (pos.y << Value.x) | (pos.x & ((1 << Value.x) - 1));
+        }
     }
 }

--- a/VelorenPort/World/Src/Sim/Location.cs
+++ b/VelorenPort/World/Src/Sim/Location.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using Unity.Mathematics;
+
+namespace VelorenPort.World.Sim
+{
+    /// <summary>
+    /// Representation of a world location with a name and neighbouring links.
+    /// Ported from <c>sim/location.rs</c>.
+    /// </summary>
+    [Serializable]
+    public class Location
+    {
+        public string Name { get; private set; } = string.Empty;
+        public int2 Center { get; private set; }
+        public Kingdom? Kingdom { get; set; }
+        private readonly HashSet<ulong> _neighbours = new();
+
+        public IEnumerable<ulong> Neighbours => _neighbours;
+
+        private Location(string name, int2 center)
+        {
+            Name = name;
+            Center = center;
+        }
+
+        /// <summary>Create a new random location.</summary>
+        public static Location Generate(int2 center, System.Random rng)
+        {
+            string name = GenerateName(rng);
+            return new Location(name, center);
+        }
+
+        public void AddNeighbour(ulong id) => _neighbours.Add(id);
+
+        private static readonly string[] FirstSyl = new[] {
+            "Eri","Val","Gla","Wilde","Cold","Deep","Dura","Ester","Fay","Dark","West",
+            "East","North","South","Ray","Eri","Dal","Som","Sommer","Black","Iron","Grey",
+            "Hel","Gal","Mor","Lo","Nil","Bel","Lor","Gold","Red","Marble","Mana","Gar",
+            "Mountain","Red","Cheo","Far","High"
+        };
+
+        private static readonly string[] Mid = new[] { "ka", "se", "au", "da", "di" };
+
+        private static readonly string[] Tails = new[] {
+            "ben","sel","dori","theas","dar","bur","to","vis","ten",
+            "stone","tiva","id","and","or","el","ond","ia","eld","ald","aft","ift","ity",
+            "well","oll","ill","all","wyn","light"," Hill","lin","mont","mor","cliff","rok",
+            "den","mi","rock","glenn","rovi","lea","gate","view","ley","wood","ovia",
+            "cliff","marsh","kor","ice","acre","venn","crest","field",
+            "vale","spring"," Vale","grasp","fel","fall","grove","wyn","edge"
+        };
+
+        private static string GenerateName(System.Random rng)
+        {
+            string name = string.Empty;
+            if (rng.NextDouble() < 0.5)
+            {
+                name += FirstSyl[rng.Next(FirstSyl.Length)];
+                name += Mid[rng.Next(Mid.Length)];
+                name += Tails[rng.Next(Tails.Length)];
+            }
+            else
+            {
+                name += FirstSyl[rng.Next(FirstSyl.Length)];
+                name += Tails[rng.Next(Tails.Length)];
+            }
+            return name;
+        }
+    }
+
+    /// <summary>Placeholder kingdom information.</summary>
+    [Serializable]
+    public class Kingdom
+    {
+        public string RegionName { get; set; } = string.Empty;
+    }
+}

--- a/VelorenPort/World/Src/Sim/Util.cs
+++ b/VelorenPort/World/Src/Sim/Util.cs
@@ -1,0 +1,65 @@
+using System;
+using Unity.Mathematics;
+
+namespace VelorenPort.World.Sim
+{
+    /// <summary>
+    /// Helper functions ported from world/src/sim/util.rs
+    /// </summary>
+    public static class Util
+    {
+        /// <summary>
+        /// Calculate a factor representing how close a chunk index is to the edge of the map.
+        /// Returns values in [0,1], where 1 is far from the edge.
+        /// </summary>
+        public static float MapEdgeFactor(MapSizeLg mapSizeLg, int posIndex)
+        {
+            int2 pos = mapSizeLg.UniformIdxAsVec2(posIndex);
+            int2 size = mapSizeLg.Chunks;
+            float2 f = new float2(
+                (size.x / 2f - math.abs(pos.x - size.x / 2f)) / (16f / 1024f * size.x),
+                (size.y / 2f - math.abs(pos.y - size.y / 2f)) / (16f / 1024f * size.y)
+            );
+            float r = math.min(f.x, f.y);
+            return math.max(0f, math.min(1f, r));
+        }
+
+        /// <summary>
+        /// Compute the CDF of the weighted sum of uniformly distributed variables.
+        /// </summary>
+        public static float CdfIrwinHall(float[] weights, float[] samples)
+        {
+            int n = weights.Length;
+            if (samples.Length != n) throw new ArgumentException("samples length mismatch");
+
+            double x = 0.0;
+            for (int i = 0; i < n; i++) x += weights[i] * samples[i];
+
+            double y = 0.0;
+            int subsets = 1 << n;
+            for (int subset = 0; subset < subsets; subset++)
+            {
+                int k = 0;
+                double sum = 0.0;
+                for (int i = 0; i < n; i++)
+                {
+                    if ((subset & (1 << i)) != 0)
+                    {
+                        k++;
+                        sum += weights[i];
+                    }
+                }
+                double z = Math.Pow(Math.Max(0.0, x - sum), n);
+                y += (k % 2 == 0) ? z : -z;
+            }
+            double denom = 1.0;
+            for (int i = 0; i < n; i++) denom *= weights[i];
+            y /= denom;
+
+            // divide by n!
+            double fact = 1.0;
+            for (int i = 2; i <= n; i++) fact *= i;
+            return (float)(y / fact);
+        }
+    }
+}

--- a/VelorenPort/World/Src/Sim/Way.cs
+++ b/VelorenPort/World/Src/Sim/Way.cs
@@ -1,5 +1,6 @@
 using System;
 using Unity.Mathematics;
+using VelorenPort.CoreEngine;
 
 namespace VelorenPort.World.Sim {
     /// <summary>
@@ -19,5 +20,45 @@ namespace VelorenPort.World.Sim {
     public struct Path {
         public float Width;
         public static Path Default => new Path { Width = 5f };
+
+        /// <summary>
+        /// Interpolate two paths.
+        /// </summary>
+        public static Path Lerp(Path from, Path to, float factor)
+        {
+            return new Path { Width = math.lerp(from.Width, to.Width, factor) };
+        }
+
+        /// <summary>
+        /// Return the number of blocks of head space required at the given
+        /// distance from the path centre.
+        /// </summary>
+        public int HeadSpace(float dist)
+        {
+            return math.max(1, (int)math.round(8f - math.pow(dist * 0.25f, 6))); 
+        }
+
+        /// <summary>Get the surface colour of a path given the surrounding colour.</summary>
+        public Rgb8 SurfaceColor(Rgb8 col, int3 wpos)
+        {
+            Rgb8 scaled = new Rgb8(
+                (byte)math.round(col.R * 0.7f),
+                (byte)math.round(col.G * 0.7f),
+                (byte)math.round(col.B * 0.7f)
+            );
+            return NoisyColor(scaled, 8, wpos);
+        }
+
+        /// <summary>Add deterministic noise to a colour.</summary>
+        public static Rgb8 NoisyColor(Rgb8 color, uint factor, int3 wpos)
+        {
+            uint nz = new RandomField(0).Get(wpos);
+            byte Apply(byte c)
+            {
+                int val = c + (int)(nz % (factor * 2)) - (int)factor;
+                return (byte)math.clamp(val, 0, 255);
+            }
+            return new Rgb8(Apply(color.R), Apply(color.G), Apply(color.B));
+        }
     }
 }

--- a/VelorenPort/World/Src/Site/Util/Dir.cs
+++ b/VelorenPort/World/Src/Site/Util/Dir.cs
@@ -1,0 +1,306 @@
+using System;
+using Unity.Mathematics;
+using VelorenPort.CoreEngine;
+
+namespace VelorenPort.World.Site.Util
+{
+    /// <summary>
+    /// Two-dimensional cardinal directions used for town generation.
+    /// Ported in simplified form from the Rust implementation.
+    /// </summary>
+    public enum Dir
+    {
+        X,
+        Y,
+        NegX,
+        NegY,
+    }
+
+    /// <summary>Utility helpers for <see cref="Dir"/>.</summary>
+    public static class DirExt
+    {
+        /// <summary>Select a random direction.</summary>
+        public static Dir Choose(System.Random rng)
+            => (Dir)rng.Next(0, 4);
+
+        /// <summary>Create a direction based on a vector.</summary>
+        public static Dir FromVec2(int2 vec)
+        {
+            return math.abs(vec.x) > math.abs(vec.y)
+                ? (vec.x > 0 ? Dir.X : Dir.NegX)
+                : (vec.y > 0 ? Dir.Y : Dir.NegY);
+        }
+
+        public static Dir Opposite(this Dir dir)
+            => dir switch
+            {
+                Dir.X => Dir.NegX,
+                Dir.NegX => Dir.X,
+                Dir.Y => Dir.NegY,
+                _ => Dir.Y,
+            };
+
+        public static Dir RotatedCcw(this Dir dir)
+            => dir switch
+            {
+                Dir.X => Dir.Y,
+                Dir.Y => Dir.NegX,
+                Dir.NegX => Dir.NegY,
+                _ => Dir.X,
+            };
+
+        public static Dir RotatedCw(this Dir dir) => dir.RotatedCcw().Opposite();
+
+        public static Dir Orthogonal(this Dir dir)
+            => dir is Dir.X or Dir.NegX ? Dir.Y : Dir.X;
+
+        public static Dir Abs(this Dir dir)
+            => dir is Dir.X or Dir.NegX ? Dir.X : Dir.Y;
+
+        public static int Signum(this Dir dir)
+            => dir is Dir.X or Dir.Y ? 1 : -1;
+
+        public static bool IsX(this Dir dir) => dir is Dir.X or Dir.NegX;
+        public static bool IsY(this Dir dir) => dir is Dir.Y or Dir.NegY;
+        public static bool IsPositive(this Dir dir) => dir is Dir.X or Dir.Y;
+        public static bool IsNegative(this Dir dir) => !dir.IsPositive();
+
+        public static Dir RelativeTo(this Dir dir, Dir other)
+            => other switch
+            {
+                Dir.X => dir,
+                Dir.NegX => dir.Opposite(),
+                Dir.Y => dir.RotatedCw(),
+                _ => dir.RotatedCcw(),
+            };
+
+        public static int2 ToVec2(this Dir dir)
+            => dir switch
+            {
+                Dir.X => new int2(1, 0),
+                Dir.NegX => new int2(-1, 0),
+                Dir.Y => new int2(0, 1),
+                _ => new int2(0, -1),
+            };
+
+        /// <summary>Diagonal vector to the left of this direction.</summary>
+        public static int2 Diagonal(this Dir dir) => dir.ToVec2() + dir.RotatedCcw().ToVec2();
+
+        public static int3 ToVec3(this Dir dir)
+            => dir switch
+            {
+                Dir.X => new int3(1, 0, 0),
+                Dir.NegX => new int3(-1, 0, 0),
+                Dir.Y => new int3(0, 1, 0),
+                _ => new int3(0, -1, 0),
+            };
+
+        public static int2 Vec2(this Dir dir, int x, int y)
+            => dir switch
+            {
+                Dir.X => new int2(x, y),
+                Dir.NegX => new int2(-x, -y),
+                Dir.Y => new int2(y, x),
+                _ => new int2(-y, -x),
+            };
+
+        public static int2 Vec2Abs(this Dir dir, int x, int y)
+            => dir switch
+            {
+                Dir.X => new int2(x, y),
+                Dir.NegX => new int2(x, y),
+                Dir.Y => new int2(y, x),
+                _ => new int2(y, x),
+            };
+
+        public static float3x3 ToMat3(this Dir dir) => dir switch
+        {
+            Dir.X => float3x3.identity,
+            Dir.NegX => new float3x3(-1, 0, 0,
+                                      0, -1, 0,
+                                      0, 0, 1),
+            Dir.Y => new float3x3(0, -1, 0,
+                                  1, 0, 0,
+                                  0, 0, 1),
+            _ => new float3x3(0, 1, 0,
+                              -1, 0, 0,
+                               0, 0, 1),
+        };
+
+        public static float3x3 FromZMat3(this Dir dir) => dir switch
+        {
+            Dir.X => new float3x3(0, 0, -1,
+                                  0, 1, 0,
+                                  1, 0, 0),
+            Dir.NegX => new float3x3(0, 0, 1,
+                                     0, 1, 0,
+                                    -1, 0, 0),
+            Dir.Y => new float3x3(1, 0, 0,
+                                  0, 0, -1,
+                                  0, 1, 0),
+            _ => new float3x3(1, 0, 0,
+                             0, 0, 1,
+                             0, -1, 0),
+        };
+
+        public static int Select(this Dir dir, int2 vec)
+            => dir is Dir.X or Dir.NegX ? vec.x : vec.y;
+
+        public static int2 SelectWith(this Dir dir, int2 vec, int2 other)
+            => dir is Dir.X or Dir.NegX
+                ? new int2(vec.x, other.y)
+                : new int2(other.x, vec.y);
+
+        public static int SpriteOri(this Dir dir) => dir switch
+        {
+            Dir.X => 0,
+            Dir.Y => 2,
+            Dir.NegX => 4,
+            _ => 6,
+        };
+
+        public static (Dir dir, int rest)? FromSpriteOri(int ori)
+        {
+            Dir dir = ori / 2 switch
+            {
+                0 => Dir.X,
+                1 => Dir.Y,
+                2 => Dir.NegX,
+                3 => Dir.NegY,
+                _ => (Dir)(-1)
+            };
+            if ((int)dir == -1) return null;
+            return (dir, ori % 2);
+        }
+
+        public static int SpriteOriLegacy(this Dir dir) => dir switch
+        {
+            Dir.X => 2,
+            Dir.NegX => 6,
+            Dir.Y => 4,
+            _ => 0,
+        };
+    }
+
+    /// <summary>Three-dimensional directions.</summary>
+    public enum Dir3
+    {
+        X,
+        Y,
+        Z,
+        NegX,
+        NegY,
+        NegZ,
+    }
+
+    /// <summary>Utility helpers for <see cref="Dir3"/>.</summary>
+    public static class Dir3Ext
+    {
+        public static Dir3 Choose(System.Random rng)
+            => (Dir3)rng.Next(0, 6);
+
+        public static Dir3 FromDir(Dir dir)
+            => dir switch
+            {
+                Dir.X => Dir3.X,
+                Dir.Y => Dir3.Y,
+                Dir.NegX => Dir3.NegX,
+                _ => Dir3.NegY,
+            };
+
+        public static Dir? ToDir(this Dir3 dir)
+            => dir switch
+            {
+                Dir3.X => Dir.X,
+                Dir3.Y => Dir.Y,
+                Dir3.NegX => Dir.NegX,
+                Dir3.NegY => Dir.NegY,
+                _ => null,
+            };
+
+        public static Dir3 Opposite(this Dir3 dir)
+            => dir switch
+            {
+                Dir3.X => Dir3.NegX,
+                Dir3.NegX => Dir3.X,
+                Dir3.Y => Dir3.NegY,
+                Dir3.NegY => Dir3.Y,
+                Dir3.Z => Dir3.NegZ,
+                _ => Dir3.Z,
+            };
+
+        public static int Signum(this Dir3 dir)
+            => dir is Dir3.X or Dir3.Y or Dir3.Z ? 1 : -1;
+
+        public static bool IsX(this Dir3 dir) => dir is Dir3.X or Dir3.NegX;
+        public static bool IsY(this Dir3 dir) => dir is Dir3.Y or Dir3.NegY;
+        public static bool IsZ(this Dir3 dir) => dir is Dir3.Z or Dir3.NegZ;
+        public static bool IsPositive(this Dir3 dir) => dir is Dir3.X or Dir3.Y or Dir3.Z;
+        public static bool IsNegative(this Dir3 dir) => !dir.IsPositive();
+
+        public static Dir3 FromVec3(int3 vec)
+        {
+            int ax = math.abs(vec.x);
+            int ay = math.abs(vec.y);
+            int az = math.abs(vec.z);
+            if (ax >= ay && ax >= az) return vec.x >= 0 ? Dir3.X : Dir3.NegX;
+            if (ay >= az) return vec.y >= 0 ? Dir3.Y : Dir3.NegY;
+            return vec.z >= 0 ? Dir3.Z : Dir3.NegZ;
+        }
+
+        public static int3 ToVec3(this Dir3 dir)
+            => dir switch
+            {
+                Dir3.X => new int3(1, 0, 0),
+                Dir3.NegX => new int3(-1, 0, 0),
+                Dir3.Y => new int3(0, 1, 0),
+                Dir3.NegY => new int3(0, -1, 0),
+                Dir3.Z => new int3(0, 0, 1),
+                _ => new int3(0, 0, -1),
+            };
+
+        public static Dir3 RotateAxisCcw(this Dir3 dir, Dir3 axis) => axis switch
+        {
+            Dir3.X or Dir3.NegX => dir switch
+            {
+                Dir3.Y => Dir3.Z,
+                Dir3.NegY => Dir3.NegZ,
+                Dir3.Z => Dir3.NegY,
+                Dir3.NegZ => Dir3.Y,
+                _ => dir,
+            },
+            Dir3.Y or Dir3.NegY => dir switch
+            {
+                Dir3.X => Dir3.Z,
+                Dir3.NegX => Dir3.NegZ,
+                Dir3.Z => Dir3.NegX,
+                Dir3.NegZ => Dir3.X,
+                _ => dir,
+            },
+            _ => dir switch
+            {
+                Dir3.X => Dir3.Y,
+                Dir3.NegX => Dir3.NegY,
+                Dir3.Y => Dir3.NegX,
+                Dir3.NegY => Dir3.X,
+                _ => dir,
+            }
+        };
+
+        public static Dir3 RotateAxisCw(this Dir3 dir, Dir3 axis)
+            => dir.RotateAxisCcw(axis).Opposite();
+
+        public static Dir3 Cross(this Dir3 a, Dir3 b) => (a, b) switch
+        {
+            (Dir3.X or Dir3.NegX, Dir3.Y or Dir3.NegY)
+                or (Dir3.Y or Dir3.NegY, Dir3.X or Dir3.NegX) => Dir3.Z,
+            (Dir3.X or Dir3.NegX, Dir3.Z or Dir3.NegZ)
+                or (Dir3.Z or Dir3.NegZ, Dir3.X or Dir3.NegX) => Dir3.Y,
+            (Dir3.Z or Dir3.NegZ, Dir3.Y or Dir3.NegY)
+                or (Dir3.Y or Dir3.NegY, Dir3.Z or Dir3.NegZ) => Dir3.X,
+            (Dir3.X or Dir3.NegX, Dir3.X or Dir3.NegX) => Dir3.Y,
+            (Dir3.Y or Dir3.NegY, Dir3.Y or Dir3.NegY) => Dir3.X,
+            _ => Dir3.Y,
+        };
+    }
+}

--- a/VelorenPort/World/Src/Site/Util/Gradient.cs
+++ b/VelorenPort/World/Src/Site/Util/Gradient.cs
@@ -1,0 +1,107 @@
+using System;
+using VelorenPort.CoreEngine;
+using Unity.Mathematics;
+
+namespace VelorenPort.World.Site.Util;
+
+/// <summary>
+/// Wrapping behavior when sampling beyond the gradient range.
+/// Mirrors <c>WrapMode</c> in the Rust project.
+/// </summary>
+public enum WrapMode
+{
+    Clamp,
+    Repeat,
+    PingPong,
+}
+
+static class WrapModeExt
+{
+    public static float Sample(this WrapMode mode, float t)
+    {
+        switch (mode)
+        {
+            case WrapMode.Clamp:
+                return math.clamp(t, 0f, 1f);
+            case WrapMode.Repeat:
+                return PositiveFrac(t);
+            case WrapMode.PingPong:
+                float u = PositiveFrac(t / 2f);
+                return 1f - 2f * math.abs(u - 0.5f);
+            default:
+                return t;
+        }
+    }
+
+    private static float PositiveFrac(float x)
+    {
+        float f = x - math.floor(x);
+        return f >= 0f ? f : f + 1f;
+    }
+}
+
+/// <summary>Shape used when computing distance to the gradient.</summary>
+public readonly struct Shape
+{
+    public enum Kind { Point, Plane, Line }
+
+    public readonly Kind Type;
+    public readonly float3 Vec;
+
+    private Shape(Kind type, float3 vec)
+    {
+        Type = type;
+        Vec = math.normalizesafe(vec, new float3(0, 1, 0));
+    }
+
+    public static Shape Point => new Shape(Kind.Point, float3.zero);
+    public static Shape Plane(float3 normal) => new Shape(Kind.Plane, normal);
+    public static Shape Line(float3 dir) => new Shape(Kind.Line, dir);
+}
+
+/// <summary>
+/// Simple color gradient helper similar to <c>Gradient</c> from the Rust code.
+/// </summary>
+[Serializable]
+public struct Gradient
+{
+    public float3 Center;
+    public float Size;
+    public Shape Shape;
+    public WrapMode Repeat;
+    public (Rgb8, Rgb8) Colors;
+
+    public Gradient(float3 center, float size, Shape shape, (Rgb8, Rgb8) colors)
+    {
+        Center = center;
+        Size = size;
+        Shape = shape;
+        Repeat = WrapMode.Clamp;
+        Colors = colors;
+    }
+
+    public Gradient WithRepeat(WrapMode mode)
+    {
+        Repeat = mode;
+        return this;
+    }
+
+    /// <summary>Sample a color from this gradient at <paramref name="pos"/>.</summary>
+    public Rgb8 Sample(float3 pos)
+    {
+        float dist = Shape.Type switch
+        {
+            Shape.Kind.Point => math.distance(pos, Center) / Size,
+            Shape.Kind.Plane => math.dot(pos - Center, Shape.Vec) / Size,
+            Shape.Kind.Line =>
+                math.length((pos - Center) - math.dot(pos - Center, Shape.Vec) * Shape.Vec) / Size,
+            _ => 0f,
+        };
+        float t = Repeat.Sample(dist);
+        byte r = (byte)math.round(math.lerp(Colors.Item1.R, Colors.Item2.R, t));
+        byte g = (byte)math.round(math.lerp(Colors.Item1.G, Colors.Item2.G, t));
+        byte b = (byte)math.round(math.lerp(Colors.Item1.B, Colors.Item2.B, t));
+        return new Rgb8(r, g, b);
+    }
+}
+

--- a/VelorenPort/World/Src/WorldUtil.cs
+++ b/VelorenPort/World/Src/WorldUtil.cs
@@ -32,5 +32,100 @@ namespace VelorenPort.World
             new int2(-1, 1),
             new int2(-1, -1)
         };
+
+        public static readonly int2[] CARDINALS =
+        {
+            new int2(1, 0),
+            new int2(0, 1),
+            new int2(-1, 0),
+            new int2(0, -1)
+        };
+
+        public static readonly int2[] DIRS =
+        {
+            new int2(1, 0),
+            new int2(1, 1),
+            new int2(0, 1),
+            new int2(-1, 1),
+            new int2(-1, 0),
+            new int2(-1, -1),
+            new int2(0, -1),
+            new int2(1, -1)
+        };
+
+        public static readonly int2[] DIAGONALS =
+        {
+            new int2(1, 1),
+            new int2(-1, 1),
+            new int2(-1, -1),
+            new int2(1, -1)
+        };
+
+        public static readonly int3[] NEIGHBORS3 =
+        {
+            new int3(0,0,-1),
+            new int3(0,0,1),
+            new int3(0,-1,0),
+            new int3(0,-1,-1),
+            new int3(0,-1,1),
+            new int3(0,1,0),
+            new int3(0,1,-1),
+            new int3(0,1,1),
+            new int3(-1,0,0),
+            new int3(-1,0,-1),
+            new int3(-1,0,1),
+            new int3(-1,-1,0),
+            new int3(-1,-1,-1),
+            new int3(-1,-1,1),
+            new int3(-1,1,0),
+            new int3(-1,1,-1),
+            new int3(-1,1,1),
+            new int3(1,0,0),
+            new int3(1,0,-1),
+            new int3(1,0,1),
+            new int3(1,-1,0),
+            new int3(1,-1,-1),
+            new int3(1,-1,1),
+            new int3(1,1,0),
+            new int3(1,1,-1),
+            new int3(1,1,1)
+        };
+
+        public static readonly int2[] CARDINAL_LOCALITY =
+        {
+            new int2(0,0),
+            new int2(0,1),
+            new int2(1,0),
+            new int2(0,-1),
+            new int2(-1,0)
+        };
+
+        public static readonly int2[] SQUARE_4 =
+        {
+            new int2(0,0),
+            new int2(1,0),
+            new int2(0,1),
+            new int2(1,1)
+        };
+
+        public static readonly int2[] SQUARE_9 =
+        {
+            new int2(-1,-1),
+            new int2(0,-1),
+            new int2(1,-1),
+            new int2(-1,0),
+            new int2(0,0),
+            new int2(1,0),
+            new int2(-1,1),
+            new int2(0,1),
+            new int2(1,1)
+        };
+
+        public static bool WithinDistance(int2 a, int2 b, int distance)
+        {
+            long dx = a.x - b.x;
+            long dy = a.y - b.y;
+            return dx * dx + dy * dy <= (long)distance * distance;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add deterministic RNG via `RandomPerm` and seed diffusion helpers
- expand `Path` with interpolation, headspace, and surface coloring
- include extensive neighbor constants and a distance helper in `WorldUtil`
- document the new world utilities and update missing feature notes
- test random permutation, path behavior, and distance checks

## Testing
- `dotnet build VelorenPort/VelorenPort.sln -c Release -v minimal` *(fails: command not found)*
- `dotnet test VelorenPort/VelorenPort.sln -c Release -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68601a1e1f948328864baf112906b1ff