### PR TITLE
Align UDP handshake with TCP/QUIC

### DIFF
--- a/VelorenPort/Network/Src/Network.cs
+++ b/VelorenPort/Network/Src/Network.cs
@@ -215,17 +215,17 @@ namespace VelorenPort.Network {
                 var remote = result.RemoteEndPoint;
                 Metrics.IncomingConnection(new ConnectAddr.Udp(remote));
                 if (!_udpMap.TryGetValue(remote, out var participant)) {
-                    if (Handshake.TryParse(result.Buffer, out var pid, out var secret, out var flags, out var ver)) {
-                        var reply = Handshake.GetBytes(LocalPid, _localSecret, _features);
-                        _udpListener.SendAsync(reply, reply.Length, remote).ConfigureAwait(false);
+                    try {
+                        using var stream = new UdpHandshakeStream(_udpListener, remote, result.Buffer);
+                        var (pid, secret, flags, ver, offset) = await Handshake.PerformAsync(stream, false, LocalPid, _localSecret, _features, token);
                         var agreed = flags & _features;
-                        participant = new Participant(pid, new ConnectAddr.Udp(remote), secret, null, null, _udpListener, Metrics, agreed, Types.STREAM_ID_OFFSET2, ver);
+                        participant = new Participant(pid, new ConnectAddr.Udp(remote), secret, null, null, _udpListener, Metrics, agreed, offset, ver);
                         _participants[participant.Id] = participant;
                         _udpMap[remote] = participant;
                         _pending.Enqueue(participant);
                         ParticipantConnected?.Invoke(participant);
                         await participant.OpenStreamAsync(participant.NextSid(), new StreamParams(Promises.Ordered));
-                    } else {
+                    } catch {
                         Metrics.FailedHandshake();
                     }
                 } else {
@@ -277,12 +277,8 @@ namespace VelorenPort.Network {
         }
 
         private static async Task<(Pid pid, Guid secret, HandshakeFeatures features, uint[] version, Sid offset)> SendUdpHandshakeAsync(UdpClient client, IPEndPoint remote, Pid localPid, Guid localSecret, HandshakeFeatures features) {
-            var buffer = Handshake.GetBytes(localPid, localSecret, features);
-            await client.SendAsync(buffer, buffer.Length);
-            var result = await client.ReceiveAsync();
-            if (!Handshake.TryParse(result.Buffer, out var pid, out var secret, out var features, out var version))
-                throw new NetworkConnectError.Handshake(new InitProtocolError<ProtocolsError>.NotHandshake());
-            return (pid, secret, features, version, Types.STREAM_ID_OFFSET1);
+            using var stream = new UdpHandshakeStream(client, remote);
+            return await Handshake.PerformAsync(stream, true, localPid, localSecret, features);
         }
 
         private static void StartMpscRelay(Stream a, Stream b) {

--- a/VelorenPort/Network/Src/UdpHandshakeStream.cs
+++ b/VelorenPort/Network/Src/UdpHandshakeStream.cs
@@ -1,0 +1,67 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VelorenPort.Network {
+    internal sealed class UdpHandshakeStream : Stream {
+        private readonly UdpClient _client;
+        private readonly IPEndPoint _remote;
+        private byte[] _buffer = Array.Empty<byte>();
+        private int _pos;
+
+        public UdpHandshakeStream(UdpClient client, IPEndPoint remote, byte[]? first = null) {
+            _client = client;
+            _remote = remote;
+            if (first != null && first.Length > 0) {
+                _buffer = first;
+                _pos = 0;
+            }
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override void Flush() { }
+        public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            ReadAsync(buffer.AsMemory(offset, count), CancellationToken.None).Result;
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            await ReadAsync(buffer.AsMemory(offset, count), cancellationToken);
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default) {
+            if (_pos >= _buffer.Length) {
+                UdpReceiveResult result;
+                do {
+                    result = await _client.ReceiveAsync(cancellationToken);
+                } while (!result.RemoteEndPoint.Equals(_remote));
+                _buffer = result.Buffer;
+                _pos = 0;
+            }
+            int toCopy = Math.Min(destination.Length, _buffer.Length - _pos);
+            _buffer.AsSpan(_pos, toCopy).CopyTo(destination.Span);
+            _pos += toCopy;
+            return toCopy;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            WriteAsync(buffer.AsMemory(offset, count), CancellationToken.None).GetAwaiter().GetResult();
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            await WriteAsync(buffer.AsMemory(offset, count), cancellationToken);
+
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default) {
+            await _client.SendAsync(source.ToArray(), source.Length, _remote);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
## Summary
- implement `UdpHandshakeStream` to wrap UDP datagrams in a `Stream`
- use the new stream in `SendUdpHandshakeAsync`
- use the new stream in `AcceptUdpAsync` so UDP handshakes go through `Handshake.PerformAsync`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68614a6748248328be6a56189fe5bde2