### PR TITLE
Add region event history accessor

### DIFF
--- a/VelorenPort/Assets/Spots/DwarvenGrave.json
+++ b/VelorenPort/Assets/Spots/DwarvenGrave.json
@@ -1,0 +1,5 @@
+{
+  "BaseStructures": "",
+  "Freq": 1.0,
+  "Spawn": false
+}

--- a/VelorenPort/Assets/Spots/Igloo.json
+++ b/VelorenPort/Assets/Spots/Igloo.json
@@ -1,0 +1,5 @@
+{
+  "BaseStructures": "",
+  "Freq": 1.0,
+  "Spawn": true
+}

--- a/VelorenPort/CoreEngine/Src/Region.cs
+++ b/VelorenPort/CoreEngine/Src/Region.cs
@@ -94,5 +94,25 @@ namespace VelorenPort.CoreEngine {
             foreach (var k in toRemove)
                 _regions.Remove(k);
         }
+
+        /// <summary>
+        /// Retrieve events that occurred in the current tick for
+        /// the region at <paramref name="key"/>. Returns an empty
+        /// list if no region exists.
+        /// </summary>
+        public IReadOnlyList<RegionEvent> GetEvents(int2 key)
+            => _regions.TryGetValue(key, out var r)
+                ? r.Events
+                : Array.Empty<RegionEvent>();
+
+        /// <summary>
+        /// Retrieve the stored history of events for the region at
+        /// <paramref name="key"/>. Returns an empty collection if the
+        /// region has not been created yet.
+        /// </summary>
+        public IReadOnlyCollection<RegionEvent> GetHistory(int2 key)
+            => _regions.TryGetValue(key, out var r)
+                ? r.History
+                : Array.Empty<RegionEvent>();
     }
 }

--- a/VelorenPort/Server/MissingFeatures.md
+++ b/VelorenPort/Server/MissingFeatures.md
@@ -1,0 +1,63 @@
+# World Port Missing Features
+
+This document tracks notable subsystems from the original Rust `world` crate
+that are not yet implemented or only partially ported to C#. The list below
+expands on all the components identificados hasta la fecha.
+
+- **Generación de civilizaciones** (`civ`): ahora se crean asentamientos
+  simples con una plaza central, casas y caminos gracias al nuevo
+  `SiteGenerator`. Todavía faltan la economía de civilizaciones, sus
+  etapas de generación completas y la asignación de NPCs y eventos.
+- **Capas dinámicas** (`layer`): ahora existen versiones básicas de cuevas,
+  dispersión de rocas, arbustos, árboles, vetas de mineral y puntos de
+  aparición de fauna. La generación de chunks aplica estas capas y
+  almacena los bloques de recursos detectados, pero aún distan de la
+  complejidad del proyecto en Rust.
+- **Simulación detallada** (`sim`): se añadió difusión iterativa de humedad
+  (`HumidityMap.RunDiffusion`) y una forma básica de erosión múltiple
+  (`Erosion.IterativeApply`). Aún faltan el modelo de erosión complejo y otras
+  utilidades. Ya se ha incorporado una versión
+  inicial de `sim/location` para nombrar lugares. Se añadieron utilidades
+  básicas en `sim/util` como `MapEdgeFactor` y `cdf_irwin_hall`, junto al módulo
+  `sim/way` y la clase `RandomPerm` para apoyar futuros caminos y
+  aleatoriedad determinista.
+- **Conjunto de sitios** (`site/gen` y `site/plot`): existe un generador
+  básico de asentamientos que crea plazas, casas, caminos y ahora parcelas de
+  cultivo sencillas. Aún falta la variedad completa de edificaciones y
+  decoraciones.
+  - **Economía compleja** (`site/economy`): la clase `Market` ahora ajusta sus
+    precios según la oferta disponible y se actualiza cada tick. Las rutas de
+    caravanas transportan bienes entre asentamientos, pero siguen pendientes las
+    tablas completas de recursos y comportamientos avanzados.
+- Se añadieron `SiteKind` y `PoiKind` para clasificar sitios y puntos de
+  interés, y los mensajes de mapa ahora exponen esta información.
+- Se añadió `SiteKindMeta` junto con utilidades para convertir desde
+  `SiteKind`, permitiendo a otros subsistemas identificar castillos,
+  asentamientos y mazmorras.
+- Los mensajes de mapa ahora incluyen una lista de posibles sitios
+  iniciales para facilitar la selección de ubicaciones de inicio.
+- Los sitios ahora almacenan su origen y exponen un cálculo aproximado
+  de "radio" y límites para usos simples. Falta integrar estos datos en
+  la generación avanzada y los sistemas de colisión.
+- **Tiles y utilidades** (`site/tile`, `site/util`): se incorporaron las
+  enumeraciones de dirección (`Dir`, `Dir3`) con utilidades de matrices de
+  orientación y un módulo básico de gradientes, pero siguen faltando sprites y
+  la lógica de baldosas.
+- **Spots** (`layer/spot`): se añadió la enumeración `Spot` y estructuras
+  relacionadas. El generador ahora puede cargar manifestos JSON para
+  determinar qué tipos aparecen y con qué frecuencia. Aún falta la
+  generación detallada de cada estructura.
+- **Eventos de regiones** y políticas de descarte de entidades: ahora cada región
+  registra un historial breve de entradas y salidas mediante `RegionMap`, pero
+  sigue faltando persistencia a largo plazo y políticas avanzadas.
+- **Recursos de chunk** (`ChunkResource` y asociadas): las vetas de mineral
+  generan bloques especiales que se registran en `ChunkSupplement`, pero
+  su explotacion todavia no afecta a la simulacion.
+- **Pathfinding avanzado**: ahora `SearchCfg` admite una función de coste
+  dinámico para ajustar caminos en tiempo de ejecución. Aún falta la
+  integración completa con datos de navegación modificables.
+- **Cobertura de pruebas**: muchas rutas de generación no están validadas por
+  pruebas unitarias o de integración.
+
+The migration will continue incrementally, porting features as they
+become necessary for gameplay.

