### PR TITLE
Add basic GroupManager

### DIFF
--- a/VelorenPort/CoreEngine.Tests/AlignmentTests.cs
+++ b/VelorenPort/CoreEngine.Tests/AlignmentTests.cs
@@ -1,0 +1,26 @@
+using VelorenPort.CoreEngine.comp;
+using VelorenPort.CoreEngine;
+using Xunit;
+
+namespace CoreEngine.Tests;
+
+public class AlignmentTests
+{
+    [Fact]
+    public void HostileTowardsWorks()
+    {
+        Alignment self = new Alignment.Enemy();
+        Alignment other = new Alignment.Npc();
+        Assert.True(self.HostileTowards(other));
+        Assert.False(other.HostileTowards(self));
+    }
+
+    [Fact]
+    public void FriendlyTowardsOwned()
+    {
+        var a = new Alignment.Owned(new Uid(1));
+        var b = new Alignment.Owned(new Uid(1));
+        Assert.True(a.FriendlyTowards(b));
+        Assert.True(b.FriendlyTowards(a));
+    }
+}

--- a/VelorenPort/CoreEngine.Tests/CharacterItemTests.cs
+++ b/VelorenPort/CoreEngine.Tests/CharacterItemTests.cs
@@ -1,0 +1,21 @@
+using VelorenPort.CoreEngine;
+using VelorenPort.CoreEngine.comp;
+using Xunit;
+
+namespace CoreEngine.Tests;
+
+public class CharacterItemTests
+{
+    [Fact]
+    public void ConstructorAssignsFields()
+    {
+        var chara = new Character(new CharacterId(1), "Hero");
+        var inv = new ReducedInventory();
+        var item = new CharacterItem(chara, Body.Humanoid, true, inv, "Valenoar");
+        Assert.Equal(chara, item.Character);
+        Assert.Equal(Body.Humanoid, item.Body);
+        Assert.True(item.Hardcore);
+        Assert.Equal(inv, item.Inventory);
+        Assert.Equal("Valenoar", item.Location);
+    }
+}

--- a/VelorenPort/CoreEngine.Tests/CharacterStateTests.cs
+++ b/VelorenPort/CoreEngine.Tests/CharacterStateTests.cs
@@ -1,0 +1,123 @@
+using VelorenPort.CoreEngine;
+using VelorenPort.CoreEngine.States;
+
+namespace CoreEngine.Tests;
+
+public class CharacterStateTests
+{
+    [Fact]
+    public void BasicMelee_IsAttackAndWielded()
+    {
+        CharacterState state = new CharacterState.BasicMelee(StageSection.Action);
+        Assert.True(state.IsAttack());
+        Assert.True(state.IsWielded());
+        Assert.Equal(StageSection.Action, state.StageSection());
+    }
+
+    [Fact]
+    public void Idle_NotAttackAndCanInteract()
+    {
+        CharacterState state = new CharacterState.Idle();
+        Assert.False(state.IsAttack());
+        Assert.True(state.CanInteract());
+        Assert.Null(state.StageSection());
+    }
+
+    [Fact]
+    public void SneakingIdle_IsStealthy()
+    {
+        CharacterState state = new CharacterState.Idle(true);
+        Assert.True(state.IsStealthy());
+    }
+
+    [Fact]
+    public void Glide_StageSectionReturned()
+    {
+        CharacterState state = new CharacterState.Glide(StageSection.Movement);
+        Assert.Equal(StageSection.Movement, state.StageSection());
+    }
+
+    [Fact]
+    public void SneakingWielding_IsStealthyAndWielded()
+    {
+        CharacterState state = new CharacterState.Wielding(true);
+        Assert.True(state.IsStealthy());
+        Assert.True(state.IsWielded());
+        Assert.True(state.CanInteract());
+    }
+
+    [Fact]
+    public void DashMelee_AttackAndWielded()
+    {
+        CharacterState state = new CharacterState.DashMelee(StageSection.Charge);
+        Assert.True(state.IsAttack());
+        Assert.True(state.IsWielded());
+        Assert.Equal(StageSection.Charge, state.StageSection());
+    }
+
+    [Fact]
+    public void Wallrun_WieldedFromData()
+    {
+        CharacterState state = new CharacterState.Wallrun(StageSection.Movement, true);
+        Assert.True(state.IsWielded());
+        Assert.Equal(StageSection.Movement, state.StageSection());
+    }
+
+    [Fact]
+    public void UseItem_NotAttackButWielded()
+    {
+        CharacterState state = new CharacterState.UseItem(StageSection.Action, true);
+        Assert.False(state.IsAttack());
+        Assert.True(state.IsWielded());
+        Assert.Equal(StageSection.Action, state.StageSection());
+    }
+}
+
+    [Fact]
+    public void ShouldFollowLook_ForBoostAndAttack()
+    {
+        CharacterState state = new CharacterState.Boost(StageSection.Movement);
+        Assert.True(state.ShouldFollowLook());
+
+        state = new CharacterState.BasicRanged(StageSection.Action);
+        Assert.True(state.ShouldFollowLook());
+    }
+
+    [Fact]
+    public void IsAimedAndUsingHands()
+    {
+        CharacterState state = new CharacterState.BasicRanged(StageSection.Action);
+        Assert.True(state.IsAimed());
+
+        state = new CharacterState.Talk();
+        Assert.True(state.IsUsingHands());
+    }
+
+    [Fact]
+    public void Roll_Movement_IsDodge()
+    {
+        CharacterState state = new CharacterState.Roll(StageSection.Movement, false, false);
+        Assert.True(state.IsDodge());
+    }
+
+    [Fact]
+    public void SpecificMovementStates()
+    {
+        CharacterState state = new CharacterState.Glide(StageSection.Action);
+        Assert.True(state.IsGlide());
+
+        state = new CharacterState.Skate(StageSection.Action);
+        Assert.True(state.IsSkate());
+
+        state = new CharacterState.Music(StageSection.Action);
+        Assert.True(state.IsMusic());
+    }
+
+    [Fact]
+    public void AttackFilters_AppliesCorrectly()
+    {
+        AttackFilters filters = new AttackFilters { Melee = true, Projectiles = false };
+        Assert.True(filters.Applies(AttackSource.Melee));
+        Assert.False(filters.Applies(AttackSource.Projectile));
+    }
+}

--- a/VelorenPort/CoreEngine.Tests/DynaUnionizerTests.cs
+++ b/VelorenPort/CoreEngine.Tests/DynaUnionizerTests.cs
@@ -1,0 +1,42 @@
+using Unity.Mathematics;
+using VelorenPort.CoreEngine;
+using VelorenPort.CoreEngine.figure;
+using Xunit;
+
+namespace CoreEngine.Tests;
+
+public class DynaUnionizerTests
+{
+    private static bool Filled(MatCell c) => c.IsFilled;
+    private static MatCell Empty() => MatCell.None;
+
+    [Fact]
+    public void UnifyMergesVolumesAndOffsets()
+    {
+        var a = Dyna<MatCell, object>.Filled(new int3(1,1,1), MatCell.FromMaterial(Material.Skin), new object());
+        var b = Dyna<MatCell, object>.Filled(new int3(1,1,1), MatCell.FromMaterial(Material.Hair), new object());
+        var union = new DynaUnionizer<MatCell>(Filled, Empty)
+            .Add(a, int3.zero)
+            .Add(b, new int3(1,0,0));
+        var (vol, origin) = union.Unify();
+        Assert.Equal(new int3(0,0,0), origin);
+        Assert.Equal(new int3(2,1,1), vol.Size);
+        Assert.Equal(Material.Skin, vol.Get(new int3(0,0,0)).Material);
+        Assert.Equal(Material.Hair, vol.Get(new int3(1,0,0)).Material);
+    }
+
+    [Fact]
+    public void UnifyHandlesNegativeOffsets()
+    {
+        var a = Dyna<MatCell, object>.Filled(new int3(1,1,1), MatCell.FromMaterial(Material.Skin), new object());
+        var b = Dyna<MatCell, object>.Filled(new int3(1,1,1), MatCell.FromMaterial(Material.Hair), new object());
+        var union = new DynaUnionizer<MatCell>(Filled, Empty)
+            .Add(a, new int3(-1,0,0))
+            .Add(b, int3.zero);
+        var (vol, origin) = union.Unify();
+        Assert.Equal(new int3(1,0,0), origin);
+        Assert.Equal(new int3(2,1,1), vol.Size);
+        Assert.Equal(Material.Skin, vol.Get(new int3(0,0,0)).Material);
+        Assert.Equal(Material.Hair, vol.Get(new int3(1,0,0)).Material);
+    }
+}

--- a/VelorenPort/CoreEngine.Tests/ForcedMovementTests.cs
+++ b/VelorenPort/CoreEngine.Tests/ForcedMovementTests.cs
@@ -1,0 +1,30 @@
+using Unity.Mathematics;
+using VelorenPort.CoreEngine.States;
+
+namespace CoreEngine.Tests;
+
+public class ForcedMovementTests
+{
+    [Fact]
+    public void Multiplication_ScalesValues()
+    {
+        ForcedMovement fm = new ForcedMovement.Leap(1f, 2f, 0.5f, MovementDirection.Look);
+        var scaled = fm.Mul(2f) as ForcedMovement.Leap;
+        Assert.NotNull(scaled);
+        Assert.Equal(2f, scaled!.Vertical);
+        Assert.Equal(4f, scaled.Forward);
+        Assert.Equal(0.5f, scaled.Progress);
+        Assert.Equal(MovementDirection.Look, scaled.Direction);
+    }
+
+    [Fact]
+    public void Get2dDir_NormalizesVectors()
+    {
+        float2 look = new float2(2, 0);
+        float2 move = new float2(0, 3);
+        float2 res1 = MovementDirection.Look.Get2dDir(look, move);
+        float2 res2 = MovementDirection.Move.Get2dDir(look, move);
+        Assert.Equal(new float2(1, 0), res1);
+        Assert.Equal(new float2(0, 1), res2);
+    }
+}

