### PR TITLE
Add uniform noise utility

### DIFF
--- a/VelorenPort/CoreEngine/Src/Dir.cs
+++ b/VelorenPort/CoreEngine/Src/Dir.cs
@@ -29,7 +29,7 @@ namespace VelorenPort.CoreEngine
         public static Dir Forward => new Dir(new float3(0f, 1f, 0f));
         public static Dir Back => new Dir(new float3(0f, -1f, 0f));
 
-        public static Dir Random2D(Random rng)
+        public static Dir Random2D(System.Random rng)
         {
             float a = (float)rng.NextDouble() * (2f * math.PI);
             return new Dir(new float3(math.cos(a), math.sin(a), 0f));

--- a/VelorenPort/CoreEngine/Src/RtSim.cs
+++ b/VelorenPort/CoreEngine/Src/RtSim.cs
@@ -16,7 +16,7 @@ namespace VelorenPort.CoreEngine {
     /// small subset of the Rust <c>Dir</c> type and exists only so the
     /// controller APIs map more closely to the original.</summary>
     [Serializable]
-    public enum Dir { North, East, South, West }
+    public enum Facing { North, East, South, West }
 
     /// <summary>Flight behaviour for flying NPCs.</summary>
     [Serializable]
@@ -30,7 +30,7 @@ namespace VelorenPort.CoreEngine {
 
         [Serializable]
         public sealed record GotoFlying(float3 Position, float Speed,
-                                        float? Height, Dir? Dir,
+                                        float? Height, Facing? Dir,
                                         FlightMode Mode) : NpcActivity;
 
         [Serializable]
@@ -40,13 +40,13 @@ namespace VelorenPort.CoreEngine {
         public sealed record HuntAnimals : NpcActivity;
 
         [Serializable]
-        public sealed record Dance(Dir? Facing) : NpcActivity;
+        public sealed record Dance(Facing? Facing) : NpcActivity;
 
         [Serializable]
-        public sealed record Cheer(Dir? Facing) : NpcActivity;
+        public sealed record Cheer(Facing? Facing) : NpcActivity;
 
         [Serializable]
-        public sealed record Sit(Dir? Facing, int3? Position) : NpcActivity;
+        public sealed record Sit(Facing? Facing, int3? Position) : NpcActivity;
 
         [Serializable]
         public sealed record Talk(Actor Target) : NpcActivity;
@@ -272,7 +272,7 @@ namespace VelorenPort.CoreEngine {
             Activity = new NpcActivity.Goto(pos, speed);
 
         public void DoGotoFlying(float3 pos, float speed, float? height = null,
-                                  Dir? dir = null, FlightMode mode = FlightMode.Braking) =>
+                                  Facing? dir = null, FlightMode mode = FlightMode.Braking) =>
             Activity = new NpcActivity.GotoFlying(pos, speed, height, dir, mode);
 
         public void DoGather(params ChunkResource[] res) =>
@@ -280,11 +280,11 @@ namespace VelorenPort.CoreEngine {
 
         public void DoHuntAnimals() => Activity = new NpcActivity.HuntAnimals();
 
-        public void DoDance(Dir? dir = null) => Activity = new NpcActivity.Dance(dir);
+        public void DoDance(Facing? dir = null) => Activity = new NpcActivity.Dance(dir);
 
-        public void DoCheer(Dir? dir = null) => Activity = new NpcActivity.Cheer(dir);
+        public void DoCheer(Facing? dir = null) => Activity = new NpcActivity.Cheer(dir);
 
-        public void DoSit(Dir? dir = null, int3? pos = null) =>
+        public void DoSit(Facing? dir = null, int3? pos = null) =>
             Activity = new NpcActivity.Sit(dir, pos);
 
         public void Say(Actor? target, Content msg) =>

--- a/VelorenPort/CoreEngine/Src/Weather.cs
+++ b/VelorenPort/CoreEngine/Src/Weather.cs
@@ -85,7 +85,7 @@ namespace VelorenPort.CoreEngine
     public class WeatherGrid
     {
         public const uint ChunksPerCell = 16;
-        public const uint CellSize = ChunksPerCell * (uint)TerrainConstants.ChunkSize.x;
+        public static readonly uint CellSize = ChunksPerCell * (uint)TerrainConstants.ChunkSize.x;
 
         private readonly Grid<Weather> _weather;
 

--- a/VelorenPort/World.Tests/SimUtilTests.cs
+++ b/VelorenPort/World.Tests/SimUtilTests.cs
@@ -32,5 +32,86 @@ public class SimUtilTests
         float v = Util.CdfIrwinHall(w, s);
         Assert.True(math.abs(v - 0.5f) < 1e-4);
     }
+
+    [Fact]
+    public void GetOceans_AllOcean()
+    {
+        var size = new MapSizeLg(new int2(2, 2));
+        bool[] res = Util.GetOceans(size, _ => -1f);
+        foreach (bool b in res)
+            Assert.True(b);
+    }
+
+    [Fact]
+    public void GetOceans_InteriorLand()
+    {
+        var size = new MapSizeLg(new int2(2, 2));
+        int2 chunks = size.Chunks;
+        bool[] res = Util.GetOceans(size, idx =>
+        {
+            int2 pos = size.UniformIdxAsVec2(idx);
+            bool edge = pos.x == 0 || pos.y == 0 || pos.x == chunks.x - 1 || pos.y == chunks.y - 1;
+            return edge ? 0f : 10f;
+        });
+
+        int interiorIdx = size.Vec2AsUniformIdx(new int2(1, 1));
+        Assert.False(res[interiorIdx]);
+    }
+
+    [Fact]
+    public void Downhill_FindsLowestNeighbor()
+    {
+        var size = new MapSizeLg(new int2(1, 1));
+        float[] alt = {4f, 3f, 2f, 1f};
+        int[] dh = Util.Downhill(size, idx => alt[idx], _ => false);
+        Assert.Equal(3, dh[0]);
+        Assert.Equal(3, dh[1]);
+        Assert.Equal(3, dh[2]);
+        Assert.Equal(-1, dh[3]);
+    }
+
+    [Fact]
+    public void LocalCells_CenterHasFullNeighborhood()
+    {
+        var size = new MapSizeLg(new int2(4, 4));
+        int idx = size.Vec2AsUniformIdx(new int2(8, 8));
+        int count = Util.LocalCells(size, idx).Count();
+        Assert.Equal(49, count);
+    }
+
+    [Fact]
+    public void LocalCells_EdgeReduced()
+    {
+        var size = new MapSizeLg(new int2(4, 4));
+        int idx = size.Vec2AsUniformIdx(int2.zero);
+        int count = Util.LocalCells(size, idx).Count();
+        Assert.Equal(16, count);
+    }
+
+    [Fact]
+    public void Uphill_ReturnsUpstreamNeighbors()
+    {
+        var size = new MapSizeLg(new int2(1, 1));
+        float[] alt = {4f, 3f, 2f, 1f};
+        int[] dh = Util.Downhill(size, idx => alt[idx], _ => false);
+        var up = Util.Uphill(size, dh, 3).ToArray();
+        Assert.Contains(0, up);
+        Assert.Contains(1, up);
+        Assert.Contains(2, up);
+        Assert.Equal(3, up.Length);
+    }
+
+    [Fact]
+    public void UniformNoise_RanksValues()
+    {
+        var size = new MapSizeLg(new int2(1,1));
+        float[] vals = {4f,1f,3f,2f};
+        var (uniform, noise) = Util.UniformNoise(size, (i, _) => vals[i]);
+        Assert.Equal((1f/4f,1f), uniform[1]);
+        Assert.Equal((2f/4f,2f), uniform[3]);
+        Assert.Equal((3f/4f,3f), uniform[2]);
+        Assert.Equal((4f/4f,4f), uniform[0]);
+        Assert.Equal(4, noise.Length);
+    }
 }
 

--- a/VelorenPort/World/Src/Sim/Util.cs
+++ b/VelorenPort/World/Src/Sim/Util.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using Unity.Mathematics;
+using VelorenPort.CoreEngine;
 
 namespace VelorenPort.World.Sim
 {
@@ -60,6 +62,175 @@ namespace VelorenPort.World.Sim
             double fact = 1.0;
             for (int i = 2; i <= n; i++) fact *= i;
             return (float)(y / fact);
+        }
+
+        /// <summary>
+        /// Evaluate <paramref name="func"/> for every chunk and return a uniformly
+        /// distributed ranking of the results. Values that return null are skipped.
+        /// </summary>
+        public static ((float rank, float value)[] uniform, (int idx, float value)[] noise)
+            UniformNoise(MapSizeLg mapSizeLg, Func<int, float2, float?> func)
+        {
+            int len = mapSizeLg.ChunksLen;
+            var vals = new List<(int idx, float val)>();
+            for (int i = 0; i < len; i++)
+            {
+                float2 pos = mapSizeLg.UniformIdxAsVec2(i) * TerrainConstants.ChunkSize;
+                float? v = func(i, pos);
+                if (v.HasValue && !float.IsNaN(v.Value))
+                    vals.Add((i, v.Value));
+            }
+
+            vals.Sort((a, b) =>
+            {
+                int c = a.val.CompareTo(b.val);
+                if (c == 0) c = a.idx.CompareTo(b.idx);
+                return c;
+            });
+
+            var uniform = new (float rank, float value)[len];
+            float total = vals.Count;
+            for (int order = 0; order < vals.Count; order++)
+            {
+                var entry = vals[order];
+                uniform[entry.idx] = ((order + 1) / total, entry.val);
+            }
+
+            return (uniform, vals.ToArray());
+        }
+
+        /// <summary>
+        /// Determine which chunks of the world should be considered ocean based
+        /// on a height function. Chunks connected to the map edge with
+        /// non-positive altitude are marked as ocean.
+        /// </summary>
+        public static bool[] GetOceans(MapSizeLg mapSizeLg, Func<int, float> alt)
+        {
+            int len = mapSizeLg.ChunksLen;
+            var result = new bool[len];
+            var stack = new System.Collections.Generic.Stack<int>();
+
+            void Push(int2 pos)
+            {
+                int idx = mapSizeLg.Vec2AsUniformIdx(pos);
+                if (alt(idx) <= 0f)
+                    stack.Push(idx);
+            }
+
+            int2 size = mapSizeLg.Chunks;
+            for (int x = 0; x < size.x; x++)
+            {
+                Push(new int2(x, 0));
+                Push(new int2(x, size.y - 1));
+            }
+            for (int y = 1; y < size.y - 1; y++)
+            {
+                Push(new int2(0, y));
+                Push(new int2(size.x - 1, y));
+            }
+
+            while (stack.Count > 0)
+            {
+                int idx = stack.Pop();
+                if (result[idx])
+                    continue;
+                result[idx] = true;
+
+                int2 pos = mapSizeLg.UniformIdxAsVec2(idx);
+                foreach (var dir in WorldUtil.CARDINALS)
+                {
+                    int2 n = pos + dir;
+                    if (n.x < 0 || n.y < 0 || n.x >= size.x || n.y >= size.y)
+                        continue;
+                    int nidx = mapSizeLg.Vec2AsUniformIdx(n);
+                    if (alt(nidx) <= 0f)
+                        stack.Push(nidx);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Enumerate neighboring chunk indices for the given index using an
+        /// eight-connected neighborhood.
+        /// </summary>
+        public static System.Collections.Generic.IEnumerable<int> Neighbors(MapSizeLg mapSizeLg, int idx)
+        {
+            int2 pos = mapSizeLg.UniformIdxAsVec2(idx);
+            int2 size = mapSizeLg.Chunks;
+            foreach (var dir in WorldUtil.NEIGHBORS)
+            {
+                int2 n = pos + dir;
+                if (n.x < 0 || n.y < 0 || n.x >= size.x || n.y >= size.y)
+                    continue;
+                yield return mapSizeLg.Vec2AsUniformIdx(n);
+            }
+        }
+
+        /// <summary>
+        /// Compute the downhill map for all chunks. Values are the index of the
+        /// lowest neighboring chunk, -1 for local minima, and -2 for ocean
+        /// chunks.
+        /// </summary>
+        public static int[] Downhill(MapSizeLg mapSizeLg, Func<int, float> alt, Func<int, bool> isOcean)
+        {
+            int len = mapSizeLg.ChunksLen;
+            var result = new int[len];
+            for (int posi = 0; posi < len; posi++)
+            {
+                float nh = alt(posi);
+                if (isOcean(posi))
+                {
+                    result[posi] = -2;
+                    continue;
+                }
+
+                int best = -1;
+                float besth = nh;
+                foreach (int n in Neighbors(mapSizeLg, posi))
+                {
+                    float nbh = alt(n);
+                    if (nbh < besth)
+                    {
+                        besth = nbh;
+                        best = n;
+                    }
+                }
+                result[posi] = best;
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Iterate through all cells in a 7x7 neighbourhood around the given chunk index.
+        /// This mirrors the behavior of Rust's local_cells function.
+        /// </summary>
+        public static System.Collections.Generic.IEnumerable<int> LocalCells(MapSizeLg mapSizeLg, int idx)
+        {
+            int2 pos = mapSizeLg.UniformIdxAsVec2(idx);
+            const int gridSize = 3;
+            int gridBounds = gridSize * 2 + 1;
+            for (int i = 0; i < gridBounds * gridBounds; i++)
+            {
+                int2 p = new int2(
+                    pos.x + (i % gridBounds) - gridSize,
+                    pos.y + (i / gridBounds) - gridSize
+                );
+                if (p.x < 0 || p.y < 0 || p.x >= mapSizeLg.Chunks.x || p.y >= mapSizeLg.Chunks.y)
+                    continue;
+                yield return mapSizeLg.Vec2AsUniformIdx(p);
+            }
+        }
+
+        /// <summary>
+        /// Enumerate neighbors whose downhill target equals <paramref name="idx"/>.
+        /// </summary>
+        public static System.Collections.Generic.IEnumerable<int> Uphill(MapSizeLg mapSizeLg, int[] downhill, int idx)
+        {
+            foreach (int n in Neighbors(mapSizeLg, idx))
+                if (downhill[n] == idx)
+                    yield return n;
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement `UniformNoise` helper in simulation utilities
- expose `CellSize` as `static readonly` in `WeatherGrid`
- fix RNG ambiguity in `Dir.Random2D`
- rename simple direction enum to `Facing`
- test `UniformNoise` ranking behaviour

## Testing
- `dotnet test VelorenPort/VelorenPort.sln -c Release` *(fails: compile errors in CoreEngine)*

------
https://chatgpt.com/codex/tasks/task_e_68604aa7f7988328a5f0111f1cee0175