--- a/VelorenPort/World.Tests/CivGeneratorTests.cs
+++ b/VelorenPort/World.Tests/CivGeneratorTests.cs
@@ -14,6 +14,8 @@ public class CivGeneratorTests
         foreach (var (_, site) in index.Sites.Enumerate())
         {
             Assert.False(string.IsNullOrWhiteSpace(site.Name));
+            Assert.NotEmpty(site.Plots);
+            Assert.Contains(site.Plots, p => p.Kind == Site.PlotKind.Road);
         }
     }
 }

--- a/VelorenPort/World.Tests/DynamicLayerTests.cs
+++ b/VelorenPort/World.Tests/DynamicLayerTests.cs
@@ -1,3 +1,4 @@
+using VelorenPort.World;
 using VelorenPort.World.Layer;
 using Unity.Mathematics;
 
@@ -11,5 +12,115 @@ public class DynamicLayerTests
         var ctx = new LayerContext { ChunkPos = new int2(0, 0) };
         LayerManager.Apply(LayerType.Cave, ctx);
         LayerManager.Apply(LayerType.Tree, ctx);
+    }
+
+    [Fact]
+    public void TreeLayer_PlacesBlocks()
+    {
+        var chunk = new Chunk(int2.zero, Block.Air);
+        var canvas = new Canvas(new CanvasInfo(int2.zero, new WorldSim(0, new int2(1,1)), new SimChunk()), chunk);
+        var ctx = new LayerContext { ChunkPos = int2.zero, Canvas = canvas };
+        LayerManager.Apply(LayerType.Tree, ctx);
+
+        bool found = false;
+        for (int x = 0; x < Chunk.Size.x && !found; x++)
+        for (int y = 0; y < Chunk.Size.y && !found; y++)
+        for (int z = 0; z < Chunk.Height && !found; z++)
+            if (chunk[x,y,z].Kind == BlockKind.Wood || chunk[x,y,z].Kind == BlockKind.Leaves)
+                found = true;
+
+        Assert.True(found);
+    }
+
+    [Fact]
+    public void ShrubLayer_PlacesBlocks()
+    {
+        var chunk = new Chunk(int2.zero, Block.Air);
+        var canvas = new Canvas(new CanvasInfo(int2.zero, new WorldSim(0, new int2(1,1)), new SimChunk()), chunk);
+        var ctx = new LayerContext { ChunkPos = int2.zero, Canvas = canvas };
+        LayerManager.Apply(LayerType.Shrub, ctx);
+
+        bool found = false;
+        for (int x = 0; x < Chunk.Size.x && !found; x++)
+        for (int y = 0; y < Chunk.Size.y && !found; y++)
+        for (int z = 0; z < Chunk.Height && !found; z++)
+            if (chunk[x,y,z].Kind == BlockKind.Leaves)
+                found = true;
+
+        Assert.True(found);
+    }
+
+    [Fact]
+    public void CaveLayer_CarvesBlocks()
+    {
+        var chunk = new Chunk(int2.zero, Block.Filled(BlockKind.Rock, 1,1,1));
+        var canvas = new Canvas(new CanvasInfo(int2.zero, new WorldSim(0, new int2(1,1)), new SimChunk()), chunk);
+        var ctx = new LayerContext { ChunkPos = int2.zero, Canvas = canvas };
+        LayerManager.Apply(LayerType.Cave, ctx);
+
+        bool air = false;
+        for (int x = 0; x < Chunk.Size.x && !air; x++)
+        for (int y = 0; y < Chunk.Size.y && !air; y++)
+        for (int z = 0; z < Chunk.Height && !air; z++)
+            if (chunk[x,y,z].Kind == BlockKind.Air)
+                air = true;
+
+        Assert.True(air);
+    }
+
+    [Fact]
+    public void ScatterLayer_PlacesRocks()
+    {
+        var chunk = new Chunk(int2.zero, Block.Air);
+        for (int x = 0; x < Chunk.Size.x; x++)
+        for (int y = 0; y < Chunk.Size.y; y++)
+            chunk[x,y,0] = Block.Filled(BlockKind.Earth, 1,1,1);
+
+        var canvas = new Canvas(new CanvasInfo(int2.zero, new WorldSim(0, new int2(1,1)), new SimChunk()), chunk);
+        var ctx = new LayerContext { ChunkPos = int2.zero, Canvas = canvas };
+        LayerManager.Apply(LayerType.Scatter, ctx);
+
+        bool rock = false;
+        for (int x = 0; x < Chunk.Size.x && !rock; x++)
+        for (int y = 0; y < Chunk.Size.y && !rock; y++)
+        for (int z = 0; z < Chunk.Height && !rock; z++)
+            if (chunk[x,y,z].Kind == BlockKind.Rock)
+                rock = true;
+
+        Assert.True(rock);
+    }
+
+    [Fact]
+    public void WildlifeLayer_AddsSpawns()
+    {
+        var chunk = new Chunk(int2.zero, Block.Air);
+        for (int x = 0; x < Chunk.Size.x; x++)
+        for (int y = 0; y < Chunk.Size.y; y++)
+            chunk[x,y,0] = Block.Filled(BlockKind.Earth,1,1,1);
+
+        var canvas = new Canvas(new CanvasInfo(int2.zero, new WorldSim(0, new int2(1,1)), new SimChunk()), chunk);
+        var ctx = new LayerContext { ChunkPos = int2.zero, Canvas = canvas };
+        LayerManager.Apply(LayerType.Wildlife, ctx);
+
+        Assert.NotEmpty(canvas.Spawns);
+    }
+
+    [Fact]
+    public void OreVeinLayer_PlacesGlowingRock()
+    {
+        var chunk = new Chunk(int2.zero, Block.Filled(BlockKind.Rock,1,1,1));
+        var canvas = new Canvas(new CanvasInfo(int2.zero, new WorldSim(0, new int2(1,1)), new SimChunk()), chunk);
+        var ctx = new LayerContext { ChunkPos = int2.zero, Canvas = canvas };
+        LayerManager.Apply(LayerType.OreVein, ctx);
+
+        bool ore = false;
+        for (int x = 0; x < Chunk.Size.x && !ore; x++)
+        for (int y = 0; y < Chunk.Size.y && !ore; y++)
+        for (int z = 0; z < Chunk.Height && !ore; z++)
+            if (chunk[x,y,z].Kind == BlockKind.GlowingRock)
+                ore = true;
+
+        Assert.True(ore);
+        Assert.NotEmpty(canvas.ResourceBlocks);
     }
 }