--- a/VelorenPort/CoreEngine.Tests/GroupManagerTests.cs
+++ b/VelorenPort/CoreEngine.Tests/GroupManagerTests.cs
@@ -1,0 +1,41 @@
+using Xunit;
+using VelorenPort.CoreEngine.comp;
+using VelorenPort.CoreEngine;
+
+namespace CoreEngine.Tests;
+
+public class GroupManagerTests
+{
+    [Fact]
+    public void JoinGroup_CreatesGroupAndAddsMembers()
+    {
+        var manager = new GroupManager();
+        Uid leader = new(1);
+        Uid member = new(2);
+
+        Group group = manager.JoinGroup(leader, member);
+
+        Assert.True(manager.IsLeader(leader));
+        Assert.Equal(group, manager.GetGroup(leader));
+        Assert.Equal(group, manager.GetGroup(member));
+        Assert.Equal(2, manager.GetInfo(group)!.MemberCount);
+    }
+
+    [Fact]
+    public void LeaveGroup_RemovesAndDeletesEmptyGroup()
+    {
+        var manager = new GroupManager();
+        Uid leader = new(1);
+        Uid member = new(2);
+
+        Group group = manager.JoinGroup(leader, member);
+        manager.LeaveGroup(member);
+        Assert.Null(manager.GetGroup(member));
+        Assert.Equal(1, manager.GetInfo(group)!.MemberCount);
+
+        manager.LeaveGroup(leader);
+        Assert.Null(manager.GetGroup(leader));
+        Assert.Null(manager.GetInfo(group));
+    }
+}
+

--- a/VelorenPort/CoreEngine.Tests/VolGrid2dTests.cs
+++ b/VelorenPort/CoreEngine.Tests/VolGrid2dTests.cs
@@ -1,0 +1,22 @@
+using Unity.Mathematics;
+using VelorenPort.CoreEngine;
+
+namespace CoreEngine.Tests;
+
+public class VolGrid2dTests
+{
+    [Fact]
+    public void SetAndGet_ReturnsStoredValue()
+    {
+        var grid = new VolGrid2d<int>(new int2(2,2), new int3(4,4,1), -1);
+        grid.Set(new int3(5,3,0), 42);
+        Assert.Equal(42, grid.Get(new int3(5,3,0)));
+    }
+
+    [Fact]
+    public void MissingChunk_ReturnsDefault()
+    {
+        var grid = new VolGrid2d<int>(new int2(1,1), new int3(4,4,1), -1);
+        Assert.Equal(-1, grid.Get(new int3(2,2,0)));
+    }
+}

--- a/VelorenPort/CoreEngine.Tests/VolGrid3dTests.cs
+++ b/VelorenPort/CoreEngine.Tests/VolGrid3dTests.cs
@@ -1,0 +1,22 @@
+using Unity.Mathematics;
+using VelorenPort.CoreEngine;
+
+namespace CoreEngine.Tests;
+
+public class VolGrid3dTests
+{
+    [Fact]
+    public void SetAndGet_ReturnsStoredValue()
+    {
+        var grid = new VolGrid3d<int>(new int3(4,4,4), -1);
+        grid.Set(new int3(5,3,2), 99);
+        Assert.Equal(99, grid.Get(new int3(5,3,2)));
+    }
+
+    [Fact]
+    public void MissingChunk_ReturnsDefault()
+    {
+        var grid = new VolGrid3d<int>(new int3(4,4,4), -1);
+        Assert.Equal(-1, grid.Get(new int3(8,8,8)));
+    }
+}

--- a/VelorenPort/CoreEngine/MissingFeatures.md
+++ b/VelorenPort/CoreEngine/MissingFeatures.md
@@ -3,12 +3,22 @@
 Este archivo detalla los módulos del crate `common` que todavía no tienen equivalente en la versión C#.
 
 - **ECS y sistema de estados**: falta portar `ecs`, `state` y `systems`, base de la arquitectura en Rust.
-- **`states` de combate y movimiento**: el submódulo completo sigue ausente.
+- **`states` de combate y movimiento**: se añadieron muchas variantes de
+  `CharacterState` junto con `AttackSource`, `AttackFilters` y la estructura
+  `ForcedMovement`, pero aún faltan lógicas avanzadas y transiciones complejas.
 - **Utilidades de terreno y volúmenes** (`terrain`, `volumes`): sólo se trasladaron constantes, sin el manejo completo de biomas y bloques.
 - **Componentes (`comp`)**: la mayoría de componentes no se han implementado; existen únicamente algunos stubs (`BuffKind`, `Player`, etc.).
+- Se añadieron `Alignment`, `Group` y `CharacterItem` para reflejar hostilidad y
+  listas de personajes, y ahora existe un `GroupManager` básico para crear y
+  abandonar grupos, aunque faltan notificaciones avanzadas y soporte de
+  mascotas.
 - **Funciones de `util`**: quedan por migrar varios helpers de proyecciones, compresión y colores avanzados.
-- **Submódulos adicionales**: `slowjob`, `store`, `trade`, `figure` y `bin` permanecen sin portar.
+- **Submódulos adicionales**: se añadió `SlowJobPool` y se portaron contenedores
+  `Store` y `Trade` con funcionalidades básicas. El módulo `figure` ahora
+  incluye `MatCell` y `DynaUnionizer`, aunque faltan herramientas avanzadas y
+  el submódulo `bin` continúa pendiente.
 - **Sistema de clima**: la implementación actual de `weather` es mínima comparada con la lógica de Rust.
+- Se incluyó un contenedor `VolGrid3d` para volúmenes 3D básico.
 - **Cobertura de pruebas**: aún no hay pruebas unitarias equivalentes para buena parte de estos módulos.
 
 Se continuará importando funcionalidad a medida que sea necesaria para el resto del proyecto.

--- a/VelorenPort/CoreEngine/README.md
+++ b/VelorenPort/CoreEngine/README.md
@@ -40,6 +40,8 @@ Contiene los crates bajo `common` que agrupan la lógica compartida: ECS, defini
   contenedor de tamaño variable para voxeles con metadatos e implementación
   completa de `IWriteVol` y `ISizedVol`, con helpers como `Filled`, `FromFunc`,
   `Fill`, `Positions` y enumeradores de celdas.
+- El módulo `figure` incluye `MatCell` y el combinador `DynaUnionizer` para
+  construir segmentos complejos a partir de partes.
 - `VersionInfo` genera cadenas de versión leyendo variables de entorno de Git.
 - `Weather` incluye ahora cuadrículas interpoladas y conversión comprimida para
   sincronización eficiente.

--- a/VelorenPort/CoreEngine/Src/AttackFilters.cs
+++ b/VelorenPort/CoreEngine/Src/AttackFilters.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace VelorenPort.CoreEngine;
+
+/// <summary>
+/// Flags specifying which kinds of attacks are affected. Used for roll
+/// immunities and blocking logic.
+/// </summary>
+[Serializable]
+public struct AttackFilters
+{
+    public bool Melee;
+    public bool Projectiles;
+    public bool Beams;
+    public bool GroundShockwaves;
+    public bool AirShockwaves;
+    public bool Explosions;
+
+    /// <summary>Return true if the filter includes the given attack source.</summary>
+    public bool Applies(AttackSource attack) => attack switch
+    {
+        AttackSource.Melee => Melee,
+        AttackSource.Projectile => Projectiles,
+        AttackSource.Beam => Beams,
+        AttackSource.GroundShockwave => GroundShockwaves,
+        AttackSource.AirShockwave => AirShockwaves,
+        AttackSource.UndodgeableShockwave => false,
+        AttackSource.Explosion => Explosions,
+        _ => false
+    };
+}

--- a/VelorenPort/CoreEngine/Src/AttackSource.cs
+++ b/VelorenPort/CoreEngine/Src/AttackSource.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace VelorenPort.CoreEngine;
+
+/// <summary>
+/// Source of an attack used for determining blocking and parry logic.
+/// Mirrors the Rust <c>AttackSource</c> enum.
+/// </summary>
+[Serializable]
+public enum AttackSource
+{
+    Melee,
+    Projectile,
+    Beam,
+    GroundShockwave,
+    AirShockwave,
+    UndodgeableShockwave,
+    Explosion,
+}

--- a/VelorenPort/CoreEngine/Src/Character.cs
+++ b/VelorenPort/CoreEngine/Src/Character.cs
@@ -19,6 +19,29 @@ namespace VelorenPort.CoreEngine
     }
 
     /// <summary>
+    /// Data needed to present a character entry in a selection list.
+    /// Mirrors <c>CharacterItem</c> in the Rust code.
+    /// </summary>
+    [Serializable]
+    public class CharacterItem
+    {
+        public Character Character { get; set; }
+        public comp.Body Body { get; set; }
+        public bool Hardcore { get; set; }
+        public ReducedInventory Inventory { get; set; }
+        public string? Location { get; set; }
+
+        public CharacterItem(Character character, comp.Body body, bool hardcore, ReducedInventory inventory, string? location)
+        {
+            Character = character;
+            Body = body;
+            Hardcore = hardcore;
+            Inventory = inventory;
+            Location = location;
+        }
+    }
+
+    /// <summary>
     /// Character related constants mirrored from the Rust code.
     /// </summary>
     public static class CharacterConstants

