### PR TITLE
Improve channel metrics and cleanup logic

### DIFF
--- a/VelorenPort/Network/Src/Stream.cs
+++ b/VelorenPort/Network/Src/Stream.cs
@@ -196,7 +196,10 @@ namespace VelorenPort.Network {
 
         public void Dispose()
         {
-            _metrics?.StreamClosed();
+            if (_participant != null)
+                _metrics?.StreamClosed(_participant.Id);
+            else
+                _metrics?.StreamClosed(new Pid(Guid.Empty));
             _transport?.Dispose();
             _bandwidthTimer?.Dispose();
             _resendTimer?.Dispose();


### PR DESCRIPTION
## Summary
- add counters for channels opened/closed
- log channel disconnections when a participant is disposed
- keep per-channel gauges and cleanup participant metrics
- track active streams per participant

## Testing
- `dotnet test VelorenPort/VelorenPort.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604afb57c883289a5f6f76551812de