--- a/VelorenPort/World.Tests/EconomyTests.cs
+++ b/VelorenPort/World.Tests/EconomyTests.cs
@@ -27,4 +27,57 @@ public class EconomyTests
         Assert.Equal(2f, a.Economy.GetStock(new Good.Wood()));
         Assert.Equal(2f, b.Economy.GetStock(new Good.Wood()));
     }
+
+    [Fact]
+    public void Market_BuyAndSell_ModifiesCoinAndStock()
+    {
+        var site = new Site { Position = Unity.Mathematics.int2.zero };
+        site.Economy.Coin = 10f;
+        site.Economy.Market.SetPrice(new Good.Wood(), 2f);
+
+        Assert.True(site.Economy.Market.Buy(site.Economy, new Good.Wood(), 3f));
+        Assert.Equal(4f, site.Economy.Coin);
+        Assert.Equal(3f, site.Economy.GetStock(new Good.Wood()));
+
+        Assert.True(site.Economy.Market.Sell(site.Economy, new Good.Wood(), 1f));
+        Assert.Equal(6f, site.Economy.Coin);
+        Assert.Equal(2f, site.Economy.GetStock(new Good.Wood()));
+    }
+
+    [Fact]
+    public void CaravanRoute_TransfersGoodsBetweenSites()
+    {
+        EconomySim.ClearCaravanRoutes();
+        var a = new Site { Position = Unity.Mathematics.int2.zero };
+        var b = new Site { Position = Unity.Mathematics.int2.one };
+        a.Economy.Produce(new Good.Stone(), 5f);
+        a.Economy.Market.SetPrice(new Good.Stone(), 1f);
+        b.Economy.Market.SetPrice(new Good.Stone(), 1f);
+
+        var route = new Economy.CaravanRoute(a, b, new Good.Stone(), 2f, 1f);
+        EconomySim.AddCaravanRoute(route);
+        EconomySim.SimulateEconomy(new WorldIndex(0), 1.1f);
+
+        Assert.Equal(3f, a.Economy.GetStock(new Good.Stone()));
+        Assert.Equal(2f, b.Economy.GetStock(new Good.Stone()));
+    }
+
+    [Fact]
+    public void Market_DynamicPricing_ChangesWithStock()
+    {
+        var site = new Site { Position = Unity.Mathematics.int2.zero };
+        site.Economy.Coin = 100f;
+        site.Economy.Market.SetPrice(new Good.Wood(), 2f);
+
+        float basePrice = site.Economy.Market.GetPrice(new Good.Wood());
+
+        site.Economy.Produce(new Good.Wood(), 5f);
+        Assert.True(site.Economy.Market.Sell(site.Economy, new Good.Wood(), 5f));
+        float cheap = site.Economy.Market.GetPrice(new Good.Wood());
+        Assert.True(cheap < basePrice);
+
+        Assert.True(site.Economy.Market.Buy(site.Economy, new Good.Wood(), 5f));
+        float expensive = site.Economy.Market.GetPrice(new Good.Wood());
+        Assert.True(expensive > cheap);
+    }
 }

--- a/VelorenPort/World.Tests/ErosionTests.cs
+++ b/VelorenPort/World.Tests/ErosionTests.cs
@@ -1,0 +1,24 @@
+using VelorenPort.World;
+using VelorenPort.World.Sim;
+using Unity.Mathematics;
+
+namespace World.Tests;
+
+public class ErosionTests
+{
+    [Fact]
+    public void IterativeApply_LowersAltitude()
+    {
+        var sim = new WorldSim(0, new int2(2,2));
+        // Initialize chunks with an artificial slope
+        foreach (var pos in new[]{int2.zero, new int2(1,0), new int2(0,1), new int2(1,1)})
+        {
+            sim.Set(pos, new SimChunk { Alt = pos.x + pos.y });
+        }
+
+        float before = sim.Get(int2.zero)!.Alt;
+        Erosion.IterativeApply(sim, 3);
+        float after = sim.Get(int2.zero)!.Alt;
+        Assert.True(after < before);
+    }
+}

--- a/VelorenPort/World.Tests/HumidityMapTests.cs
+++ b/VelorenPort/World.Tests/HumidityMapTests.cs
@@ -30,8 +30,19 @@ public class HumidityMapTests
         var (world, _) = World.Generate(0);
         var map = HumidityMap.Generate(world, 0f);
         map.Set(new int2(1, 1), 1f);
-        map.Diffuse(1f);
+        map.RunDiffusion(3, 0.5f);
         Assert.True(map.Get(new int2(0, 0)) > 0f);
         Assert.True(map.Get(new int2(1, 1)) < 1f);
+    }
+
+    [Fact]
+    public void RunDiffusion_SpreadsAcrossWorld()
+    {
+        var (world, _) = World.Generate(0);
+        var map = HumidityMap.Generate(world, 0f);
+        map.Set(new int2(2, 2), 1f);
+        map.RunDiffusion(8, 0.5f);
+        foreach (var (_, val) in map.Iterate())
+            Assert.True(val > 0f);
     }
 }

--- a/VelorenPort/World.Tests/PathfindingTests.cs
+++ b/VelorenPort/World.Tests/PathfindingTests.cs
@@ -14,4 +14,15 @@ public class PathfindingTests
         Assert.Equal(new int2(0,0), path!.Start);
         Assert.Equal(new int2(3,0), path.End);
     }
+
+    [Fact]
+    public void Searcher_AvoidsHighCost()
+    {
+        float Cost(int2 pos) => pos.Equals(new int2(1, 0)) ? 100f : 0f;
+        var cfg = new SearchCfg(0f, 0f, Cost);
+        var searcher = new Searcher(Land.Empty(), cfg);
+        var path = searcher.Search(new int2(0, 0), new int2(2, 0));
+        Assert.NotNull(path);
+        Assert.Equal(new[] { new int2(0,0), new int2(0,1), new int2(2,1), new int2(2,0) }, path!.Nodes);
+    }
 }