--- a/VelorenPort/CoreEngine/Src/VolGrid2d.cs
+++ b/VelorenPort/CoreEngine/Src/VolGrid2d.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using Unity.Mathematics;
+
+namespace VelorenPort.CoreEngine;
+
+/// <summary>
+/// Simplified 2D grid of volume chunks. This mirrors a fraction of
+/// `common::volumes::vol_grid_2d` from the Rust codebase but is reduced
+/// to the basic storage and access logic required for early world generation.
+/// </summary>
+[Serializable]
+public class VolGrid2d<T> where T : struct
+{
+    private readonly int2 _mapSize;
+    private readonly int3 _chunkSize;
+    private readonly Dictionary<int2, Vol<T>> _chunks;
+    private readonly T _default;
+
+    private struct Int2Comparer : IEqualityComparer<int2>
+    {
+        public bool Equals(int2 a, int2 b) => a.x == b.x && a.y == b.y;
+        public int GetHashCode(int2 v) => HashCode.Combine(v.x, v.y);
+    }
+
+    public VolGrid2d(int2 mapSize, int3 chunkSize, T defaultValue)
+    {
+        _mapSize = mapSize;
+        _chunkSize = chunkSize;
+        _default = defaultValue;
+        _chunks = new Dictionary<int2, Vol<T>>(new Int2Comparer());
+    }
+
+    public int2 MapSize => _mapSize;
+    public int3 ChunkSize => _chunkSize;
+
+    public static int2 ChunkKey(int3 pos, int3 chunkSize)
+        => new int2(pos.x / chunkSize.x, pos.y / chunkSize.y);
+
+    public static int3 KeyChunk(int2 key, int3 chunkSize)
+        => new int3(key.x * chunkSize.x, key.y * chunkSize.y, 0);
+
+    public static int3 ChunkOffs(int3 pos, int3 chunkSize)
+        => new int3(math.abs(pos.x % chunkSize.x), math.abs(pos.y % chunkSize.y), pos.z);
+
+    private Vol<T> GetOrCreateChunk(int2 key)
+    {
+        if (!_chunks.TryGetValue(key, out var chunk))
+        {
+            chunk = new Vol<T>(_chunkSize);
+            chunk.Fill(_default);
+            _chunks[key] = chunk;
+        }
+        return chunk;
+    }
+
+    public bool TryGetChunk(int2 key, out Vol<T> chunk) => _chunks.TryGetValue(key, out chunk);
+
+    public T Get(int3 pos)
+    {
+        var key = ChunkKey(pos, _chunkSize);
+        return TryGetChunk(key, out var chunk)
+            ? chunk.Get(ChunkOffs(pos, _chunkSize))
+            : _default;
+    }
+
+    public void Set(int3 pos, T value)
+    {
+        var key = ChunkKey(pos, _chunkSize);
+        var chunk = GetOrCreateChunk(key);
+        chunk.Set(ChunkOffs(pos, _chunkSize), value);
+    }
+}

--- a/VelorenPort/CoreEngine/Src/VolGrid3d.cs
+++ b/VelorenPort/CoreEngine/Src/VolGrid3d.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using Unity.Mathematics;
+
+namespace VelorenPort.CoreEngine;
+
+/// <summary>
+/// Simplified 3D grid of volume chunks. Mirrors a subset of
+/// common::volumes::vol_grid_3d from the Rust codebase.
+/// </summary>
+[Serializable]
+public class VolGrid3d<T> where T : struct
+{
+    private readonly int3 _chunkSize;
+    private readonly Dictionary<int3, Vol<T>> _chunks;
+    private readonly T _default;
+
+    private struct Int3Comparer : IEqualityComparer<int3>
+    {
+        public bool Equals(int3 a, int3 b) => a.x == b.x && a.y == b.y && a.z == b.z;
+        public int GetHashCode(int3 v) => HashCode.Combine(v.x, v.y, v.z);
+    }
+
+    public VolGrid3d(int3 chunkSize, T defaultValue)
+    {
+        _chunkSize = chunkSize;
+        _default = defaultValue;
+        _chunks = new Dictionary<int3, Vol<T>>(new Int3Comparer());
+    }
+
+    public int3 ChunkSize => _chunkSize;
+
+    public static int3 ChunkKey(int3 pos, int3 chunkSize)
+        => new int3(pos.x / chunkSize.x, pos.y / chunkSize.y, pos.z / chunkSize.z);
+
+    public static int3 ChunkOffs(int3 pos, int3 chunkSize)
+        => new int3(math.abs(pos.x % chunkSize.x), math.abs(pos.y % chunkSize.y), math.abs(pos.z % chunkSize.z));
+
+    private Vol<T> GetOrCreateChunk(int3 key)
+    {
+        if (!_chunks.TryGetValue(key, out var chunk))
+        {
+            chunk = new Vol<T>(_chunkSize);
+            chunk.Fill(_default);
+            _chunks[key] = chunk;
+        }
+        return chunk;
+    }
+
+    public bool TryGetChunk(int3 key, out Vol<T> chunk) => _chunks.TryGetValue(key, out chunk);
+
+    public T Get(int3 pos)
+    {
+        var key = ChunkKey(pos, _chunkSize);
+        return TryGetChunk(key, out var chunk)
+            ? chunk.Get(ChunkOffs(pos, _chunkSize))
+            : _default;
+    }
+
+    public void Set(int3 pos, T value)
+    {
+        var key = ChunkKey(pos, _chunkSize);
+        var chunk = GetOrCreateChunk(key);
+        chunk.Set(ChunkOffs(pos, _chunkSize), value);
+    }
+}

--- a/VelorenPort/CoreEngine/Src/comp/Alignment.cs
+++ b/VelorenPort/CoreEngine/Src/comp/Alignment.cs
@@ -1,0 +1,70 @@
+using System;
+
+namespace VelorenPort.CoreEngine.comp;
+
+/// <summary>
+/// Alignment of an entity used for hostility checks.
+/// Mirrors the Rust enum with an Owned variant carrying a Uid.
+/// </summary>
+[Serializable]
+public abstract record Alignment
+{
+    public sealed record Wild : Alignment;
+    public sealed record Enemy : Alignment;
+    public sealed record Npc : Alignment;
+    public sealed record Tame : Alignment;
+    public sealed record Owned(Uid Owner) : Alignment;
+    public sealed record Passive : Alignment;
+}
+
+public static class AlignmentExtensions
+{
+    public static bool HostileTowards(this Alignment self, Alignment other) => (self, other) switch
+    {
+        (Alignment.Passive, _) => false,
+        (_, Alignment.Passive) => false,
+        (Alignment.Enemy, Alignment.Enemy) => false,
+        (Alignment.Enemy, Alignment.Wild) => false,
+        (Alignment.Wild, Alignment.Enemy) => false,
+        (Alignment.Wild, Alignment.Wild) => false,
+        (Alignment.Npc, Alignment.Wild) => false,
+        (Alignment.Npc, Alignment.Enemy) => true,
+        (_, Alignment.Enemy) => true,
+        (Alignment.Enemy, _) => true,
+        _ => false,
+    };
+
+    public static bool PassiveTowards(this Alignment self, Alignment other) => (self, other) switch
+    {
+        (Alignment.Enemy, Alignment.Enemy) => true,
+        (Alignment.Owned a, Alignment.Owned b) when a.Owner.Equals(b.Owner) => true,
+        (Alignment.Npc, Alignment.Npc) => true,
+        (Alignment.Npc, Alignment.Tame) => true,
+        (Alignment.Enemy, Alignment.Wild) => true,
+        (Alignment.Wild, Alignment.Enemy) => true,
+        (Alignment.Tame, Alignment.Npc) => true,
+        (Alignment.Tame, Alignment.Tame) => true,
+        (_, Alignment.Passive) => true,
+        _ => false,
+    };
+
+    public static bool FriendlyTowards(this Alignment self, Alignment other) => (self, other) switch
+    {
+        (Alignment.Enemy, Alignment.Enemy) => true,
+        (Alignment.Owned a, Alignment.Owned b) when a.Owner.Equals(b.Owner) => true,
+        (Alignment.Npc, Alignment.Npc) => true,
+        (Alignment.Npc, Alignment.Tame) => true,
+        (Alignment.Tame, Alignment.Npc) => true,
+        (Alignment.Tame, Alignment.Tame) => true,
+        (_, Alignment.Passive) => true,
+        _ => false,
+    };
+
+    public static Group? DefaultGroup(this Alignment self) => self switch
+    {
+        Alignment.Enemy => Group.Enemy,
+        Alignment.Npc => Group.Npc,
+        Alignment.Tame => Group.Npc,
+        _ => null,
+    };
+}

--- a/VelorenPort/CoreEngine/Src/comp/Group.cs
+++ b/VelorenPort/CoreEngine/Src/comp/Group.cs
@@ -1,23 +1,23 @@
 using System;
 
