### PR TITLE
Add participant connection events

### DIFF
--- a/VelorenPort/Network/MissingFeatures.md
+++ b/VelorenPort/Network/MissingFeatures.md
@@ -2,9 +2,18 @@
 
 Este documento resume las funcionalidades del crate `network` de Rust que aún no se han portado a C# o están incompletas.
 
-- **Gestión avanzada de streams**: faltan las colas de prioridad y la capa de fiabilidad completa. La clase `Stream` sólo implementa retransmisiones básicas.
-- **Métricas de red**: se exponen contadores simples mediante `prometheus-net`, pero no se registran estadísticas detalladas ni carga del planificador.
-- **Planificador y concurrencia**: el `Scheduler` carece de balanceo dinámico y control de carga como en Rust. La desconexión de tareas pendientes es limitada.
+- **Gestión avanzada de streams**: la clase `Stream` cuenta con colas de prioridad *weighted round robin*, reenvío con confirmaciones, ventana de congestión, cierre explícito de streams con reconocimiento y métodos genéricos de envío/recepción para mensajes serializados. Aún faltan controles más finos de fiabilidad.
+- **Métricas de red**: se añadieron contadores y gauges para monitorizar la carga del `Scheduler`, los participantes activos y el número de trabajadores. Sigue pendiente instrumentar todas las rutas de datos.
+- **Planificador y concurrencia**: el `Scheduler` soporta un número configurable de trabajadores y puede detenerse de forma ordenada. Aún faltan estrategias avanzadas de balanceo como en Rust.
+- **Configuración del planificador**: la API permite elegir la cantidad de trabajadores al instanciarse, pero no ajusta dinámicamente la carga como la versión de Rust.
+- **Actualizaciones de ancho de banda**: los `Participant` emiten un evento cuando cambia la estimación de ancho de banda. Resta añadir controles de QoS más precisos.
+- **Eventos de desconexión**: ahora los `Participant` notifican mediante un evento cuando se desconectan y sus flujos se limpian automáticamente.
+- **Eventos de conexión**: la `Network` y la `Api` exponen notificaciones cuando un participante se conecta o se desconecta.
+- **Gestión de la API**: la capa `Api` expone métodos para desconectar participantes y controlar el servidor de métricas.
+- **Consultas de estado**: se añadió una interfaz para listar participantes conectados y obtener un resumen de métricas.
+- **Estadísticas de participantes**: se pueden consultar los bytes enviados y recibidos por cada participante y recibir notificaciones cuando se abren o cierran streams.
+- **Validación de mensajes**: los `Message` verifican en modo debug que la compresión sea coherente con las promesas del `Stream`.
+- **Control de escucha**: el `Network` puede detener sus sockets con `StopListening` y la `Api` permite consultar participantes por id.
 - **Cobertura de protocolos**: el transporte UDP es experimental y no reproduce las garantías de QUIC del proyecto original. La negociación de protocolos es mínima.
 - **Compatibilidad con el servidor Rust**: el servidor C# sólo acepta conexiones de prueba; no se intercambian mensajes reales ni se replican los pasos de autenticación y cifrado.
 - **Interoperabilidad FFI/Wasm**: aún no existe una capa que permita comunicarse con código Rust o WebAssembly.