--- a/VelorenPort/World.Tests/RegionTests.cs
+++ b/VelorenPort/World.Tests/RegionTests.cs
@@ -1,0 +1,54 @@
+using VelorenPort.CoreEngine;
+using Unity.Mathematics;
+
+namespace World.Tests;
+
+public class RegionTests
+{
+    [Fact]
+    public void AddAndRemove_ProduceEvents()
+    {
+        var map = new RegionMap();
+        var uid = new Uid(1);
+        int2 pos = new int2(0, 0);
+        map.Set(uid, pos);
+        var events = map.GetEvents(pos);
+        Assert.Single(events);
+        Assert.IsType<RegionEvent.Entered>(events[0]);
+        map.Tick();
+        map.Remove(uid);
+        events = map.GetEvents(pos);
+        Assert.Single(events);
+        Assert.IsType<RegionEvent.Left>(events[0]);
+    }
+
+    [Fact]
+    public void History_PersistsAcrossTicks()
+    {
+        var map = new RegionMap();
+        var uid = new Uid(2);
+        int2 pos = new int2(1, 1);
+        map.Set(uid, pos);
+        map.Tick();
+        map.Remove(uid);
+        var history = map.GetHistory(pos).ToList();
+        Assert.Equal(2, history.Count);
+        Assert.IsType<RegionEvent.Entered>(history[0]);
+        Assert.IsType<RegionEvent.Left>(history[1]);
+    }
+
+    [Fact]
+    public void History_TruncatesAfterLimit()
+    {
+        var map = new RegionMap();
+        int2 pos = new int2(2, 2);
+        for (int i = 0; i < 70; i++)
+        {
+            var uid = new Uid((ulong)i);
+            map.Set(uid, pos);
+            map.Remove(uid);
+        }
+        var history = map.GetHistory(pos);
+        Assert.Equal(64, history.Count);
+    }
+}

--- a/VelorenPort/World.Tests/SiteGeneratorTests.cs
+++ b/VelorenPort/World.Tests/SiteGeneratorTests.cs
@@ -1,0 +1,20 @@
+using VelorenPort.World.Site.Gen;
+using VelorenPort.World.Site;
+using System.Linq;
+using Unity.Mathematics;
+
+namespace World.Tests;
+
+public class SiteGeneratorTests
+{
+    [Fact]
+    public void GenerateSettlement_CreatesPlazaAndHouses()
+    {
+        var rng = new System.Random(0);
+        var site = SiteGenerator.GenerateSettlement(int2.zero, 5, rng);
+        Assert.Contains(site.Plots, p => p.Kind == PlotKind.Plaza);
+        Assert.True(site.Plots.Count(p => p.Kind == PlotKind.House) >= 5);
+        Assert.Contains(site.Plots, p => p.Kind == PlotKind.Road);
+        Assert.Contains(site.Plots, p => p.Kind == PlotKind.Farm);
+    }
+}

--- a/VelorenPort/World.Tests/SpotGeneratorTests.cs
+++ b/VelorenPort/World.Tests/SpotGeneratorTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using VelorenPort.World;
+using Unity.Mathematics;
+
+namespace World.Tests;
+
+public class SpotGeneratorTests
+{
+    [Fact]
+    public void Generate_AddsSpotsToChunks()
+    {
+        var sim = new WorldSim(0, new int2(8, 8));
+        SpotGenerator.Generate(sim, 0.1f, new System.Random(0));
+        bool found = false;
+        foreach (var (_, chunk) in sim.Chunks)
+            if (chunk.Spot != null)
+            {
+                found = true;
+                break;
+            }
+        Assert.True(found);
+    }
+
+    [Fact]
+    public void Generate_RespectsManifest()
+    {
+        var sim = new WorldSim(0, new int2(8, 8));
+        string dir = Path.Combine(AppContext.BaseDirectory,
+            "../../../../../Assets/Spots");
+        var manifest = SpotManifest.LoadFromDir(dir);
+        SpotGenerator.Generate(sim, 0.1f, new System.Random(0), manifest);
+        foreach (var (_, chunk) in sim.Chunks)
+            Assert.NotEqual(Spot.DwarvenGrave, chunk.Spot);
+    }
+}

--- a/VelorenPort/World.Tests/TerrainGeneratorTests.cs
+++ b/VelorenPort/World.Tests/TerrainGeneratorTests.cs
@@ -31,4 +31,19 @@ public class TerrainGeneratorTests
         Assert.Equal(block.Kind, from.Kind);
         Assert.Equal(block.Data, from.Data);
     }
+
+    [Fact]
+    public void World_GenerateChunk_AppliesLayers()
+    {
+        var (world, _) = World.Generate(0);
+        var (chunk, supp) = world.GenerateChunk(int2.zero);
+        bool ore = false;
+        for (int x = 0; x < Chunk.Size.x && !ore; x++)
+        for (int y = 0; y < Chunk.Size.y && !ore; y++)
+        for (int z = 0; z < Chunk.Height && !ore; z++)
+            if (chunk[x,y,z].Kind == BlockKind.GlowingRock)
+                ore = true;
+        Assert.True(ore);
+        Assert.NotEmpty(supp.ResourceBlocks);
+    }
 }

--- a/VelorenPort/World/Src/Civ/CivGenerator.cs
+++ b/VelorenPort/World/Src/Civ/CivGenerator.cs
@@ -1,5 +1,6 @@
 using System;
 using Unity.Mathematics;
+using VelorenPort.World.Site.Gen;
 
 namespace VelorenPort.World.Civ
 {
@@ -16,32 +17,11 @@ namespace VelorenPort.World.Civ
             var rng = new Random((int)index.Seed);
             int2 mapSize = TerrainChunkSize.Blocks(world.Sim.GetSize());
 
-            var kinds = Enum.GetValues<SiteKind>();
-
             for (int i = 0; i < count; i++)
             {
                 var pos = new int2(rng.Next(0, mapSize.x), rng.Next(0, mapSize.y));
-                string name = Site.NameGen.Generate(rng);
-
-                var site = new Site.Site
-                {
-                    Position = pos,
-                    Origin = pos,
-                    Name = name,
-                    Kind = Site.SiteKind.Refactor
-                };
-
-                int plotCount = rng.Next(1, 4);
-                for (int p = 0; p < plotCount; p++)
-                {
-                    var plot = new Site.Plot
-                    {
-                        LocalPos = new int2(rng.Next(-2, 3), rng.Next(-2, 3)),
-                        Kind = Site.PlotKind.House
-                    };
-                    site.Plots.Add(plot);
-                }
-
+                int houses = rng.Next(3, 6);
+                var site = SiteGenerator.GenerateSettlement(pos, houses, rng);
                 index.Sites.Insert(site);
             }
         }