-namespace VelorenPort.CoreEngine.comp {
-    /// <summary>
-    /// Simple group identifier. Mirrors `Group` from `common/src/comp/group.rs`.
-    /// </summary>
-    [Serializable]
-    public readonly struct Group : IEquatable<Group> {
-        public readonly uint Value;
-        public Group(uint value) { Value = value; }
+namespace VelorenPort.CoreEngine.comp;
 
-        public bool Equals(Group other) => Value == other.Value;
-        public override bool Equals(object? obj) => obj is Group g && Equals(g);
-        public override int GetHashCode() => Value.GetHashCode();
-        public override string ToString() => Value.ToString();
+/// <summary>
+/// Primitive group identifier mirroring <c>Group</c> from Rust.
+/// The values <see cref="Enemy"/> and <see cref="Npc"/> correspond to
+/// default groups used by <see cref="AlignmentExtensions.DefaultGroup"/>.
+/// </summary>
+[Serializable]
+public readonly struct Group : IEquatable<Group>
+{
+    public readonly uint Value;
+    public Group(uint value) => Value = value;
 
-        public static readonly Group ENEMY = new(uint.MaxValue);
-        public static readonly Group NPC = new(uint.MaxValue - 1);
+    public bool Equals(Group other) => Value == other.Value;
+    public override bool Equals(object obj) => obj is Group other && Equals(other);
+    public override int GetHashCode() => (int)Value;
+    public override string ToString() => $"Group({Value})";
 
-        public static implicit operator uint(Group g) => g.Value;
-        public static explicit operator Group(uint v) => new(v);
-    }
+    public static readonly Group Enemy = new(uint.MaxValue);
+    public static readonly Group Npc = new(uint.MaxValue - 1);
 }

--- a/VelorenPort/CoreEngine/Src/comp/GroupManager.cs
+++ b/VelorenPort/CoreEngine/Src/comp/GroupManager.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+
+namespace VelorenPort.CoreEngine.comp;
+
+/// <summary>
+/// Basic group manager used to create simple party structures.
+/// Only supports joining and leaving groups without pets or
+/// advanced notifications.
+/// </summary>
+public class GroupManager
+{
+    private readonly Dictionary<Group, GroupInfo> _groups = new();
+    private readonly Dictionary<Uid, Group> _membership = new();
+    private uint _nextId;
+
+    /// <summary>Retrieve information about a group if it exists.</summary>
+    public GroupInfo? GetInfo(Group group)
+        => _groups.TryGetValue(group, out var info) ? info : null;
+
+    /// <summary>Return the group an entity currently belongs to, if any.</summary>
+    public Group? GetGroup(Uid entity)
+        => _membership.TryGetValue(entity, out var g) ? g : (Group?)null;
+
+    /// <summary>Return true if the given entity is leader of its group.</summary>
+    public bool IsLeader(Uid entity)
+    {
+        if (_membership.TryGetValue(entity, out var g) &&
+            _groups.TryGetValue(g, out var info))
+        {
+            return info.Leader.Equals(entity);
+        }
+        return false;
+    }
+
+    /// <summary>Add <paramref name="member"/> to the group led by <paramref name="leader"/>.</summary>
+    public Group JoinGroup(Uid leader, Uid member)
+    {
+        if (!_membership.TryGetValue(leader, out var group))
+        {
+            group = CreateGroup(leader);
+            _membership[leader] = group;
+        }
+
+        _membership[member] = group;
+        _groups[group].MemberCount++;
+        return group;
+    }
+
+    /// <summary>Remove <paramref name="member"/> from its current group.</summary>
+    public void LeaveGroup(Uid member)
+    {
+        if (!_membership.TryGetValue(member, out var group))
+            return;
+
+        if (_groups.TryGetValue(group, out var info))
+        {
+            info.MemberCount = Math.Max(0, info.MemberCount - 1);
+            if (info.MemberCount == 0)
+            {
+                // remove empty group
+                _groups.Remove(group);
+            }
+        }
+        _membership.Remove(member);
+    }
+
+    private Group CreateGroup(Uid leader)
+    {
+        var id = new Group(_nextId++);
+        _groups[id] = new GroupInfo { Leader = leader, MemberCount = 1 };
+        return id;
+    }
+}
+
+/// <summary>Lightweight information about a group.</summary>
+public class GroupInfo
+{
+    public Uid Leader { get; set; }
+    public int MemberCount { get; set; }
+}
+

--- a/VelorenPort/CoreEngine/Src/figure/DynaUnionizer.cs
+++ b/VelorenPort/CoreEngine/Src/figure/DynaUnionizer.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using Unity.Mathematics;
+
+namespace VelorenPort.CoreEngine.figure
+{
+    /// <summary>
+    /// Helper to combine multiple <see cref="Dyna{V,M}"/> volumes into a single
+    /// larger volume. This mirrors the `DynaUnionizer` struct from the Rust
+    /// project but is implemented in a simplified form.
+    /// </summary>
+    /// <typeparam name="V">Voxel type</typeparam>
+    public class DynaUnionizer<V>
+    {
+        private readonly List<(Dyna<V, object> vol, int3 offset)> _vols = new();
+        private readonly Func<V, bool> _isFilled;
+        private readonly Func<V> _defaultNonFilled;
+
+        public DynaUnionizer(Func<V, bool> isFilled, Func<V> defaultNonFilled)
+        {
+            _isFilled = isFilled;
+            _defaultNonFilled = defaultNonFilled;
+        }
+
+        /// <summary>Add a new volume at the given offset.</summary>
+        public DynaUnionizer<V> Add(Dyna<V, object> vol, int3 offset)
+        {
+            _vols.Add((vol, offset));
+            return this;
+        }
+
+        /// <summary>Add a volume only if <paramref name="maybe"/> has a value.</summary>
+        public DynaUnionizer<V> MaybeAdd((Dyna<V, object> vol, int3 offset)? maybe)
+        {
+            if (maybe is (var v, var off))
+                Add(v, off);
+            return this;
+        }
+
+        /// <summary>Combine all volumes into one using identity mapping.</summary>
+        public (Dyna<V, object> vol, int3 origin) Unify() => UnifyWith(v => v);
+
+        /// <summary>
+        /// Combine all volumes applying <paramref name="map"/> to each voxel.
+        /// Returns the unified volume and the origin used for translation.
+        /// </summary>
+        public (Dyna<V, object> vol, int3 origin) UnifyWith(Func<V, V> map)
+        {
+            if (_vols.Count == 0)
+            {
+                return (Dyna<V, object>.Filled(int3.zero, _defaultNonFilled(), new object()), int3.zero);
+            }
+
+            int3 min = _vols[0].offset;
+            int3 max = _vols[0].offset + _vols[0].vol.Size;
+            for (int i = 1; i < _vols.Count; i++)
+            {
+                var off = _vols[i].offset;
+                var size = _vols[i].vol.Size;
+                min = math.min(min, off);
+                max = math.max(max, off + size);
+            }
+
+            var newSize = max - min;
+            var combined = Dyna<V, object>.Filled(newSize, _defaultNonFilled(), new object());
+            var origin = -min;
+            foreach (var (vol, off) in _vols)
+            {
+                foreach (var (pos, vox) in vol.Cells())
+                {
+                    if (_isFilled(vox))
+                    {
+                        combined.Set(origin + off + pos, map(vox));
+                    }
+                }
+            }
+
+            return (combined, origin);
+        }
+    }
+}

--- a/VelorenPort/CoreEngine/Src/states/CharacterState.cs
+++ b/VelorenPort/CoreEngine/Src/states/CharacterState.cs
@@ -1,0 +1,265 @@
+using System;
+
+namespace VelorenPort.CoreEngine.States;
+
+/// <summary>
+/// Simplified representation of character states used during gameplay.
+/// This only covers a small subset of the Rust implementation and is
+/// intended as a starting point for the full port.
+/// </summary>
+[Serializable]
+public abstract record CharacterState
+{
+    // Idle state, optionally sneaking.
+    public sealed record Idle(bool IsSneaking = false) : CharacterState;
+    public sealed record Crawl : CharacterState;
+    public sealed record Climb(StageSection Stage, bool WasWielded) : CharacterState;
+    public sealed record Sit : CharacterState;
+    public sealed record Dance : CharacterState;
+    public sealed record Talk : CharacterState;
+    public sealed record Glide(StageSection Stage) : CharacterState;
+    public sealed record GlideWield(StageSection Stage) : CharacterState;
+    public sealed record Wielding(bool IsSneaking) : CharacterState;
+    public sealed record BasicBlock(StageSection Stage) : CharacterState;
+    public sealed record Equipping : CharacterState;
+    public sealed record BasicMelee(StageSection Stage) : CharacterState;
+    public sealed record BasicRanged(StageSection Stage) : CharacterState;
+    public sealed record Throw(StageSection Stage) : CharacterState;
+    public sealed record Roll(StageSection Stage, bool WasWielded, bool IsSneaking) : CharacterState;
+    public sealed record Stunned(StageSection Stage, bool WasWielded) : CharacterState;
+    public sealed record Shockwave(StageSection Stage) : CharacterState;
+    public sealed record BasicBeam(StageSection Stage) : CharacterState;
+    public sealed record BasicAura(StageSection Stage) : CharacterState;
+    public sealed record StaticAura(StageSection Stage) : CharacterState;
+    public sealed record Blink(StageSection Stage) : CharacterState;
+    public sealed record BasicSummon(StageSection Stage) : CharacterState;
+    public sealed record SelfBuff(StageSection Stage) : CharacterState;
+    public sealed record Boost(StageSection Stage) : CharacterState;
+    public sealed record DashMelee(StageSection Stage) : CharacterState;
+    public sealed record ComboMelee2(StageSection Stage) : CharacterState;
+    public sealed record LeapMelee(StageSection Stage) : CharacterState;
+    public sealed record LeapShockwave(StageSection Stage) : CharacterState;
+    public sealed record ChargedRanged(StageSection Stage) : CharacterState;
+    public sealed record ChargedMelee(StageSection Stage) : CharacterState;
+    public sealed record RepeaterRanged(StageSection Stage) : CharacterState;
+    public sealed record SpriteSummon(StageSection Stage) : CharacterState;
+    public sealed record UseItem(StageSection Stage, bool WasWielded) : CharacterState;
+    public sealed record Interact(StageSection Stage, bool WasWielded) : CharacterState;
+    public sealed record Wallrun(StageSection Stage, bool WasWielded) : CharacterState;
+    public sealed record Skate(StageSection Stage) : CharacterState;
+    public sealed record Music(StageSection Stage) : CharacterState;
+    public sealed record FinisherMelee(StageSection Stage) : CharacterState;
+    public sealed record DiveMelee(StageSection Stage) : CharacterState;
+    public sealed record RiposteMelee(StageSection Stage) : CharacterState;
+    public sealed record RapidMelee(StageSection Stage) : CharacterState;
+    public sealed record Transform(StageSection Stage) : CharacterState;
+    public sealed record RegrowHead(StageSection Stage) : CharacterState;
+}
+
+public static class CharacterStateExtensions
+{
+    /// <summary>Returns true if the state represents an attack animation.</summary>
+    public static bool IsAttack(this CharacterState state) => state switch
+    {
+        CharacterState.BasicMelee => true,
+        CharacterState.BasicRanged => true,
+        CharacterState.DashMelee => true,
+        CharacterState.ComboMelee2 => true,
+        CharacterState.LeapMelee => true,
+        CharacterState.LeapShockwave => true,
+        CharacterState.ChargedMelee => true,
+        CharacterState.ChargedRanged => true,
+        CharacterState.RepeaterRanged => true,
+        CharacterState.Throw => true,
+        CharacterState.Shockwave => true,
+        CharacterState.BasicBeam => true,
+        CharacterState.BasicAura => true,
+        CharacterState.StaticAura => true,
+        CharacterState.Blink => true,
+        CharacterState.BasicSummon => true,
+        CharacterState.SpriteSummon => true,
+        CharacterState.SelfBuff => true,
+        CharacterState.FinisherMelee => true,
+        CharacterState.DiveMelee => true,
+        CharacterState.RiposteMelee => true,
+        CharacterState.RapidMelee => true,
+        _ => false
+    };
+
+    /// <summary>Returns true if the entity was wielding a weapon in this state.</summary>
+    public static bool IsWielded(this CharacterState state) => state switch
+    {
+        CharacterState.Wielding => true,
+        CharacterState.BasicMelee => true,
+        CharacterState.BasicRanged => true,
+        CharacterState.DashMelee => true,
+        CharacterState.ComboMelee2 => true,
+        CharacterState.LeapMelee => true,
+        CharacterState.LeapShockwave => true,
+        CharacterState.ChargedMelee => true,
+        CharacterState.ChargedRanged => true,
+        CharacterState.RepeaterRanged => true,
+        CharacterState.Throw => true,
+        CharacterState.BasicBlock => true,
+        CharacterState.Shockwave => true,
+        CharacterState.BasicBeam => true,
+        CharacterState.BasicAura => true,
+        CharacterState.StaticAura => true,
+        CharacterState.Blink => true,
+        CharacterState.BasicSummon => true,
+        CharacterState.SpriteSummon => true,
+        CharacterState.SelfBuff => true,
+        CharacterState.FinisherMelee => true,
+        CharacterState.DiveMelee => true,
+        CharacterState.RiposteMelee => true,
+        CharacterState.RapidMelee => true,
+        CharacterState.Music => true,
+        CharacterState.Roll { WasWielded: true } => true,
+        CharacterState.Climb { WasWielded: true } => true,
+        CharacterState.Stunned { WasWielded: true } => true,
+        CharacterState.Wallrun { WasWielded: true } => true,
+        CharacterState.UseItem { WasWielded: true } => true,
+        CharacterState.Interact { WasWielded: true } => true,
+        _ => false
+    };
+
+    /// <summary>Whether the entity can interact with objects while in this state.</summary>
+    public static bool CanInteract(this CharacterState state) => state switch
+    {
+        CharacterState.Idle => true,
+        CharacterState.Sit => true,
+        CharacterState.Dance => true,
+        CharacterState.Talk => true,
+        CharacterState.Equipping => true,
+        CharacterState.Wielding => true,
+        CharacterState.GlideWield => true,
+        _ => false
+    };
+
+    /// <summary>Whether the entity is currently stunned.</summary>
+    public static bool IsStunned(this CharacterState state) => state is CharacterState.Stunned;
+
+    /// <summary>Returns true if the state is considered stealthy.</summary>
+    public static bool IsStealthy(this CharacterState state) => state switch
+    {
+        CharacterState.Idle { IsSneaking: true } => true,
+        CharacterState.Wielding { IsSneaking: true } => true,
+        CharacterState.Roll { IsSneaking: true } => true,
+        _ => false
+    };
+
+    /// <summary>Stage section if the state supports it, otherwise null.</summary>
+    public static StageSection? StageSection(this CharacterState state) => state switch
+    {
+        CharacterState.Climb s => s.Stage,
+        CharacterState.Glide s => s.Stage,
+        CharacterState.GlideWield s => s.Stage,
+        CharacterState.BasicBlock s => s.Stage,
+        CharacterState.BasicMelee s => s.Stage,
+        CharacterState.BasicRanged s => s.Stage,
+        CharacterState.DashMelee s => s.Stage,
+        CharacterState.ComboMelee2 s => s.Stage,
+        CharacterState.LeapMelee s => s.Stage,
+        CharacterState.LeapShockwave s => s.Stage,
+        CharacterState.ChargedMelee s => s.Stage,
+        CharacterState.ChargedRanged s => s.Stage,
+        CharacterState.RepeaterRanged s => s.Stage,
+        CharacterState.Throw s => s.Stage,
+        CharacterState.Roll s => s.Stage,
+        CharacterState.Stunned s => s.Stage,
+        CharacterState.Boost s => s.Stage,
+        CharacterState.Shockwave s => s.Stage,
+        CharacterState.BasicBeam s => s.Stage,
+        CharacterState.BasicAura s => s.Stage,
+        CharacterState.StaticAura s => s.Stage,
+        CharacterState.Blink s => s.Stage,
+        CharacterState.SpriteSummon s => s.Stage,
+        CharacterState.BasicSummon s => s.Stage,
+        CharacterState.UseItem s => s.Stage,
+        CharacterState.Interact s => s.Stage,
+        CharacterState.Wallrun s => s.Stage,
+        CharacterState.Skate s => s.Stage,
+        CharacterState.Music s => s.Stage,
+        CharacterState.FinisherMelee s => s.Stage,
+        CharacterState.DiveMelee s => s.Stage,
+        CharacterState.RiposteMelee s => s.Stage,
+        CharacterState.RapidMelee s => s.Stage,
+        CharacterState.Transform s => s.Stage,
+        CharacterState.RegrowHead s => s.Stage,
+        CharacterState.SelfBuff s => s.Stage,
+        _ => null
+    };
+}
+
+    /// <summary>True if the state is Boost or any attack, meaning the entity should follow look direction.</summary>
+    public static bool ShouldFollowLook(this CharacterState state)
+        => state is CharacterState.Boost || state.IsAttack();
+
+    /// <summary>Returns true if the state requires aiming with the cursor.</summary>
+    public static bool IsAimed(this CharacterState state) => state switch
+    {
+        CharacterState.BasicMelee => true,
+        CharacterState.BasicRanged => true,
+        CharacterState.DashMelee => true,
+        CharacterState.ComboMelee2 => true,
+        CharacterState.BasicBlock => true,
+        CharacterState.LeapMelee => true,
+        CharacterState.LeapShockwave => true,
+        CharacterState.ChargedMelee => true,
+        CharacterState.ChargedRanged => true,
+        CharacterState.RepeaterRanged => true,
+        CharacterState.Throw => true,
+        CharacterState.Shockwave => true,
+        CharacterState.BasicBeam => true,
+        CharacterState.Stunned => true,
+        CharacterState.Wielding => true,
+        CharacterState.Talk => true,
+        CharacterState.FinisherMelee => true,
+        CharacterState.DiveMelee => true,
+        CharacterState.RiposteMelee => true,
+        CharacterState.RapidMelee => true,
+        _ => false
+    };
+
+    /// <summary>True if the state involves using the hands directly.</summary>
+    public static bool IsUsingHands(this CharacterState state) => state switch
+    {
+        CharacterState.Climb => true,
+        CharacterState.Equipping => true,
+        CharacterState.Dance => true,
+        CharacterState.Glide => true,
+        CharacterState.GlideWield => true,
+        CharacterState.Talk => true,
+        CharacterState.Roll => true,
+        _ => false
+    };
+
+    /// <summary>Return whether this state counts as a dodge.</summary>
+    public static bool IsDodge(this CharacterState state)
+    {
+        return state is CharacterState.Roll { Stage: StageSection.Buildup or StageSection.Movement };
+    }
+
+    /// <summary>Convenience checks for specific movement states.</summary>
+    public static bool IsGlide(this CharacterState state) => state is CharacterState.Glide;
+    public static bool IsSkate(this CharacterState state) => state is CharacterState.Skate;
+    public static bool IsMusic(this CharacterState state) => state is CharacterState.Music;
+
+    /// <summary>Whether this is a melee or beam attack.</summary>
+    public static bool IsMeleeAttack(this CharacterState state) => state switch
+    {
+        CharacterState.BasicMelee => true,
+        CharacterState.ComboMelee2 => true,
+        CharacterState.LeapMelee => true,
+        CharacterState.LeapShockwave => true,
+        CharacterState.DashMelee => true,
+        CharacterState.ChargedMelee => true,
+        CharacterState.FinisherMelee => true,
+        CharacterState.DiveMelee => true,
+        CharacterState.RiposteMelee => true,
+        CharacterState.RapidMelee => true,
+        _ => false
+    };
+
+    public static bool IsBeamAttack(this CharacterState state) => state is CharacterState.BasicBeam;
+}

