### PR TITLE
Implement chat channels and new commands

### DIFF
--- a/VelorenPort/CoreEngine/Src/Cmd.cs
+++ b/VelorenPort/CoreEngine/Src/Cmd.cs
@@ -29,6 +29,8 @@ namespace VelorenPort.CoreEngine {
         AcceptInvite,
         DeclineInvite,
         SetWaypoint,
+        Whisper,
+        Team,
     }
 
     /// <summary>Simple registry mapping commands to their metadata.</summary>
@@ -42,6 +44,8 @@ namespace VelorenPort.CoreEngine {
             { ServerChatCommand.AcceptInvite, new ChatCommandData(new[]{"uid","kind"}, "Accept a pending invite", false) },
             { ServerChatCommand.DeclineInvite, new ChatCommandData(new[]{"uid","kind"}, "Decline a pending invite", false) },
             { ServerChatCommand.SetWaypoint, new ChatCommandData(Array.Empty<string>(), "Set a personal waypoint", false) },
+            { ServerChatCommand.Whisper, new ChatCommandData(new[]{"uid","message"}, "Send a private message", false) },
+            { ServerChatCommand.Team, new ChatCommandData(new[]{"message"}, "Send a message to your group", false) },
         };
 
         public static ChatCommandData Data(ServerChatCommand cmd) => _data[cmd];

--- a/VelorenPort/Server.Tests/ChatSystemAutoModTests.cs
+++ b/VelorenPort/Server.Tests/ChatSystemAutoModTests.cs
@@ -37,7 +37,8 @@ public class ChatSystemAutoModTests
             emitter.Emit(new ChatEvent(msg, true));
         }
         var automod = new AutoMod(new ModerationSettings { Automod = true }, new Censor(new[] { "badword" }));
-        ChatSystem.Update(events, exporter, automod, new[] { client });
+        var gm = new GroupManager();
+        ChatSystem.Update(events, exporter, automod, new[] { client }, gm);
         Task.Delay(50).Wait();
         Assert.Empty(cache.Messages);
     }
@@ -56,7 +57,8 @@ public class ChatSystemAutoModTests
             emitter.Emit(new ChatEvent(msg, true));
         }
         var automod = new AutoMod(new ModerationSettings { Automod = true }, new Censor(new[] { "badword" }));
-        ChatSystem.Update(events, exporter, automod, new[] { client });
+        var gm2 = new GroupManager();
+        ChatSystem.Update(events, exporter, automod, new[] { client }, gm2);
         Task.Delay(50).Wait();
         Assert.Single(cache.Messages);
     }

--- a/VelorenPort/Server.Tests/CmdTests.cs
+++ b/VelorenPort/Server.Tests/CmdTests.cs
@@ -4,6 +4,7 @@ using VelorenPort.NativeMath;
 using VelorenPort.CoreEngine;
 using VelorenPort.Server;
 using VelorenPort.Network;
+using VelorenPort.Server.Sys;
 
 namespace Server.Tests;
 
@@ -15,6 +16,14 @@ public class CmdTests
         Assert.True(Cmd.TryParse("/say hello world", out var cmd, out var args));
         Assert.Equal(ServerChatCommand.Say, cmd);
         Assert.Equal(new[] { "hello", "world" }, args);
+    }
+
+    [Fact]
+    public void TryParse_ParsesWhisper()
+    {
+        Assert.True(Cmd.TryParse("/whisper 1 hi", out var cmd, out var args));
+        Assert.Equal(ServerChatCommand.Whisper, cmd);
+        Assert.Equal(new[] { "1", "hi" }, args);
     }
 
     [Fact]
@@ -99,5 +108,45 @@ public class CmdTests
         Cmd.Execute(ServerChatCommand.Invite, server, inviter, new[] { invitee.Uid.Value.ToString(), "Group" });
 
         Assert.Single(inviter.PendingInvites.Invites);