--- a/VelorenPort/World/Src/Layer/DynamicLayers.cs
+++ b/VelorenPort/World/Src/Layer/DynamicLayers.cs
@@ -1,5 +1,6 @@
 using System;
 using Unity.Mathematics;
+using VelorenPort.World;
 
 namespace VelorenPort.World.Layer
 {
@@ -15,7 +16,8 @@ namespace VelorenPort.World.Layer
         Scatter,
         Shrub,
         Tree,
-        Wildlife
+        Wildlife,
+        OreVein
     }
 
     /// <summary>
@@ -25,6 +27,7 @@ namespace VelorenPort.World.Layer
     {
         public int2 ChunkPos { get; init; }
         public Random Rng { get; } = new();
+        public Canvas? Canvas { get; init; }
     }
 
     /// <summary>
@@ -37,10 +40,200 @@ namespace VelorenPort.World.Layer
         /// </summary>
         public static void Apply(LayerType layer, LayerContext ctx)
         {
-            // In the real implementation this would modify the chunk data.
-            // For now we simply simulate some work by consuming RNG values.
-            _ = ctx.Rng.Next();
-            // Future work: integrate generation logic from the Rust project.
+            switch (layer)
+            {
+                case LayerType.Cave:
+                    ApplyCaves(ctx);
+                    break;
+                case LayerType.Scatter:
+                    ApplyScatter(ctx);
+                    break;
+                case LayerType.Tree:
+                    ApplyTrees(ctx);
+                    break;
+                case LayerType.Shrub:
+                    ApplyShrubs(ctx);
+                    break;
+                case LayerType.Wildlife:
+                    ApplyWildlife(ctx);
+                    break;
+                case LayerType.OreVein:
+                    ApplyOreVeins(ctx);
+                    break;
+                default:
+                    // Fallback: consume RNG to mimic work
+                    _ = ctx.Rng.Next();
+                    break;
+            }
+        }
+
+        private static void ApplyCaves(LayerContext ctx)
+        {
+            if (ctx.Canvas == null) return;
+            int caves = ctx.Rng.Next(1, 3);
+            for (int i = 0; i < caves; i++)
+            {
+                int radius = ctx.Rng.Next(2, 5);
+                int3 center = new int3(
+                    ctx.Rng.Next(radius, Chunk.Size.x - radius),
+                    ctx.Rng.Next(radius, Chunk.Size.y - radius),
+                    ctx.Rng.Next(radius, Chunk.Height - radius));
+                CarveSphere(ctx.Canvas, center, radius);
+            }
+        }
+
+        private static void ApplyScatter(LayerContext ctx)
+        {
+            if (ctx.Canvas == null) return;
+            int count = ctx.Rng.Next(4, 10);
+            for (int i = 0; i < count; i++)
+            {
+                int2 pos = new int2(
+                    ctx.Rng.Next(0, Chunk.Size.x),
+                    ctx.Rng.Next(0, Chunk.Size.y));
+                int? ground = FindGround(ctx.Canvas.Chunk, pos);
+                if (ground == null || ground.Value >= Chunk.Height - 1) continue;
+                int3 bpos = new int3(pos.x, pos.y, ground.Value + 1);
+                if (!ctx.Canvas.Chunk[bpos.x, bpos.y, bpos.z].IsFilled)
+                    ctx.Canvas.SetBlock(bpos, new Block(BlockKind.Rock));
+            }
+        }
+
+        private static void ApplyWildlife(LayerContext ctx)
+        {
+            if (ctx.Canvas == null) return;
+            int count = ctx.Rng.Next(1, 4);
+            for (int i = 0; i < count; i++)
+            {
+                int2 pos = new int2(
+                    ctx.Rng.Next(0, Chunk.Size.x),
+                    ctx.Rng.Next(0, Chunk.Size.y));
+                int? ground = FindGround(ctx.Canvas.Chunk, pos);
+                if (ground == null || ground.Value >= Chunk.Height - 2) continue;
+                ctx.Canvas.Spawn(new int3(pos.x, pos.y, ground.Value + 1));
+            }
+        }
+
+        private static void ApplyOreVeins(LayerContext ctx)
+        {
+            if (ctx.Canvas == null) return;
+            int veins = ctx.Rng.Next(1, 4);
+            for (int i = 0; i < veins; i++)
+            {
+                int3 center = new int3(
+                    ctx.Rng.Next(4, Chunk.Size.x - 4),
+                    ctx.Rng.Next(4, Chunk.Size.y - 4),
+                    ctx.Rng.Next(4, Chunk.Height / 2));
+                int radius = ctx.Rng.Next(1, 3);
+                FillSphere(ctx.Canvas, center, radius, new Block(BlockKind.GlowingRock));
+            }
+        }
+
+        private static void CarveSphere(Canvas canvas, int3 center, int radius)
+        {
+            int r2 = radius * radius;
+            for (int x = center.x - radius; x <= center.x + radius; x++)
+            for (int y = center.y - radius; y <= center.y + radius; y++)
+            for (int z = center.z - radius; z <= center.z + radius; z++)
+            {
+                if (x < 0 || x >= Chunk.Size.x ||
+                    y < 0 || y >= Chunk.Size.y ||
+                    z < 0 || z >= Chunk.Height)
+                    continue;
+                int dx = x - center.x;
+                int dy = y - center.y;
+                int dz = z - center.z;
+                if (dx * dx + dy * dy + dz * dz <= r2)
+                    canvas.SetBlock(new int3(x, y, z), Block.Air);
+            }
+        }
+
+        private static void FillSphere(Canvas canvas, int3 center, int radius, Block block)
+        {
+            int r2 = radius * radius;
+            for (int x = center.x - radius; x <= center.x + radius; x++)
+            for (int y = center.y - radius; y <= center.y + radius; y++)
+            for (int z = center.z - radius; z <= center.z + radius; z++)
+            {
+                if (x < 0 || x >= Chunk.Size.x ||
+                    y < 0 || y >= Chunk.Size.y ||
+                    z < 0 || z >= Chunk.Height)
+                    continue;
+                int dx = x - center.x;
+                int dy = y - center.y;
+                int dz = z - center.z;
+                if (dx * dx + dy * dy + dz * dz <= r2)
+                    canvas.SetBlock(new int3(x, y, z), block);
+            }
+        }
+
+        private static void ApplyTrees(LayerContext ctx)
+        {
+            if (ctx.Canvas == null) return;
+            int count = ctx.Rng.Next(1, 4);
+            for (int i = 0; i < count; i++)
+            {
+                int2 pos = new int2(
+                    ctx.Rng.Next(0, Chunk.Size.x),
+                    ctx.Rng.Next(0, Chunk.Size.y));
+                BuildSimpleTree(ctx.Canvas, pos, ctx.Rng);
+            }
+        }
+
+        private static void ApplyShrubs(LayerContext ctx)
+        {
+            if (ctx.Canvas == null) return;
+            int count = ctx.Rng.Next(2, 6);
+            for (int i = 0; i < count; i++)
+            {
+                int2 pos = new int2(
+                    ctx.Rng.Next(0, Chunk.Size.x),
+                    ctx.Rng.Next(0, Chunk.Size.y));
+                BuildShrub(ctx.Canvas, pos);
+            }
+        }
+
+        private static void BuildSimpleTree(Canvas canvas, int2 local, Random rng)
+        {
+            int? ground = FindGround(canvas.Chunk, local);
+            if (ground == null || ground >= Chunk.Height - 5) return;
+
+            int height = rng.Next(3, 6);
+            for (int i = 1; i <= height; i++)
+            {
+                int z = ground.Value + i;
+                canvas.SetBlock(new int3(local.x, local.y, z), new Block(BlockKind.Wood));
+            }
+
+            int leafStart = ground.Value + height - 1;
+            for (int dx = -1; dx <= 1; dx++)
+            for (int dy = -1; dy <= 1; dy++)
+            for (int dz = 0; dz <= 1; dz++)
+            {
+                int3 pos = new int3(local.x + dx, local.y + dy, leafStart + dz);
+                if (pos.x < 0 || pos.x >= Chunk.Size.x ||
+                    pos.y < 0 || pos.y >= Chunk.Size.y ||
+                    pos.z < 0 || pos.z >= Chunk.Height)
+                    continue;
+                if (!canvas.Chunk[pos.x, pos.y, pos.z].IsFilled)
+                    canvas.SetBlock(pos, new Block(BlockKind.Leaves));
+            }
+        }
+
+        private static void BuildShrub(Canvas canvas, int2 local)
+        {
+            int? ground = FindGround(canvas.Chunk, local);
+            if (ground == null || ground >= Chunk.Height - 2) return;
+            int z = ground.Value + 1;
+            canvas.SetBlock(new int3(local.x, local.y, z), new Block(BlockKind.Leaves));
+        }
+
+        private static int? FindGround(Chunk chunk, int2 local)
+        {
+            for (int z = Chunk.Height - 1; z >= 0; z--)
+                if (chunk[local.x, local.y, z].IsFilled)
+                    return z;
+            return null;
         }
     }
 }