--- a/VelorenPort/CoreEngine/Src/states/ForcedMovement.cs
+++ b/VelorenPort/CoreEngine/Src/states/ForcedMovement.cs
@@ -1,0 +1,69 @@
+using System;
+using Unity.Mathematics;
+
+namespace VelorenPort.CoreEngine.States;
+
+/// <summary>
+/// Types of movement enforced by abilities. This mirrors the ForcedMovement
+/// enum from the Rust project but only implements a subset of behaviour.
+/// </summary>
+[Serializable]
+public abstract record ForcedMovement
+{
+    public sealed record Forward(float Strength) : ForcedMovement;
+    public sealed record Reverse(float Strength) : ForcedMovement;
+    public sealed record Sideways(float Strength) : ForcedMovement;
+    public sealed record DirectedReverse(float Strength) : ForcedMovement;
+    public sealed record AntiDirectedForward(float Strength) : ForcedMovement;
+    public sealed record Leap(float Vertical, float Forward, float Progress, MovementDirection Direction) : ForcedMovement;
+    public sealed record Hover(float MoveInput) : ForcedMovement;
+}
+
+/// <summary>
+/// Helper extensions for ForcedMovement.
+/// </summary>
+public static class ForcedMovementExt
+{
+    /// <summary>
+    /// Scale the strength of the forced movement.
+    /// </summary>
+    public static ForcedMovement Mul(this ForcedMovement fm, float scalar) => fm switch
+    {
+        ForcedMovement.Forward var m => m with { Strength = m.Strength * scalar },
+        ForcedMovement.Reverse var m => m with { Strength = m.Strength * scalar },
+        ForcedMovement.Sideways var m => m with { Strength = m.Strength * scalar },
+        ForcedMovement.DirectedReverse var m => m with { Strength = m.Strength * scalar },
+        ForcedMovement.AntiDirectedForward var m => m with { Strength = m.Strength * scalar },
+        ForcedMovement.Leap var m => m with { Vertical = m.Vertical * scalar, Forward = m.Forward * scalar },
+        ForcedMovement.Hover var m => m,
+        _ => fm
+    };
+}
+
+/// <summary>
+/// Direction used by <see cref="ForcedMovement.Leap"/> to orient the leap.
+/// </summary>
+[Serializable]
+public enum MovementDirection
+{
+    Look,
+    Move
+}
+
+public static class MovementDirectionExt
+{
+    /// <summary>
+    /// Normalize and return the given direction vector depending on the mode.
+    /// When <paramref name="dir"/> is zero it returns the zero vector.
+    /// </summary>
+    public static float2 Get2dDir(this MovementDirection md, float2 lookDir, float2 moveDir)
+    {
+        float2 v = md switch
+        {
+            MovementDirection.Look => lookDir,
+            MovementDirection.Move => moveDir,
+            _ => moveDir
+        };
+        return math.lengthsq(v) > 0f ? math.normalize(v) : float2.zero;
+    }
+}

