### PR TITLE
Implement optional stream encryption

### DIFF
--- a/VelorenPort/Network/MissingFeatures.md
+++ b/VelorenPort/Network/MissingFeatures.md
@@ -1,22 +1,13 @@
 # Network Port Missing Features
 
-Este documento resume las funcionalidades del crate `network` de Rust que aún no se han portado a C# o están incompletas.
+This document tracks notable systems from the original Rust `network` crate that are not yet implemented or only partially ported to C#. The list below expands on all the components identificados hasta la fecha.
 
-- **Gestión avanzada de streams**: la clase `Stream` cuenta con colas de prioridad *weighted round robin*, reenvío con confirmaciones, ventana de congestión, cierre explícito de streams con reconocimiento y métodos genéricos de envío/recepción para mensajes serializados. Aún faltan controles más finos de fiabilidad.
-- **Métricas de red**: se añadieron contadores y gauges para monitorizar la carga del `Scheduler`, los participantes activos y el número de trabajadores. Sigue pendiente instrumentar todas las rutas de datos.
-- **Planificador y concurrencia**: el `Scheduler` soporta un número configurable de trabajadores y puede detenerse de forma ordenada. Aún faltan estrategias avanzadas de balanceo como en Rust.
-- **Configuración del planificador**: la API permite elegir la cantidad de trabajadores al instanciarse, pero no ajusta dinámicamente la carga como la versión de Rust.
-- **Actualizaciones de ancho de banda**: los `Participant` emiten un evento cuando cambia la estimación de ancho de banda. Resta añadir controles de QoS más precisos.
-- **Eventos de desconexión**: ahora los `Participant` notifican mediante un evento cuando se desconectan y sus flujos se limpian automáticamente.
-- **Eventos de conexión**: la `Network` y la `Api` exponen notificaciones cuando un participante se conecta o se desconecta.
-- **Gestión de la API**: la capa `Api` expone métodos para desconectar participantes y controlar el servidor de métricas.
-- **Consultas de estado**: se añadió una interfaz para listar participantes conectados y obtener un resumen de métricas.
-- **Estadísticas de participantes**: se pueden consultar los bytes enviados y recibidos por cada participante y recibir notificaciones cuando se abren o cierran streams.
-- **Validación de mensajes**: los `Message` verifican en modo debug que la compresión sea coherente con las promesas del `Stream`.
-- **Control de escucha**: el `Network` puede detener sus sockets con `StopListening` y la `Api` permite consultar participantes por id.
-- **Cobertura de protocolos**: el transporte UDP es experimental y no reproduce las garantías de QUIC del proyecto original. La negociación de protocolos es mínima.
-- **Compatibilidad con el servidor Rust**: el servidor C# sólo acepta conexiones de prueba; no se intercambian mensajes reales ni se replican los pasos de autenticación y cifrado.
-- **Interoperabilidad FFI/Wasm**: aún no existe una capa que permita comunicarse con código Rust o WebAssembly.
-- **Pruebas automatizadas**: sólo se han portado algunos tests locales de MPSC; faltan pruebas integrales comparables a la suite de Rust.
+- **Protocolo de handshake avanzado**: el intercambio actual se limita a `Pid`, secreto y banderas básicas. Falta replicar el estado completo de negociación y versiones compatible con Rust.
+- **Gestión completa de streams**: el control de congestión AIMD y la retransmisión existen, pero faltan colas múltiples, prioridades por mensaje y confirmaciones selectivas.
+- **Soporte de QUIC real**: se utiliza UDP confiable de forma experimental; no se ha portado la capa QUIC que emplea el servidor Rust.
+- **Autenticación y roles**: la conexión no valida credenciales ni tipos de cliente; la lógica de permisos está incompleta.
+- **Instrumentación avanzada del `Scheduler`**: el autoescalado es básico y no se miden latencias ni tiempos de espera como en Rust.
+- **Capa de interoperabilidad (FFI/Wasm)**: aún no existe una forma de integrar código nativo o WebAssembly con la red en C#.
+- **Cobertura de pruebas**: sólo hay pruebas unitarias básicas; faltan tests de integración que aseguren compatibilidad con el servidor de Rust.
 
-La migración continuará abordando estas áreas para alcanzar la paridad con la implementación original.
+The migration will continue incrementally, porting features as they become necessary for gameplay.