--- a/VelorenPort/World/Src/Lib.cs
+++ b/VelorenPort/World/Src/Lib.cs
@@ -65,6 +65,8 @@ namespace VelorenPort.World {
                             });
                         }
                     }
+                    // randomly tag additional chunks with simple spots
+                    SpotGenerator.Generate(world.Sim, 0.002f, new Random((int)index.Seed));
                     break;
                 case WorldGenerateStage.RegionGeneration:
                     foreach (var cpos in world.Sim.LoadedChunks)

--- a/VelorenPort/World/Src/Pathfinding.cs
+++ b/VelorenPort/World/Src/Pathfinding.cs
@@ -12,9 +12,18 @@ namespace VelorenPort.World {
         public float PathDiscount;
         public float GradientAversion;
 
-        public SearchCfg(float pathDiscount, float gradientAversion) {
+        /// <summary>
+        /// Optional dynamic cost function that can be used to influence the
+        /// search at runtime. This allows temporary navigation data such as
+        /// obstacles or preferred tiles to affect the path result.
+        /// </summary>
+        public Func<int2, float>? DynamicCost;
+
+        public SearchCfg(float pathDiscount, float gradientAversion,
+                          Func<int2, float>? dynamicCost = null) {
             PathDiscount = pathDiscount;
             GradientAversion = gradientAversion;
+            DynamicCost = dynamicCost;
         }
     }
 
@@ -45,6 +54,8 @@ namespace VelorenPort.World {
                 int2 wpos = TerrainChunkSize.CposToWposCenter(next);
                 float grad = _land.GetGradientApprox(wpos);
                 float cost = baseCost * (1f + grad * Cfg.GradientAversion);
+                if (Cfg.DynamicCost != null)
+                    cost += Cfg.DynamicCost(next);
                 yield return (next, cost);
             }
         }

--- a/VelorenPort/World/Src/Sim/Erosion.cs
+++ b/VelorenPort/World/Src/Sim/Erosion.cs
@@ -31,5 +31,16 @@ namespace VelorenPort.World.Sim {
                 chunk.Downhill = downhill;
             }
         }
+
+        /// <summary>
+        /// Run the simple erosion multiple times to smooth terrain more
+        /// aggressively. This approximates the iterative process used by the
+        /// Rust implementation but remains much cheaper.
+        /// </summary>
+        public static void IterativeApply(WorldSim sim, int iterations)
+        {
+            for (int i = 0; i < iterations; i++)
+                Apply(sim);
+        }
     }
 }

--- a/VelorenPort/World/Src/Sim/HumidityMap.cs
+++ b/VelorenPort/World/Src/Sim/HumidityMap.cs
@@ -66,4 +66,15 @@ public class HumidityMap
         foreach (var (pos, val) in next.Iterate())
             _map.Set(pos, val);
     }
+
+    /// <summary>
+    /// Run diffusion repeatedly to allow humidity to propagate further across
+    /// the map. This mirrors the iterative approach of the original Rust code
+    /// but without complex boundary conditions.
+    /// </summary>
+    public void RunDiffusion(int iterations, float strength = 0.25f)
+    {
+        for (int i = 0; i < iterations; i++)
+            Diffuse(strength);
+    }
 }