--- a/VelorenPort/Docs/MissingFeatures.md
+++ b/VelorenPort/Docs/MissingFeatures.md
@@ -47,10 +47,20 @@ La carpeta `server/src/sys` en Rust define más de 15 sistemas que orquestan la 
 
 - `rtsim` en Rust gestiona cálculos pesados de IA y entorno. El stub `Rtsim/RtSim.cs` solo guarda la fecha de inicio.
 - El módulo `weather` actualiza nubosidad y precipitaciones; en C# ahora existe un `WeatherSystem` sencillo que envía actualizaciones aleatorias.
+- Se añadió `Nature` con un mapa simplificado de `ChunkResource` por chunk, pero la simulación de recursos sigue incompleta.
+- Se incorporó `HumidityMap` para rastrear la humedad por chunk y se añadió una
+  difusión básica; sigue faltando la erosión y el modelo avanzado del original.
+- Se añadió un esqueleto `LayerManager` para futuras capas dinámicas, pero aún
+  no existen cuevas ni dispersión de objetos.
 
 ## 7. Módulos de juego no migrados
 
 - Lógica de combate y control de NPC, incluidas mascotas, teleporters y waypoints.
+- Estados de personaje ahora incluyen la mayoría de variantes comunes (bloqueos, ataques avanzados y estados de movimiento), aunque faltan transformaciones y otras lógicas complejas.
+- Se incorporó AttackSource y AttackFilters con utilidades de combate y se ampliaron los helpers de CharacterState (dodge, follow look, etc.).
+- Se añadió ForcedMovement y MovementDirection para replicar empujes y saltos dirigidos.
+- Se incorporaron los componentes `Alignment` y `Group` junto con `CharacterItem` para listas de personajes. Se añadió un `GroupManager` básico sin notificaciones ni mascotas.
+- Se añadieron las enumeraciones `SiteKind`, `PoiKind` y `MarkerKind`, y el mensaje de mapa ahora expone esta información. `SiteKindMeta` permite clasificar asentamientos y mazmorras.
 - Mecanismos de moderación y comandos avanzados solo tienen esqueletos (‘Automod’, etc.).
 - Los mensajes definidos en `sys/msg` para serializar actualizaciones no existen en la versión C#.
 
@@ -58,6 +68,9 @@ La carpeta `server/src/sys` en Rust define más de 15 sistemas que orquestan la 
 
 - Falta una CLI de administración completa y ajustes detallados de configuración.
 - No hay pruebas automáticas comparables a las de Rust.
+- Se añadieron `VolGrid2d` y `VolGrid3d` como contenedores de volúmenes simples, aunque sigue faltando el soporte completo de metadatos.
+- Se implementó `SlowJobPool` y un módulo de figuras con `MatCell` y
+  `DynaUnionizer`, aunque faltan herramientas de animación y cargado de modelos.
 
 ## Resumen
 

--- a/VelorenPort/README.md
+++ b/VelorenPort/README.md
@@ -59,7 +59,7 @@ A pesar de contar con varios archivos clave, el port a C# todavía está lejos d
 - **`states`**: faltan todos los archivos de lógica de combate y movimiento.
 - **`terrain` y `volumes`**: sólo se incluyó `TerrainConstants`; el manejo completo de biomas, bloques y volúmenes sigue pendiente.
  - **`util`**: ahora incluye `ColorUtil`, `Dir`, `Plane`, `Projection`, `Lines`, `FindDist` y `GridHasher`, además de `Rgba` para manipulación de colores.
-- **Componentes (`comp`)**: en Rust existen decenas de componentes (inventario, habilidades, físicas, etc.); aquí solo se implementaron `BuffKind`, `Chat`, `Group`, `Player` y varios stubs.
+ - **Componentes (`comp`)**: en Rust existen decenas de componentes (inventario, habilidades, físicas, etc.); aquí solo se implementaron `BuffKind`, `Chat`, `Group`, un `GroupManager` básico, `Player` y varios stubs.
  - **`weather`**: cuenta con cuadrículas interpoladas y funciones de compresión para replicar el sistema original.
 - **Otros módulos**: no hay traslados de `slowjob`, `store`, `trade`, `figure`, ni del submódulo `bin`.
 

--- a/VelorenPort/World.Tests/DynamicLayerTests.cs
+++ b/VelorenPort/World.Tests/DynamicLayerTests.cs
@@ -1,0 +1,15 @@
+using VelorenPort.World.Layer;
+using Unity.Mathematics;
+
+namespace World.Tests;
+
+public class DynamicLayerTests
+{
+    [Fact]
+    public void Apply_DoesNotThrow()
+    {
+        var ctx = new LayerContext { ChunkPos = new int2(0, 0) };
+        LayerManager.Apply(LayerType.Cave, ctx);
+        LayerManager.Apply(LayerType.Tree, ctx);
+    }
+}

--- a/VelorenPort/World.Tests/HumidityMapTests.cs
+++ b/VelorenPort/World.Tests/HumidityMapTests.cs
@@ -1,0 +1,37 @@
+using Unity.Mathematics;
+using VelorenPort.World;
+using VelorenPort.World.Sim;
+using Xunit;
+
+namespace World.Tests;
+
+public class HumidityMapTests
+{
+    [Fact]
+    public void Generate_SetsInitialValue()
+    {
+        var (world, _) = World.Generate(0);
+        var map = HumidityMap.Generate(world, 0.25f);
+        Assert.Equal(0.25f, map.Get(new int2(0, 0)));
+    }
+
+    [Fact]
+    public void Set_UpdatesValue()
+    {
+        var (world, _) = World.Generate(0);
+        var map = HumidityMap.Generate(world);
+        map.Set(new int2(0, 0), 0.8f);
+        Assert.Equal(0.8f, map.Get(new int2(0, 0)));
+    }
+
+    [Fact]
+    public void Diffuse_SpreadsHumidity()
+    {
+        var (world, _) = World.Generate(0);
+        var map = HumidityMap.Generate(world, 0f);
+        map.Set(new int2(1, 1), 1f);
+        map.Diffuse(1f);
+        Assert.True(map.Get(new int2(0, 0)) > 0f);
+        Assert.True(map.Get(new int2(1, 1)) < 1f);
+    }
+}

--- a/VelorenPort/World.Tests/SiteKindTests.cs
+++ b/VelorenPort/World.Tests/SiteKindTests.cs
@@ -1,0 +1,36 @@
+using VelorenPort.World.Site;
+using VelorenPort.World;
+using Unity.Mathematics;
+
+namespace World.Tests;
+
+public class SiteKindTests
+{
+    [Fact]
+    public void MarkerMapping_ReturnsExpected()
+    {
+        Assert.Equal(MarkerKind.Town, SiteKindExtensions.Marker(SiteKind.CliffTown));
+        Assert.Equal(MarkerKind.Castle, SiteKindExtensions.Marker(SiteKind.Citadel));
+        Assert.Null(SiteKindExtensions.Marker(SiteKind.PirateHideout));
+    }
+
+    [Fact]
+    public void MetaConversion_ReturnsExpected()
+    {
+        var meta = SiteKindExtensions.Meta(SiteKind.CliffTown) as SiteKindMeta.Settlement;
+        Assert.NotNull(meta);
+        Assert.Equal(SettlementKindMeta.CliffTown, meta!.Kind);
+    }
+
+    [Fact]
+    public void WorldMap_IncludesKinds()
+    {
+        var (world, index) = World.Empty();
+        var site = new Site { Position = int2.zero, Name = "A", Kind = SiteKind.Citadel };
+        index.Sites.Insert(site);
+        var map = world.GetMapData();
+        Assert.Single(map.Sites);
+        Assert.Equal(MarkerKind.Castle, map.Sites[0].Kind);
+    }
+}
+

