### PR TITLE
Add chase and flee behaviour to NPCs

### DIFF
--- a/VelorenPort/CoreEngine/Src/NativeMath.cs
+++ b/VelorenPort/CoreEngine/Src/NativeMath.cs
@@ -283,5 +283,12 @@ namespace VelorenPort.NativeMath {
         private System.Random _rng;
         public Random(uint seed) { _rng = new System.Random((int)seed); }
         public float3 NextFloat3() => new float3((float)_rng.NextDouble(), (float)_rng.NextDouble(), (float)_rng.NextDouble());
+        public float2 NextFloat2(float min, float max)
+        {
+            float range = max - min;
+            return new float2(
+                (float)_rng.NextDouble() * range + min,
+                (float)_rng.NextDouble() * range + min);
+        }
     }
 }

--- a/VelorenPort/CoreEngine/Src/Npc.cs
+++ b/VelorenPort/CoreEngine/Src/Npc.cs
@@ -33,11 +33,11 @@ namespace VelorenPort.CoreEngine {
                 case NpcState.Idle:
                     IdleTime += dt;
                     if (IdleTime > 5f) {
-                        State = NpcState.Wandering;
+                        State = NpcState.Patrol;
                         IdleTime = 0f;
                     }
                     break;
-                case NpcState.Wandering:
+                case NpcState.Patrol:
                     // Wander for a short time then return to idle
                     IdleTime += dt;
                     if (IdleTime > 3f)
@@ -46,6 +46,8 @@ namespace VelorenPort.CoreEngine {
                         IdleTime = 0f;
                     }
                     break;
+                case NpcState.Chase:
+                case NpcState.Flee:
                 case NpcState.Combat:
                     // In this stub we simply stay in combat
                     break;
@@ -64,7 +66,9 @@ namespace VelorenPort.CoreEngine {
 
     public enum NpcState {
         Idle,
-        Wandering,
+        Patrol,
+        Chase,
+        Flee,
         Combat
     }
 }

--- a/VelorenPort/CoreEngine/Src/Vel.cs
+++ b/VelorenPort/CoreEngine/Src/Vel.cs
@@ -1,0 +1,27 @@
+using System;
+using VelorenPort.NativeMath;
+
+namespace VelorenPort.CoreEngine
+{
+    /// <summary>
+    /// Simple velocity component mirroring the Rust <c>Vel</c> struct.
+    /// </summary>
+    [Serializable]
+    public struct Vel
+    {
+        public float3 Value;
+
+        public Vel(float3 value)
+        {
+            Value = value;
+        }
+
+        public static Vel Zero => new Vel(float3.zero);
+
+        /// <summary>Direction of the velocity or zero if stationary.</summary>
+        public float3 Direction => math.lengthsq(Value) > 0f ? math.normalize(Value) : float3.zero;
+
+        public static implicit operator float3(Vel v) => v.Value;
+        public static implicit operator Vel(float3 v) => new Vel(v);
+    }
+}

--- a/VelorenPort/Server/Src/StateExt.cs
+++ b/VelorenPort/Server/Src/StateExt.cs
@@ -12,6 +12,7 @@ namespace VelorenPort.Server {
         public static Entity CreateNpc(EntityManager em, float3 pos, string name) {
             var entity = em.CreateEntity();
             em.AddComponentData(entity, new Pos(pos));
+            em.AddComponentData(entity, new Vel(float3.zero));
             em.AddComponentData(entity, new Npc(new Uid((uint)entity.Index)) { Name = name });
             return entity;
         }

--- a/VelorenPort/Server/Src/Sys/NpcAiSystem.cs
+++ b/VelorenPort/Server/Src/Sys/NpcAiSystem.cs
@@ -14,6 +14,8 @@ namespace VelorenPort.Server.Sys;
 public static class NpcAiSystem
 {
     private const float WanderRange = 1f;
+    private const float ChaseSpeed = 3f;
+    private const float FleeSpeed = 4f;
     private const float AttackRange = 2f;
     private const float AttackDamage = 5f;
 
@@ -26,24 +28,88 @@ public static class NpcAiSystem
             if (!em.TryGetComponentData(ent, out Pos pos))
                 continue;
 
+            var vel = em.TryGetComponentData(ent, out Vel v) ? v : Vel.Zero;
             npc.Tick(dt);
-            if (npc.State == NpcState.Wandering)
-            {
-                float2 dir = math.normalizesafe(rand.NextFloat2(-1f, 1f));
-                var move = new float3(dir.x, 0f, dir.y) * WanderRange * dt;
-                em.SetComponentData(ent, new Pos(pos.Value + move));
-            }
 
+            // Find nearest player or pet
+            float3 targetPos = default;
+            float bestDist = float.MaxValue;
+            Client? targetClient = null;
             foreach (var c in clients)
             {
-                if (math.distance(c.Position.Value, pos.Value) <= AttackRange)
+                float dist = math.distance(c.Position.Value, pos.Value);
+                if (dist < bestDist)
                 {
-                    npc.EnterCombat();
-                    var attack = new Attack(npc.Id, new HitInfo(c.Uid, AttackDamage, DamageKind.Physical));
-                    CombatUtils.Apply(c, attack, null);
+                    bestDist = dist;
+                    targetPos = c.Position.Value;
+                    targetClient = c;
+                }
+            }
+            foreach (var (owner, pet) in Pet.EnumeratePets())
+            {
+                if (!em.TryGetComponentData(pet, out Pos pPos))
+                    continue;
+                float dist = math.distance(pPos.Value, pos.Value);
+                if (dist < bestDist)
+                {
+                    bestDist = dist;
+                    targetPos = pPos.Value;
+                    targetClient = null;
                 }
             }
 
+            // State transitions based on proximity
+            if (bestDist <= AttackRange)
+            {
+                npc.EnterCombat();
+                if (targetClient != null)
+                {
+                    var attack = new Attack(npc.Id, new HitInfo(targetClient.Uid, AttackDamage, DamageKind.Physical));
+                    CombatUtils.Apply(targetClient, attack, null);
+                }
+            }
+            else if (bestDist < 10f)
+            {
+                npc.State = npc.Health < 30f ? NpcState.Flee : NpcState.Chase;
+            }
+            else if (npc.State is NpcState.Chase or NpcState.Flee)
+            {
+                npc.State = NpcState.Patrol;
+            }
+
+            // Movement behaviour per state
+            switch (npc.State)
+            {
+                case NpcState.Patrol:
+                    {
+                        float2 dir = rand.NextFloat2(-1f, 1f);
+                        dir = math.lengthsq(dir) > 0f ? math.normalize(dir) : float2.zero;
+                        var move = new float3(dir.x, 0f, dir.y) * WanderRange * dt;
+                        pos = new Pos(pos.Value + move);
+                        vel = new Vel(move / dt);
+                        break;
+                    }
+                case NpcState.Chase:
+                    {
+                        float3 dir = math.normalize(targetPos - pos.Value);
+                        vel = new Vel(dir * ChaseSpeed);
+                        pos = new Pos(pos.Value + vel.Value * dt);
+                        break;
+                    }
+                case NpcState.Flee:
+                    {
+                        float3 dir = math.normalize(pos.Value - targetPos);
+                        vel = new Vel(dir * FleeSpeed);
+                        pos = new Pos(pos.Value + vel.Value * dt);
+                        break;
+                    }
+            }
+
+            em.SetComponentData(ent, pos);
+            if (em.HasComponent<Vel>(ent))
+                em.SetComponentData(ent, vel);
+            else
+                em.AddComponentData(ent, vel);
             em.SetComponentData(ent, npc);
         }
     }


### PR DESCRIPTION
## Summary
- create `Vel` component for velocity tracking
- extend `NpcState` with patrol, chase and flee states
- update `NpcAiSystem` to chase players or flee when low on health
- initialize NPCs with a `Vel` component
- provide `NextFloat2` helper in `NativeMath.Random`

## Testing
- `dotnet test VelorenPort/VelorenPort.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68614658e7a48328bc5b85380394246a