--- a/VelorenPort/World/Src/Site/Economy.cs
+++ b/VelorenPort/World/Src/Site/Economy.cs
@@ -7,6 +7,20 @@ namespace VelorenPort.World.Site {
     /// Each registered site advances its internal state every tick.
     /// </summary>
     public static class EconomySim {
+        private static readonly System.Collections.Generic.List<Economy.CaravanRoute> _caravans = new();
+
+        /// <summary>Active caravan routes transferring goods between sites.</summary>
+        public static System.Collections.Generic.IReadOnlyList<Economy.CaravanRoute> Caravans => _caravans;
+
+        /// <summary>Create and register a new caravan route.</summary>
+        public static Economy.CaravanRoute AddCaravanRoute(Economy.CaravanRoute route)
+        {
+            _caravans.Add(route);
+            return route;
+        }
+
+        /// <summary>Remove all caravan routes.</summary>
+        public static void ClearCaravanRoutes() => _caravans.Clear();
         /// <summary>
         /// Progress the economy of all sites contained in <paramref name="index"/>.
         /// </summary>
@@ -15,7 +29,11 @@ namespace VelorenPort.World.Site {
                 site.Economy.Tick(dt);
                 // Produce a small amount of food each tick for demonstration purposes
                 site.Economy.Produce(new Good.Food(), dt);
+                site.Economy.Market.Tick(dt);
             }
+
+            foreach (var caravan in _caravans)
+                caravan.Tick(dt);
         }
 
         /// <summary>

--- a/VelorenPort/World/Src/Site/Economy/CaravanRoute.cs
+++ b/VelorenPort/World/Src/Site/Economy/CaravanRoute.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace VelorenPort.World.Site.Economy
+{
+    /// <summary>
+    /// Very small representation of a caravan traveling between two sites.
+    /// On arrival it transfers a fixed amount of a single good from the origin
+    /// to the destination and then swaps direction.
+    /// </summary>
+    [Serializable]
+    public class CaravanRoute
+    {
+        public Site From { get; private set; }
+        public Site To { get; private set; }
+        public Good Good { get; }
+        public float Amount { get; }
+        public float TravelTime { get; }
+        private float _progress;
+
+        public CaravanRoute(Site from, Site to, Good good, float amount, float travelTime = 1f)
+        {
+            From = from;
+            To = to;
+            Good = good;
+            Amount = amount;
+            TravelTime = travelTime;
+            _progress = 0f;
+        }
+
+        public void Tick(float dt)
+        {
+            _progress += dt;
+            if (_progress < TravelTime)
+                return;
+            _progress -= TravelTime;
+
+            // Attempt trade: origin sells to destination via markets
+            if (From.Economy.Market.Sell(From.Economy, Good, Amount))
+            {
+                To.Economy.Market.Buy(To.Economy, Good, Amount);
+            }
+
+            // Swap direction for round trip
+            (From, To) = (To, From);
+        }
+    }
+}

--- a/VelorenPort/World/Src/Site/Economy/Market.cs
+++ b/VelorenPort/World/Src/Site/Economy/Market.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace VelorenPort.World.Site.Economy
+{
+    /// <summary>
+    /// Simple market allowing sites to buy and sell goods. Prices are
+    /// influenced by supply levels, approximating the dynamic behaviour of the
+    /// original Rust version albeit in a much simpler form.
+    /// </summary>
+    [Serializable]
+    public class Market
+    {
+        private readonly Dictionary<Good, float> _basePrices = new();
+        private readonly Dictionary<Good, float> _stock = new();
+
+        /// <summary>
+        /// Desired stock level used when calculating price adjustments.
+        /// </summary>
+        public float TargetStock { get; set; } = 10f;
+
+        /// <summary>Set the price of <paramref name="good"/>.</summary>
+        public void SetPrice(Good good, float price) => _basePrices[good] = price;
+
+        /// <summary>Retrieve the price of <paramref name="good"/> or 1 if unset.</summary>
+        public float GetPrice(Good good)
+        {
+            float basePrice = _basePrices.TryGetValue(good, out var p) ? p : 1f;
+            _stock.TryGetValue(good, out var stock);
+            float factor = 1f + (TargetStock - stock) / TargetStock;
+            factor = Clamp(factor, 0.5f, 2f);
+            return basePrice * factor;
+        }
+
+        /// <summary>
+        /// Attempt to buy <paramref name="amount"/> of <paramref name="good"/> from this market.
+        /// Returns <c>true</c> if the buyer had enough coin.
+        /// </summary>
+        public bool Buy(EconomyData buyer, Good good, float amount)
+        {
+            float cost = GetPrice(good) * amount;
+            if (buyer.Coin < cost || amount <= 0f)
+                return false;
+            buyer.Coin -= cost;
+            buyer.Produce(good, amount);
+            _stock.TryGetValue(good, out var stock);
+            _stock[good] = Clamp(stock - amount, 0f, float.MaxValue);
+            return true;
+        }
+
+        /// <summary>
+        /// Sell <paramref name="amount"/> of <paramref name="good"/> to this market.
+        /// </summary>
+        public bool Sell(EconomyData seller, Good good, float amount)
+        {
+            if (!seller.Consume(good, amount) || amount <= 0f)
+                return false;
+            float value = GetPrice(good) * amount;
+            seller.Coin += value;
+            _stock.TryGetValue(good, out var stock);
+            _stock[good] = stock + amount;
+            return true;
+        }
+
+        /// <summary>
+        /// Very small decay of stored stock to mimic consumption and let prices
+        /// drift back towards their base value.
+        /// </summary>
+        public void Tick(float dt)
+        {
+            foreach (var key in _stock.Keys.ToArray())
+            {
+                float val = _stock[key] - dt;
+                _stock[key] = val <= 0f ? 0f : val;
+            }
+        }
+
+        private static float Clamp(float v, float min, float max)
+            => v < min ? min : (v > max ? max : v);
+    }
+}

--- a/VelorenPort/World/Src/Site/Gen/SiteGenerator.cs
+++ b/VelorenPort/World/Src/Site/Gen/SiteGenerator.cs
@@ -1,0 +1,61 @@
+using System;
+using Unity.Mathematics;
+
+namespace VelorenPort.World.Site.Gen;
+
+/// <summary>
+/// Basic settlement generator used by <see cref="VelorenPort.World.Civ.CivGenerator"/>.
+/// Creates a site with a central plaza and a grid of houses connected by simple
+/// road plots. This expands on the previous minimal implementation but still
+/// lacks detailed decorations from the Rust version.
+/// </summary>
+public static class SiteGenerator
+{
+    /// <summary>Create a settlement at <paramref name="pos"/> with at least
+    /// <paramref name="houseCount"/> houses.</summary>
+    public static Site GenerateSettlement(int2 pos, int houseCount, Random rng)
+    {
+        var site = new Site
+        {
+            Position = pos,
+            Origin = pos,
+            Name = NameGen.Generate(rng),
+            Kind = SiteKind.Settlement
+        };
+
+        // Central plaza at origin
+        site.Plots.Add(new Plot { LocalPos = int2.zero, Kind = PlotKind.Plaza });
+
+        // Place houses in a 3x3 grid around the plaza
+        int placed = 0;
+        for (int y = -1; y <= 1 && placed < houseCount; y++)
+        for (int x = -1; x <= 1 && placed < houseCount; x++)
+        {
+            if (x == 0 && y == 0) continue;
+            site.Plots.Add(new Plot
+            {
+                LocalPos = new int2(x * 4, y * 4),
+                Kind = PlotKind.House
+            });
+            placed++;
+        }
+
+
+        // Simple roads along X and Y axes
+        for (int d = -4; d <= 4; d += 4)
+        {
+            if (d == 0) continue;
+            site.Plots.Add(new Plot { LocalPos = new int2(d, 0), Kind = PlotKind.Road });
+            site.Plots.Add(new Plot { LocalPos = new int2(0, d), Kind = PlotKind.Road });
+        }
+
+        // Farms a short distance from the plaza
+        int farmDist = 8;
+        site.Plots.Add(new Plot { LocalPos = new int2(farmDist, 0), Kind = PlotKind.Farm });
+        site.Plots.Add(new Plot { LocalPos = new int2(-farmDist, 0), Kind = PlotKind.Farm });
+        site.Plots.Add(new Plot { LocalPos = new int2(0, farmDist), Kind = PlotKind.Farm });
+        site.Plots.Add(new Plot { LocalPos = new int2(0, -farmDist), Kind = PlotKind.Farm });
+
+        return site;
+    }
+}

--- a/VelorenPort/World/Src/Site/Site.cs
+++ b/VelorenPort/World/Src/Site/Site.cs
@@ -80,6 +80,7 @@ namespace VelorenPort.World.Site {
     public class EconomyData {
         public Dictionary<Good, float> Stocks { get; } = new();
         public float Coin { get; set; } = 0f;
+        public Economy.Market Market { get; } = new Economy.Market();
 
         /// <summary>Retrieve the amount of <paramref name="good"/> in stock.</summary>
         public float GetStock(Good good)

--- a/VelorenPort/World/Src/SpotGenerator.cs
+++ b/VelorenPort/World/Src/SpotGenerator.cs
@@ -1,0 +1,55 @@
+using System;
+using Unity.Mathematics;
+
+namespace VelorenPort.World;
+
+/// <summary>
+/// Simple placement of <see cref="Spot"/> values across the world simulation.
+/// This does not load any external manifests and only tags chunks with a random
+/// spot type.
+/// </summary>
+public static class SpotGenerator
+{
+    /// <summary>Assign random spots to chunks according to the given density.</summary>
+    /// <param name="sim">World simulation to modify.</param>
+    /// <param name="density">Approximate fraction of chunks that receive a spot.</param>
+    /// <param name="rng">Optional RNG instance for deterministic placement.</param>
+public static void Generate(
+    WorldSim sim,
+    float density = 0.002f,
+    Random? rng = null,
+    SpotManifest? manifest = null)
+{
+    rng ??= new Random();
+    int2 size = sim.GetSize();
+    if (manifest != null && manifest.Spots.Count > 0)
+    {
+        foreach (var (spot, props) in manifest.Spots)
+        {
+            if (!props.Spawn) continue;
+            int total = (int)(size.x * size.y * density * props.Freq);
+            for (int i = 0; i < total; i++)
+            {
+                int2 pos = new int2(rng.Next(0, size.x), rng.Next(0, size.y));
+                var chunk = sim.Get(pos);
+                if (chunk == null || chunk.Spot != null)
+                    continue;
+                chunk.Spot = spot;
+            }
+        }
+    }
+    else
+    {
+        int total = (int)(size.x * size.y * density);
+        var spots = Enum.GetValues(typeof(Spot));
+        for (int i = 0; i < total; i++)
+        {
+            int2 pos = new int2(rng.Next(0, size.x), rng.Next(0, size.y));
+            var chunk = sim.Get(pos);
+            if (chunk == null || chunk.Spot != null)
+                continue;
+            chunk.Spot = (Spot)spots.GetValue(rng.Next(spots.Length))!;
+        }
+    }
+}
+}

--- a/VelorenPort/World/Src/SpotManifest.cs
+++ b/VelorenPort/World/Src/SpotManifest.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace VelorenPort.World;
+
+/// <summary>
+/// Utility for loading <see cref="SpotProperties"/> from JSON files.
+/// Each file name must match a value of <see cref="Spot"/>.
+/// </summary>
+[Serializable]
+public class SpotManifest
+{
+    public Dictionary<Spot, SpotProperties> Spots { get; } = new();
+
+    /// <summary>Load all JSON manifests in <paramref name="directory"/>.</summary>
+    public static SpotManifest LoadFromDir(string directory)
+    {
+        var manifest = new SpotManifest();
+        if (!Directory.Exists(directory))
+            return manifest;
+
+        foreach (var file in Directory.GetFiles(directory, "*.json"))
+        {
+            try
+            {
+                string name = Path.GetFileNameWithoutExtension(file);
+                if (!Enum.TryParse(name, out Spot spot))
+                    continue;
+                var props = JsonSerializer.Deserialize<SpotProperties>(File.ReadAllText(file));
+                if (props != null)
+                    manifest.Spots[spot] = props;
+            }
+            catch
+            {
+                // ignore malformed files
+            }
+        }
+        return manifest;
+    }
+}


### PR DESCRIPTION
## Summary
- expose region events and history via RegionMap
- document limited event history in missing features
- test region event recording and history limits

## Testing
- `dotnet build VelorenPort/VelorenPort.sln -v minimal` *(fails: command not found)*
- `dotnet test VelorenPort/VelorenPort.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68608ce9ae108328a29769c297b7c64d