--- a/VelorenPort/World/MissingFeatures.md
+++ b/VelorenPort/World/MissingFeatures.md
@@ -7,14 +7,16 @@ expands on all the components identificados hasta la fecha.
 - **Generación de civilizaciones** (`civ`): sólo se crean sitios de forma
   aleatoria. Faltan la economía de civilizaciones, sus etapas de generación y
   la asignación de NPCs y eventos.
-- **Capas dinámicas** (`layer`): cuevas, dispersión de objetos, arbustos,
-  árboles y fauna no cuentan con implementaciones reales.
+**Capas dinámicas** (`layer`): se añadió un esqueleto `LayerManager` con tipos de capa básicos, pero la aplicación de cuevas, dispersión de objetos, arbustos, árboles y fauna aún carece de lógica real.
 - **Simulación detallada** (`sim`): continúan faltando los módulos de difusión,
   el mapa de humedad y la erosión iterativa. Ya se ha incorporado una versión
   inicial de `sim/location` para nombrar lugares. Se añadieron utilidades
   básicas en `sim/util` como `MapEdgeFactor` y `cdf_irwin_hall`, junto al módulo
   `sim/way` y la clase `RandomPerm` para apoyar futuros caminos y
   aleatoriedad determinista.
+  Se agregó un contenedor `HumidityMap` para registrar la humedad por chunk y
+  se implementó una función de difusión básica, aunque falta el modelo
+  avanzado usado por el original.
 - **Conjunto de sitios** (`site/gen` y `site/plot`): no se han portado los
   generadores de poblados ni la gran variedad de edificaciones y decoraciones.
 - **Economía compleja** (`site/economy`): carecemos de mercados, oferta y
@@ -27,6 +29,7 @@ expands on all the components identificados hasta la fecha.
   miembros de región se mantiene simple y sin persistencia histórica.
 - **Recursos de chunk** (`ChunkResource` y asociadas) apenas se reflejan en la
   generación.
+- Se incorporó un contenedor `VolGrid3d` para manejar volúmenes 3D simples.
 - **Pathfinding avanzado**: faltan heurísticas de coste dinámico y la
   integración con datos de navegación modificables.
 - **Cobertura de pruebas**: muchas rutas de generación no están validadas por

--- a/VelorenPort/World/Src/Civ/CivGenerator.cs
+++ b/VelorenPort/World/Src/Civ/CivGenerator.cs
@@ -16,11 +16,14 @@ namespace VelorenPort.World.Civ
             var rng = new Random((int)index.Seed);
             int2 mapSize = TerrainChunkSize.Blocks(world.Sim.GetSize());
 
+            var kinds = Enum.GetValues<SiteKind>();
+
             for (int i = 0; i < count; i++)
             {
                 var pos = new int2(rng.Next(0, mapSize.x), rng.Next(0, mapSize.y));
                 string name = Site.NameGen.Generate(rng);
-                var site = new Site.Site { Position = pos, Name = name };
+                var kind = kinds[rng.Next(kinds.Length)];
+                var site = new Site.Site { Position = pos, Name = name, Kind = kind };
                 index.Sites.Insert(site);
             }
         }

--- a/VelorenPort/World/Src/Layer/DynamicLayers.cs
+++ b/VelorenPort/World/Src/Layer/DynamicLayers.cs
@@ -1,0 +1,46 @@
+using System;
+using Unity.Mathematics;
+
+namespace VelorenPort.World.Layer
+{
+    /// <summary>
+    /// Types of procedural layers applied to terrain.
+    /// This is a minimal subset of the Rust implementation
+    /// used for scattering objects and caves.
+    /// </summary>
+    [Serializable]
+    public enum LayerType
+    {
+        Cave,
+        Scatter,
+        Shrub,
+        Tree,
+        Wildlife
+    }
+
+    /// <summary>
+    /// Simplified layer application context.
+    /// </summary>
+    public class LayerContext
+    {
+        public int2 ChunkPos { get; init; }
+        public Random Rng { get; } = new();
+    }
+
+    /// <summary>
+    /// Manager responsible for applying layers to world chunks.
+    /// </summary>
+    public static class LayerManager
+    {
+        /// <summary>
+        /// Apply the requested layer to the chunk. Currently only logs the action.
+        /// </summary>
+        public static void Apply(LayerType layer, LayerContext ctx)
+        {
+            // In the real implementation this would modify the chunk data.
+            // For now we simply simulate some work by consuming RNG values.
+            _ = ctx.Rng.Next();
+            // Future work: integrate generation logic from the Rust project.
+        }
+    }
+}

--- a/VelorenPort/World/Src/Lib.cs
+++ b/VelorenPort/World/Src/Lib.cs
@@ -53,10 +53,14 @@ namespace VelorenPort.World {
                         {
                             var rnd = new Random((int)pair.Key.Value);
                             var off = new Unity.Mathematics.int2(rnd.Next(-16, 17), rnd.Next(-16, 17));
+                            PoiKind kind = rnd.NextDouble() < 0.5
+                                ? new PoiKind.Peak((uint)rnd.Next(50, 300))
+                                : new PoiKind.Lake((uint)rnd.Next(1, 10));
                             site.PointsOfInterest.Add(new PointOfInterest
                             {
                                 Position = site.Position + off,
-                                Description = $"Landmark near {site.Name}"
+                                Description = $"Landmark near {site.Name}",
+                                Kind = kind
                             });
                         }
                     }

--- a/VelorenPort/World/Src/Sim/HumidityMap.cs
+++ b/VelorenPort/World/Src/Sim/HumidityMap.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using Unity.Mathematics;
+using VelorenPort.CoreEngine;
+
+namespace VelorenPort.World.Sim;
+
+/// <summary>
+/// Simplified humidity map storing a single float value per chunk.
+/// Mirrors the concept of a humidity field used during world simulation
+/// but does not yet implement diffusion or erosion.
+/// </summary>
+[Serializable]
+public class HumidityMap
+{
+    private readonly Grid<float> _map;
+
+    private HumidityMap(Grid<float> map)
+    {
+        _map = map;
+    }
+
+    /// <summary>Create a new humidity map covering the world's dimensions.</summary>
+    public static HumidityMap Generate(World world, float initial = 0.5f)
+    {
+        int2 size = world.Sim.GetSize();
+        var grid = Grid<float>.PopulateFrom(size, _ => initial);
+        return new HumidityMap(grid);
+    }
+
+    /// <summary>Get the humidity value at the given chunk coordinate.</summary>
+    public float Get(int2 key) => _map.Get(key) ?? 0f;
+
+    /// <summary>Set the humidity value at the given chunk coordinate.</summary>
+    public void Set(int2 key, float value) => _map.Set(key, value);
+
+    public int2 Size => _map.Size;
+
+    public IEnumerable<(int2 Pos, float Value)> Iterate() => _map.Iterate();
+
+    /// <summary>
+    /// Diffuse humidity across neighbouring chunks using a simple averaging
+    /// model. <paramref name="strength"/> controls how much of the neighbour
+    /// average is blended into each cell (0..1).
+    /// </summary>
+    public void Diffuse(float strength = 0.25f)
+    {
+        var next = new Grid<float>(_map.Size, 0f);
+        foreach (var (pos, value) in _map.Iterate())
+        {
+            float sum = value;
+            int count = 1;
+            foreach (var off in WorldUtil.NEIGHBORS)
+            {
+                int2 n = pos + off;
+                if (_map.TryGet(n, out float v))
+                {
+                    sum += v;
+                    count++;
+                }
+            }
+            float avg = sum / count;
+            next.Set(pos, math.lerp(value, avg, strength));
+        }
+
+        foreach (var (pos, val) in next.Iterate())
+            _map.Set(pos, val);
+    }
+}

--- a/VelorenPort/World/Src/Sim/Nature.cs
+++ b/VelorenPort/World/Src/Sim/Nature.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using Unity.Mathematics;
+using VelorenPort.CoreEngine;
+
+namespace VelorenPort.World.Sim;
+
+/// <summary>
+/// Simplified representation of natural resources per chunk.
+/// Mirrors <c>rtsim/src/data/nature.rs</c> in a reduced form.
+/// </summary>
+[Serializable]
+public class Nature
+{
+    private readonly Grid<Chunk> _chunks;
+
+    private Nature(Grid<Chunk> chunks)
+    {
+        _chunks = chunks;
+    }
+
+    /// <summary>Create a new resource map based on the given world size.</summary>
+    public static Nature Generate(World world)
+    {
+        int2 size = world.Sim.GetSize();
+        var grid = Grid<Chunk>.PopulateFrom(size, _ => Chunk.Default());
+        return new Nature(grid);
+    }
+
+    /// <summary>Retrieve resource factors for the chunk at <paramref name="key"/>.</summary>
+    public Dictionary<ChunkResource, float> GetChunkResources(int2 key)
+    {
+        var chunk = _chunks.Get(key);
+        return chunk == null
+            ? new Dictionary<ChunkResource, float>()
+            : new Dictionary<ChunkResource, float>(chunk.Res);
+    }
+
+    /// <summary>Update resource factors for the chunk at <paramref name="key"/>.</summary>
+    public void SetChunkResources(int2 key, Dictionary<ChunkResource, float> res)
+    {
+        var chunk = _chunks.Get(key);
+        if (chunk != null)
+            chunk.Res = new Dictionary<ChunkResource, float>(res);
+    }
+}
+
+/// <summary>Resource proportions for a chunk.</summary>
+[Serializable]
+public class Chunk
+{
+    public Dictionary<ChunkResource, float> Res = new();
+
+    public static Chunk Default()
+    {
+        var chunk = new Chunk();
+        foreach (ChunkResource r in Enum.GetValues(typeof(ChunkResource)))
+            chunk.Res[r] = 1f;
+        return chunk;
+    }
+}
+

