### PR TITLE
Implement login persistence features

### DIFF
--- a/VelorenPort/Server/MissingFeatures.md
+++ b/VelorenPort/Server/MissingFeatures.md
@@ -34,8 +34,8 @@ removing code.
   not perform heavy world calculations like the original.
 - **Metrics and monitoring**: `PrometheusExporter` exposes a few counters,
   lacking the detailed metrics collected by the Rust server.
-- **Administration CLI**: advanced commands and configuration helpers from
-  `server-cli` are not fully translated.
+- **Administration CLI**: basic admin and banlist management commands are now
+  available, though more helpers from `server-cli` remain to be ported.
 
 ## Recent progress
 

--- a/VelorenPort/Server/Src/Settings/Banlist.cs
+++ b/VelorenPort/Server/Src/Settings/Banlist.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text.Json;
+using VelorenPort.CoreEngine;
+
+namespace VelorenPort.Server.Settings {
+    /// <summary>
+    /// Simple ban list storage mirroring the Rust implementation in a minimal
+    /// form. Entries are loaded from and saved to disk as JSON.
+    /// </summary>
+    public class Banlist {
+        public record BanInfo(string Reason, long? Until);
+
+        public record Ban(BanInfo Info, DateTime? EndDate) {
+            public bool IsExpired(DateTime now) => EndDate.HasValue && EndDate.Value <= now;
+            public AdminRole PerformedByRole() => AdminRole.Admin;
+            public BanInfo GetInfo() => Info;
+        }
+
+        public abstract record BanAction {
+            public sealed record Unban(BanInfo Info) : BanAction;
+            public sealed record Apply(Ban Data) : BanAction {
+                public Ban Data { get; } = Data;
+            }
+            public Ban? AsBan() => this is Apply a ? a.Data : null;
+        }
+
+        public record BanRecord(string UsernameWhenPerformed, BanAction Action, DateTime Date) {
+            public bool IsExpired(DateTime now) => Action switch {
+                BanAction.Apply b => b.Data.IsExpired(now),
+                _ => true
+            };
+        }
+
+        public record BanEntry(BanRecord Current);
+
+        private readonly Dictionary<Guid, BanEntry> _uuidBans = new();
+        private readonly Dictionary<LoginProvider.NormalizedIpAddr, BanEntry> _ipBans = new();
+
+        public IReadOnlyDictionary<Guid, BanEntry> UuidBans() => _uuidBans;
+        public IReadOnlyDictionary<LoginProvider.NormalizedIpAddr, BanEntry> IpBans() => _ipBans;
+
+        public void BanUuid(Guid uuid, string username, BanInfo info, DateTime? endDate) {
+            _uuidBans[uuid] = new BanEntry(new BanRecord(username,
+                new BanAction.Apply(new Ban(info, endDate)), DateTime.UtcNow));
+        }
+
+        public void UnbanUuid(Guid uuid, string username, BanInfo info) {
+            _uuidBans[uuid] = new BanEntry(new BanRecord(username,
+                new BanAction.Unban(info), DateTime.UtcNow));
+        }
+
+        public void BanIp(IPAddress ip, string username, BanInfo info, DateTime? endDate) {
+            var key = new LoginProvider.NormalizedIpAddr(ip);
+            _ipBans[key] = new BanEntry(new BanRecord(username,
+                new BanAction.Apply(new Ban(info, endDate)), DateTime.UtcNow));
+        }
+
+        public void UnbanIp(IPAddress ip, string username, BanInfo info) {
+            var key = new LoginProvider.NormalizedIpAddr(ip);
+            _ipBans[key] = new BanEntry(new BanRecord(username,
+                new BanAction.Unban(info), DateTime.UtcNow));
+        }
+
+        public bool TryGetActiveBan(Guid uuid, IPAddress? ip, DateTime now, out Ban? ban) {
+            ban = null;
+            if (_uuidBans.TryGetValue(uuid, out var be))
+                ban = be.Current.Action.AsBan();
+            if (ban == null && ip != null && _ipBans.TryGetValue(new LoginProvider.NormalizedIpAddr(ip), out var ibe))
+                ban = ibe.Current.Action.AsBan();
+            if (ban != null && LoginProvider.BanApplies(ban, null, now))
+                return true;
+            ban = null;
+            return false;
+        }
+
+        public static Banlist Load(string path) {
+            if (!File.Exists(path))
+                return new Banlist();
+            try {
+                var json = File.ReadAllText(path);
+                var data = JsonSerializer.Deserialize<BanFile>(json);
+                var list = new Banlist();
+                if (data != null) {
+                    foreach (var b in data.UuidBans)
+                        list._uuidBans[b.Uuid] = new BanEntry(b.Record);
+                    foreach (var b in data.IpBans)
+                        list._ipBans[new LoginProvider.NormalizedIpAddr(IPAddress.Parse(b.Ip))] = new BanEntry(b.Record);
+                }
+                return list;
+            } catch {
+                return new Banlist();
+            }
+        }
+
+        public void Save(string path) {
+            var data = new BanFile {
+                UuidBans = new List<BanFileUuidEntry>(),
+                IpBans = new List<BanFileIpEntry>()
+            };
+            foreach (var (uuid, entry) in _uuidBans)
+                data.UuidBans.Add(new BanFileUuidEntry { Uuid = uuid, Record = entry.Current });
+            foreach (var (ip, entry) in _ipBans)
+                data.IpBans.Add(new BanFileIpEntry { Ip = ip.Address.ToString(), Record = entry.Current });
+            var json = JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(path, json);
+        }
+
+        private class BanFile {
+            public List<BanFileUuidEntry> UuidBans { get; set; } = new();
+            public List<BanFileIpEntry> IpBans { get; set; } = new();
+        }
+
+        private class BanFileUuidEntry {
+            public Guid Uuid { get; set; }
+            public BanRecord Record { get; set; } = null!;
+        }
+
+        private class BanFileIpEntry {
+            public string Ip { get; set; } = string.Empty;
+            public BanRecord Record { get; set; } = null!;
+        }
+    }
+}