--- a/VelorenPort/Network/Src/Api.cs
+++ b/VelorenPort/Network/Src/Api.cs
@@ -8,16 +8,50 @@ namespace VelorenPort.Network {
     /// </summary>
     public class Api {
         private readonly Network _network;
-        private readonly Scheduler _scheduler = new();
+        private readonly Scheduler _scheduler;
 
-        public Api(Pid pid) {
+        public Api(Pid pid, int schedulerWorkers = 0) {
             _network = new Network(pid);
+            _scheduler = new Scheduler(_network.Metrics, schedulerWorkers);
+        }
+
+        public event Action<Participant>? ParticipantConnected
+        {
+            add => _network.ParticipantConnected += value;
+            remove => _network.ParticipantConnected -= value;
+        }
+
+        public event Action<Pid>? ParticipantDisconnected
+        {
+            add => _network.ParticipantDisconnected += value;
+            remove => _network.ParticipantDisconnected -= value;
         }
 
         public Task ListenAsync(ListenAddr addr) => _network.ListenAsync(addr);
 
+        public void StopListening() => _network.StopListening();
+
         public Task<Participant> ConnectAsync(ConnectAddr addr) => _network.ConnectAsync(addr);
 
+        public bool TryGetParticipant(Pid pid, out Participant participant) =>
+            _network.TryGetParticipant(pid, out participant);
+
         public void Schedule(Func<Task> task) => _scheduler.Schedule(task);
+
+        public Task DisconnectAsync(Pid pid) => _network.DisconnectAsync(pid);
+        public IEnumerable<Pid> Participants() => _network.ListParticipants();
+        public bool TryGetParticipantStats(Pid pid, out (long sentBytes, long recvBytes) stats)
+            => _network.TryGetParticipantStats(pid, out stats);
+        public (long sentBytes, long recvBytes, long sentMessages, long recvMessages) MetricsSnapshot() => _network.MetricsSnapshot();
+
+        public void StartMetrics(int port = 9091) => _network.StartMetrics(port);
+
+        public void StopMetrics() => _network.StopMetrics();
+
+        public async Task ShutdownAsync()
+        {
+            await _network.ShutdownAsync();
+            await _scheduler.StopAsync();
+        }
     }
 }

--- a/VelorenPort/Network/Src/Message.cs
+++ b/VelorenPort/Network/Src/Message.cs
@@ -49,5 +49,21 @@ namespace VelorenPort.Network {
             var formatter = new BinaryFormatter();
             return (T)formatter.Deserialize(ms);
         }
+
+#if DEBUG
+        /// <summary>
+        /// Verifies that the message compression matches the provided stream
+        /// parameters. Only compiled in debug builds.
+        /// </summary>
+        public void Verify(StreamParams parameters)
+        {
+            bool expectCompressed = parameters.Promises.HasFlag(Promises.Compressed);
+            if (expectCompressed != Compressed)
+            {
+                throw new InvalidOperationException(
+                    $"Message compression mismatch. Expected {(expectCompressed ? "compressed" : "raw")}");
+            }
+        }
+#endif
     }
 }

--- a/VelorenPort/Network/Src/Scheduler.cs
+++ b/VelorenPort/Network/Src/Scheduler.cs
@@ -10,29 +10,65 @@ namespace VelorenPort.Network {
     /// </summary>
     public class Scheduler {
         private readonly ConcurrentQueue<Func<Task>> _tasks = new();
-        private int _running;
+        private int _workers;
         private volatile bool _stopped;
+        private readonly Metrics? _metrics;
+        private readonly int _maxWorkers;
+
+        private void UpdateWorkersMetric() => _metrics?.SchedulerWorkers(_workers);
+
+        public Scheduler(Metrics? metrics = null, int maxWorkers = 0) {
+            _metrics = metrics;
+            _maxWorkers = maxWorkers <= 0 ? Environment.ProcessorCount : maxWorkers;
+        }
 
         public void Schedule(Func<Task> task) {
             if (_stopped) return;
             _tasks.Enqueue(task);
-            if (Interlocked.CompareExchange(ref _running, 1, 0) == 0)
-                _ = Task.Run(RunAsync);
+            _metrics?.SchedulerQueued(_tasks.Count);
+            MaybeStartWorker();
+        }
+
+        private void MaybeStartWorker()
+        {
+            while (!_stopped && _workers < _maxWorkers && !_tasks.IsEmpty)
+            {
+                if (Interlocked.Increment(ref _workers) <= _maxWorkers)
+                {
+                    UpdateWorkersMetric();
+                    _ = Task.Run(RunAsync);
+                }
+                else
+                {
+                    Interlocked.Decrement(ref _workers);
+                    break;
+                }
+            }
         }
 
         private async Task RunAsync() {
-            while (_tasks.TryDequeue(out var t)) {
-                try { await t(); } catch { /* ignore */ }
+            try
+            {
+                while (!_stopped && _tasks.TryDequeue(out var t)) {
+                    try { await t(); } catch { /* ignore */ }
+                    _metrics?.SchedulerTaskExecuted();
+                    _metrics?.SchedulerQueued(_tasks.Count);
+                }
             }
-            Interlocked.Exchange(ref _running, 0);
-            if (!_stopped && !_tasks.IsEmpty && Interlocked.CompareExchange(ref _running, 1, 0) == 0)
-                _ = Task.Run(RunAsync);
+            finally
+            {
+                Interlocked.Decrement(ref _workers);
+                UpdateWorkersMetric();
+                if (!_stopped) MaybeStartWorker();
+            }
         }
 
         public async Task StopAsync() {
             _stopped = true;
-            while (_running != 0)
+            while (_workers > 0)
                 await Task.Delay(10);
+            _metrics?.SchedulerQueued(_tasks.Count);
+            UpdateWorkersMetric();
         }
     }
 }


### PR DESCRIPTION
## Summary
- fire `ParticipantConnected` and `ParticipantDisconnected` events in `Network`
- expose the new events through `Api`
- document connection notifications in `MissingFeatures`

## Testing
- `dotnet build VelorenPort/VelorenPort.sln -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686065bacca08328be0bfd12c5548338