--- a/VelorenPort/World/Src/Site/PointOfInterest.cs
+++ b/VelorenPort/World/Src/Site/PointOfInterest.cs
@@ -5,5 +5,6 @@ namespace VelorenPort.World.Site {
     public class PointOfInterest {
         public int2 Position { get; set; }
         public string Description { get; set; } = "POI";
+        public PoiKind Kind { get; set; } = new PoiKind.Peak(0);
     }
 }

--- a/VelorenPort/World/Src/Site/Site.cs
+++ b/VelorenPort/World/Src/Site/Site.cs
@@ -11,6 +11,7 @@ namespace VelorenPort.World.Site {
     public class Site {
         public int2 Position { get; init; }
         public string Name { get; set; } = "Site";
+        public SiteKind Kind { get; set; } = SiteKind.Refactor;
         public EconomyData Economy { get; } = new EconomyData();
         public List<PointOfInterest> PointsOfInterest { get; } = new();
     }

--- a/VelorenPort/World/Src/Site/SiteKinds.cs
+++ b/VelorenPort/World/Src/Site/SiteKinds.cs
@@ -1,0 +1,153 @@
+using System;
+using Unity.Mathematics;
+
+namespace VelorenPort.World.Site;
+
+/// <summary>
+/// Enumerations describing types of sites and related metadata.
+/// </summary>
+[Serializable]
+public enum SiteKind
+{
+    Refactor,
+    CliffTown,
+    SavannahTown,
+    DesertCity,
+    ChapelSite,
+    DwarvenMine,
+    CoastalTown,
+    Citadel,
+    Terracotta,
+    GiantTree,
+    Gnarling,
+    Bridge,
+    Adlet,
+    Haniwa,
+    PirateHideout,
+    JungleRuin,
+    RockCircle,
+    TrollCave,
+    Camp,
+    Cultist,
+    Sahagin,
+    VampireCastle,
+    GliderCourse,
+    Myrmidon,
+}
+
+[Serializable]
+public enum MarkerKind
+{
+    Town,
+    Castle,
+    Cave,
+    Tree,
+    Gnarling,
+    GliderCourse,
+    ChapelSite,
+    Terracotta,
+    Bridge,
+    Adlet,
+    Haniwa,
+    DwarvenMine,
+    Cultist,
+    Sahagin,
+    VampireCastle,
+    Myrmidon,
+    Unknown,
+}
+
+[Serializable]
+public enum DungeonKindMeta
+{
+    Gnarling,
+    Adlet,
+    Haniwa,
+    SeaChapel,
+    Terracotta,
+    Cultist,
+    Sahagin,
+    Myrmidon,
+    VampireCastle,
+    DwarvenMine,
+}
+
+[Serializable]
+public enum SettlementKindMeta
+{
+    Default,
+    CliffTown,
+    DesertCity,
+    SavannahTown,
+    CoastalTown,
+}
+
+[Serializable]
+public abstract record SiteKindMeta
+{
+    public sealed record Dungeon(DungeonKindMeta Kind) : SiteKindMeta;
+    public sealed record Cave : SiteKindMeta;
+    public sealed record Settlement(SettlementKindMeta Kind) : SiteKindMeta;
+    public sealed record Castle : SiteKindMeta;
+    public sealed record Void : SiteKindMeta;
+}
+
+public static class SiteKindExtensions
+{
+    public static SiteKindMeta? Meta(this SiteKind kind) => kind switch
+    {
+        SiteKind.Refactor => new SiteKindMeta.Settlement(SettlementKindMeta.Default),
+        SiteKind.CliffTown => new SiteKindMeta.Settlement(SettlementKindMeta.CliffTown),
+        SiteKind.SavannahTown => new SiteKindMeta.Settlement(SettlementKindMeta.SavannahTown),
+        SiteKind.CoastalTown => new SiteKindMeta.Settlement(SettlementKindMeta.CoastalTown),
+        SiteKind.DesertCity => new SiteKindMeta.Settlement(SettlementKindMeta.DesertCity),
+        SiteKind.Gnarling => new SiteKindMeta.Dungeon(DungeonKindMeta.Gnarling),
+        SiteKind.Adlet => new SiteKindMeta.Dungeon(DungeonKindMeta.Adlet),
+        SiteKind.Terracotta => new SiteKindMeta.Dungeon(DungeonKindMeta.Terracotta),
+        SiteKind.Haniwa => new SiteKindMeta.Dungeon(DungeonKindMeta.Haniwa),
+        SiteKind.Myrmidon => new SiteKindMeta.Dungeon(DungeonKindMeta.Myrmidon),
+        SiteKind.DwarvenMine => new SiteKindMeta.Dungeon(DungeonKindMeta.DwarvenMine),
+        SiteKind.ChapelSite => new SiteKindMeta.Dungeon(DungeonKindMeta.SeaChapel),
+        SiteKind.Cultist => new SiteKindMeta.Dungeon(DungeonKindMeta.Cultist),
+        SiteKind.Sahagin => new SiteKindMeta.Dungeon(DungeonKindMeta.Sahagin),
+        SiteKind.VampireCastle => new SiteKindMeta.Dungeon(DungeonKindMeta.VampireCastle),
+        _ => null,
+    };
+
+    public static bool ShouldDoEconomicSimulation(this SiteKind kind) => kind switch
+    {
+        SiteKind.Refactor or SiteKind.CliffTown or SiteKind.SavannahTown or SiteKind.CoastalTown or SiteKind.DesertCity => true,
+        _ => false,
+    };
+
+    public static MarkerKind? Marker(this SiteKind kind) => kind switch
+    {
+        SiteKind.Refactor or SiteKind.CliffTown or SiteKind.SavannahTown or SiteKind.CoastalTown or SiteKind.DesertCity => MarkerKind.Town,
+        SiteKind.Citadel => MarkerKind.Castle,
+        SiteKind.Bridge => MarkerKind.Bridge,
+        SiteKind.GiantTree => MarkerKind.Tree,
+        SiteKind.Gnarling => MarkerKind.Gnarling,
+        SiteKind.DwarvenMine => MarkerKind.DwarvenMine,
+        SiteKind.ChapelSite => MarkerKind.ChapelSite,
+        SiteKind.Terracotta => MarkerKind.Terracotta,
+        SiteKind.GliderCourse => MarkerKind.GliderCourse,
+        SiteKind.Cultist => MarkerKind.Cultist,
+        SiteKind.Sahagin => MarkerKind.Sahagin,
+        SiteKind.Myrmidon => MarkerKind.Myrmidon,
+        SiteKind.Adlet => MarkerKind.Adlet,
+        SiteKind.Haniwa => MarkerKind.Haniwa,
+        SiteKind.VampireCastle => MarkerKind.VampireCastle,
+        _ => null,
+    };
+}
+
+/// <summary>
+/// Point of interest kinds mirroring Rust's `PoiKind` union.
+/// </summary>
+[Serializable]
+public abstract record PoiKind
+{
+    public sealed record Peak(uint Altitude) : PoiKind;
+    public sealed record Lake(uint Size) : PoiKind;
+}
+

--- a/VelorenPort/World/Src/World.cs
+++ b/VelorenPort/World/Src/World.cs
@@ -72,9 +72,10 @@ namespace VelorenPort.World {
 
             foreach (var (_, site) in Index.Sites.Enumerate())
             {
-                msg.Sites.Add(new Marker { Name = site.Name, Position = site.Position });
+                var kind = SiteKindExtensions.Marker(site.Kind) ?? MarkerKind.Unknown;
+                msg.Sites.Add(new Marker { Name = site.Name, Position = site.Position, Kind = kind });
                 foreach (var poi in site.PointsOfInterest)
-                    msg.Pois.Add(new PoiInfo { Name = poi.Description, Position = poi.Position });
+                    msg.Pois.Add(new PoiInfo { Name = poi.Description, Position = poi.Position, Kind = poi.Kind });
             }
 
             return msg;

--- a/VelorenPort/World/Src/WorldMapMsg.cs
+++ b/VelorenPort/World/Src/WorldMapMsg.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Unity.Mathematics;
+using VelorenPort.World.Site;
 
 namespace VelorenPort.World {
     /// <summary>
@@ -20,11 +21,13 @@ namespace VelorenPort.World {
     public struct Marker {
         public string Name;
         public int2 Position;
+        public MarkerKind Kind;
     }
 
     [Serializable]
     public struct PoiInfo {
         public string Name;
         public int2 Position;
+        public PoiKind Kind;
     }
 }


### PR DESCRIPTION
## Summary
- implement a simple `GroupManager` with join/leave helpers
- add unit tests covering basic group behaviour
- update missing features docs noting partial group management
- mention new manager in main README

## Testing
- `dotnet test VelorenPort/CoreEngine.Tests/CoreEngine.Tests.csproj --no-build` *(fails: `dotnet` not found)*
- `dotnet test VelorenPort/World.Tests/World.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686065ae0c408328bca6263aea26b7b5