+    }
+
+    [Fact]
+    public void ExecuteWhisper_AddsChatEvent()
+    {
+        var server = new GameServer(Pid.NewPid(), TimeSpan.FromMilliseconds(1), 1);
+        var p1 = (Participant)Activator.CreateInstance(
+            typeof(Participant), BindingFlags.NonPublic | BindingFlags.Instance,
+            new object?[] { Pid.NewPid(), new ConnectAddr.Mpsc(1), Guid.NewGuid(), null, null, null })!;
+        var sender = (Client)Activator.CreateInstance(
+            typeof(Client), BindingFlags.NonPublic | BindingFlags.Instance,
+            new object?[] { p1 })!;
+        var p2 = (Participant)Activator.CreateInstance(
+            typeof(Participant), BindingFlags.NonPublic | BindingFlags.Instance,
+            new object?[] { Pid.NewPid(), new ConnectAddr.Mpsc(2), Guid.NewGuid(), null, null, null })!;
+        var receiver = (Client)Activator.CreateInstance(
+            typeof(Client), BindingFlags.NonPublic | BindingFlags.Instance,
+            new object?[] { p2 })!;
+        var list = (System.Collections.IList)typeof(GameServer).GetField("_clients", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(server)!;
+        list.Add(sender);
+        list.Add(receiver);
+        Cmd.Execute(ServerChatCommand.Whisper, server, sender, new[] { receiver.Uid.Value.ToString(), "hi" });
+        var (cache, exporter) = Chat.ChatCache.Create(TimeSpan.FromSeconds(1));
+        ChatSystem.Update(server.Events, exporter, new AutoMod(new ModerationSettings(), new Censor(Array.Empty<string>())), new[] { sender, receiver }, server.GroupManager);
+        Assert.Single(cache.Messages);
+        Assert.IsType<Chat.ChatParties.Tell>(cache.Messages[0].Parties);
+    }
+
+    [Fact]
+    public void ExecuteTeam_RequiresGroup()
+    {
+        var server = new GameServer(Pid.NewPid(), TimeSpan.FromMilliseconds(1), 1);
+        var p = (Participant)Activator.CreateInstance(
+            typeof(Participant), BindingFlags.NonPublic | BindingFlags.Instance,
+            new object?[] { Pid.NewPid(), new ConnectAddr.Mpsc(1), Guid.NewGuid(), null, null, null })!;
+        var client = (Client)Activator.CreateInstance(
+            typeof(Client), BindingFlags.NonPublic | BindingFlags.Instance,
+            new object?[] { p })!;
+        var result = Cmd.Execute(ServerChatCommand.Team, server, client, new[] { "hi" });
+        Assert.Equal("Not in a group", result);
     }
 }

--- a/VelorenPort/Server/Src/Cmd.cs
+++ b/VelorenPort/Server/Src/Cmd.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using VelorenPort.NativeMath;
 using VelorenPort.CoreEngine;
 using VelorenPort.CoreEngine.comp;
+using VelorenPort.Server.Events;
 
 namespace VelorenPort.Server;
 
@@ -81,6 +82,38 @@ public static class Cmd
             case ServerChatCommand.SetWaypoint:
                 client.Waypoint = new Waypoint { Position = client.Position.Value };
                 return "Waypoint set";
+            case ServerChatCommand.Whisper:
+                if (args.Length >= 2 && ulong.TryParse(args[0], out var toUid))
+                {
+                    var target = server.Clients.FirstOrDefault(c => c.Uid.Value == toUid);
+                    if (target == null)
+                        return "Player not found";
+                    var text = string.Join(' ', args.Skip(1));
+                    using (var emitter = server.Events.GetChatEmitter())
+                    {
+                        var msg = new UnresolvedChatMsg(
+                            new ChatType<Group>.Tell<Group>(client.Uid, target.Uid),
+                            new Content.Plain(text));
+                        emitter.Emit(new ChatEvent(msg, true));
+                    }
+                    return "Whisper sent";
+                }
+                return "Usage: /whisper <uid> <message>";
+            case ServerChatCommand.Team:
+                var group = server.GroupManager.GetGroup(client.Uid);
+                if (group == null)
+                    return "Not in a group";
+                if (args.Length == 0)
+                    return "Usage: /team <message>";
+                var gText = string.Join(' ', args);
+                using (var emitter = server.Events.GetChatEmitter())
+                {
+                    var msg = new UnresolvedChatMsg(
+                        new ChatType<Group>.Group<Group>(client.Uid, group.Value),
+                        new Content.Plain(gText));
+                    emitter.Emit(new ChatEvent(msg, true));
+                }
+                return gText;
             default:
                 return "Unknown command";
         }

--- a/VelorenPort/Server/Src/GameServer.cs
+++ b/VelorenPort/Server/Src/GameServer.cs
@@ -129,7 +129,7 @@ namespace VelorenPort.Server {
             }
 
             InviteTimeout.Update(_clients);
-            ChatSystem.Update(_eventManager, _chatExporter, _autoMod, _clients);
+            ChatSystem.Update(_eventManager, _chatExporter, _autoMod, _clients, _groupManager);
             WeatherSystem.Update(WorldIndex, _weatherJob, _clients);
             TeleporterSystem.Update(_clients, _teleporters);
             PortalSystem.Update(WorldIndex.EntityManager, _clients, (float)Clock.Dt.TotalSeconds);


### PR DESCRIPTION
## Summary
- support whisper, team, world and local chat in `ChatSystem`
- extend command parsing with `/whisper` and `/team`
- add new command metadata in `CoreEngine`
- wire `ChatSystem` into `GameServer`
- update tests for new behaviour

## Testing
- `dotnet build VelorenPort/VelorenPort.sln` *(fails: command not found)*
- `dotnet test VelorenPort/VelorenPort.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861465dfe8c83288f3c456cf0cbbcc6