--- a/VelorenPort/Server/Src/Settings/Settings.cs
+++ b/VelorenPort/Server/Src/Settings/Settings.cs
@@ -12,17 +12,33 @@ namespace VelorenPort.Server.Settings {
         public uint WorldSeed { get; set; } = 1;
         public int MaxPlayers { get; set; } = 100;
 
-        public static Settings Load(string path) {
-            if (File.Exists(path)) {
-                var json = File.ReadAllText(path);
-                return JsonSerializer.Deserialize<Settings>(json) ?? new Settings();
+        public AdminList Admins { get; set; } = new();
+        public Banlist Banlist { get; set; } = new();
+        public Whitelist Whitelist { get; set; } = new();
+
+        public static Settings Load(string dataDir) {
+            var settingsPath = Path.Combine(dataDir, "settings.json");
+            Settings settings;
+            if (File.Exists(settingsPath)) {
+                var json = File.ReadAllText(settingsPath);
+                settings = JsonSerializer.Deserialize<Settings>(json) ?? new Settings();
+            } else {
+                settings = new Settings();
             }
-            return new Settings();
+            settings.Admins = AdminList.Load(Path.Combine(dataDir, "admins.json"));
+            settings.Banlist = Banlist.Load(Path.Combine(dataDir, "banlist.json"));
+            settings.Whitelist = Whitelist.Load(Path.Combine(dataDir, "whitelist.json"));
+            return settings;
         }
 
-        public void Save(string path) {
+        public void Save(string dataDir) {
+            Directory.CreateDirectory(dataDir);
+            var settingsPath = Path.Combine(dataDir, "settings.json");
             var json = JsonSerializer.Serialize(this, new JsonSerializerOptions { WriteIndented = true });
-            File.WriteAllText(path, json);
+            File.WriteAllText(settingsPath, json);
+            Admins.Save(Path.Combine(dataDir, "admins.json"));
+            Banlist.Save(Path.Combine(dataDir, "banlist.json"));
+            Whitelist.Save(Path.Combine(dataDir, "whitelist.json"));
         }
     }
 }


### PR DESCRIPTION
## Summary
- persist admin and ban lists in `LoginProvider`
- extend settings loader to manage admin, ban and whitelist files
- add CLI admin/ban commands
- document new administration capabilities

## Testing
- `dotnet format --no-restore` *(failed: command not found)*
- `dotnet test VelorenPort/VelorenPort.sln` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615015fa0883289bd11a4ee3beaac1