--- a/VelorenPort/Network/Src/Channel.cs
+++ b/VelorenPort/Network/Src/Channel.cs
@@ -9,22 +9,39 @@ namespace VelorenPort.Network {
         public Sid Id { get; }
         private readonly ConcurrentQueue<Message> _incoming = new();
         private readonly ConcurrentQueue<Message> _outgoing = new();
+        private readonly Metrics? _metrics;
+        private readonly Pid _pid;
 
-        internal Channel(Sid id) {
+        internal Channel(Sid id, Pid pid, Metrics? metrics = null) {
             Id = id;
+            _pid = pid;
+            _metrics = metrics;
+            _metrics?.ChannelCongestion(_pid, Id, 0);
         }
 
         public Task SendAsync(Message msg) {
             _outgoing.Enqueue(msg);
+            _metrics?.ChannelSent(_pid, Id, msg.Data.Length);
+            _metrics?.ChannelSentMessage(_pid, Id);
+            _metrics?.ChannelCongestion(_pid, Id, _outgoing.Count);
             return Task.CompletedTask;
         }
 
         public Task<Message?> ReceiveAsync() {
-            _incoming.TryDequeue(out var msg);
-            return Task.FromResult(msg);
+            if (_incoming.TryDequeue(out var msg)) {
+                _metrics?.ChannelReceived(_pid, Id, msg.Data.Length);
+                _metrics?.ChannelReceivedMessage(_pid, Id);
+                return Task.FromResult<Message?>(msg);
+            }
+            return Task.FromResult<Message?>(null);
         }
 
         internal void PushIncoming(Message msg) => _incoming.Enqueue(msg);
-        internal bool TryGetOutgoing(out Message msg) => _outgoing.TryDequeue(out msg);
+        internal bool TryGetOutgoing(out Message msg) {
+            var result = _outgoing.TryDequeue(out msg);
+            if (result)
+                _metrics?.ChannelCongestion(_pid, Id, _outgoing.Count);
+            return result;
+        }
     }
 }

--- a/VelorenPort/Network/Src/HandshakeFeatures.cs
+++ b/VelorenPort/Network/Src/HandshakeFeatures.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace VelorenPort.Network {
+    /// <summary>
+    /// Flags exchanged during the handshake to negotiate optional features.
+    /// Mirrors the Rust bitflags.
+    /// </summary>
+    [Flags]
+    public enum HandshakeFeatures : uint {
+        None = 0,
+        ReliableUdp = 1 << 0,
+        Compression = 1 << 1,
+        Encryption = 1 << 2,
+    }
+}

--- a/VelorenPort/Network/Src/Protocol/Handshake.cs
+++ b/VelorenPort/Network/Src/Protocol/Handshake.cs
@@ -8,18 +8,21 @@ namespace VelorenPort.Network.Protocol {
     /// Wrapper over the higher level Handshake implementation for protocol code.
     /// </summary>
     public static class Handshake {
-        public static Task<(Pid pid, Guid secret)> PerformAsync(
+        public static Task<(Pid pid, Guid secret, HandshakeFeatures features)> PerformAsync(
             Stream stream,
             bool initiator,
             Pid localPid,
             Guid localSecret,
+            HandshakeFeatures localFeatures = HandshakeFeatures.None,
             CancellationToken token = default)
         {
-            return Network.Handshake.PerformAsync(stream, initiator, localPid, localSecret, token);
+            return Network.Handshake.PerformAsync(stream, initiator, localPid, localSecret, localFeatures, token);
         }
 
-        public static byte[] GetBytes(Pid pid, Guid secret) => Network.Handshake.GetBytes(pid, secret);
+        public static byte[] GetBytes(Pid pid, Guid secret, HandshakeFeatures features = HandshakeFeatures.None)
+            => Network.Handshake.GetBytes(pid, secret, features);
 
-        public static bool TryParse(byte[] data, out Pid pid, out Guid secret) => Network.Handshake.TryParse(data, out pid, out secret);
+        public static bool TryParse(byte[] data, out Pid pid, out Guid secret, out HandshakeFeatures features)
+            => Network.Handshake.TryParse(data, out pid, out secret, out features);
     }
 }


### PR DESCRIPTION
## Summary
- extend Streams with AES encryption when the `Encrypted` promise is used
- derive the key from the handshake secret
- decrypt payloads automatically on receive
- document encryption in README and migration notes
- expose handshake feature negotiation via API
- refresh the Network migration status document

## Testing
- `dotnet test VelorenPort/VelorenPort.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68608cfe7d288328b5cc04227c39fb8e