### PR TITLE
Implement generic event handling

### DIFF
--- a/VelorenPort/Server.Tests/EventManagerTests.cs
+++ b/VelorenPort/Server.Tests/EventManagerTests.cs
@@ -1,6 +1,7 @@
 using VelorenPort.Server.Events;
 using VelorenPort.CoreEngine.comp;
 using VelorenPort.Server;
+using VelorenPort.NativeMath;
 
 namespace Server.Tests;
 
@@ -20,5 +21,18 @@ public class EventManagerTests
         Assert.Single(events);
         Assert.Equal("hi", (events[0].Msg.Content as Content.Plain)!.Text);
         Assert.True(events[0].FromClient);
+    }
+
+    [Fact]
+    public void GenericEmitter_WorksForCustomEvent()
+    {
+        var manager = new EventManager();
+        using (var emitter = manager.GetEmitter<CreateItemDropEvent>())
+        {
+            emitter.Emit(new CreateItemDropEvent(new float3(1, 2, 3)));
+        }
+        var evs = manager.Drain<CreateItemDropEvent>();
+        Assert.Single(evs);
+        Assert.Equal(new float3(1, 2, 3), evs[0].Position);
     }
 }

--- a/VelorenPort/Server/README.md
+++ b/VelorenPort/Server/README.md
@@ -20,6 +20,10 @@ Código del servidor principal (`server` y `server-cli`). Maneja sesiones de jue
   Se implementó `DataDir` para indicar la ruta de datos del servidor, la
   enumeración `Error` que centraliza los fallos de red, y
   `PersistenceError` para los errores de almacenamiento.
+  También se añadió un manejador de eventos simple basado en `EventBus` que
+  permite a los sistemas emitir y consumir eventos tipados. El `Dispatcher`
+  entrega la instancia de `EventManager` a cada sistema en cada ciclo y así se
+  propagan los eventos como en el original en Rust.
 
 ## Compilación y ejecución
 

--- a/VelorenPort/Server/Src/Dispatcher.cs
+++ b/VelorenPort/Server/Src/Dispatcher.cs
@@ -5,15 +5,15 @@ namespace VelorenPort.Server.Ecs {
     /// Simple dispatcher that executes registered systems sequentially.
     /// </summary>
     public interface IGameSystem {
-        void Update(float dt);
+        void Update(float dt, Events.EventManager events);
     }
 
     public class Dispatcher {
         private readonly List<IGameSystem> _systems = new();
         public void AddSystem(IGameSystem system) => _systems.Add(system);
-        public void Update(float dt) {
+        public void Update(float dt, Events.EventManager events) {
             foreach (var s in _systems)
-                s.Update(dt);
+                s.Update(dt, events);
         }
     }
 
@@ -21,8 +21,8 @@ namespace VelorenPort.Server.Ecs {
     /// Utility system wrapper using a delegate.
     /// </summary>
     public class DelegateSystem : IGameSystem {
-        private readonly System.Action<float> _run;
-        public DelegateSystem(System.Action<float> run) { _run = run; }
-        public void Update(float dt) => _run(dt);
+        private readonly System.Action<float, Events.EventManager> _run;
+        public DelegateSystem(System.Action<float, Events.EventManager> run) { _run = run; }
+        public void Update(float dt, Events.EventManager events) => _run(dt, events);
     }
 }

--- a/VelorenPort/Server/Src/Events/CreateItemDropEvent.cs
+++ b/VelorenPort/Server/Src/Events/CreateItemDropEvent.cs
@@ -1,0 +1,10 @@
+using VelorenPort.NativeMath;
+using Unity.Entities;
+
+namespace VelorenPort.Server.Events;
+
+/// <summary>
+/// Simplified representation of the Rust CreateItemDropEvent.
+/// Only includes the world position of the drop for now.
+/// </summary>
+public readonly record struct CreateItemDropEvent(float3 Position);

--- a/VelorenPort/Server/Src/GameServer.cs
+++ b/VelorenPort/Server/Src/GameServer.cs
@@ -87,16 +87,16 @@ namespace VelorenPort.Server {
                 MaxNpcs = 3
             });
 
-            _dispatcher.AddSystem(new DelegateSystem(dt => {
+            _dispatcher.AddSystem(new DelegateSystem((dt, ev) => {
                 InviteTimeout.Update(_clients);
-                ChatSystem.Update(_eventManager, _chatExporter, _autoMod, _clients);
+                ChatSystem.Update(ev, _chatExporter, _autoMod, _clients, _groupManager);
                 WeatherSystem.Update(WorldIndex, _weatherJob, _clients);
                 TeleporterSystem.Update(_clients, _teleporters);
                 PortalSystem.Update(WorldIndex.EntityManager, _clients, dt);
                 NpcSpawnerSystem.Update(WorldIndex.EntityManager, _npcSpawnPoints, dt);
                 NpcAiSystem.Update(WorldIndex.EntityManager, _clients, dt);
                 PetsSystem.Update(WorldIndex.EntityManager, _clients, dt);
-                LootSystem.Update(WorldIndex.EntityManager);
+                LootSystem.Update(ev, WorldIndex.EntityManager);
                 ObjectSystem.Update(WorldIndex.EntityManager);
                 WiringSystem.Update(WorldIndex.EntityManager);
                 SentinelSystem.Update(WorldIndex.EntityManager, _sentinelTrackers);
@@ -164,7 +164,7 @@ namespace VelorenPort.Server {
             NpcSpawnerSystem.Update(WorldIndex.EntityManager, _npcSpawnPoints, (float)Clock.Dt.TotalSeconds);
             NpcAiSystem.Update(WorldIndex.EntityManager, _clients, (float)Clock.Dt.TotalSeconds);
             PetsSystem.Update(WorldIndex.EntityManager);
-            LootSystem.Update(WorldIndex.EntityManager);
+            LootSystem.Update(_eventManager, WorldIndex.EntityManager);
             ObjectSystem.Update(WorldIndex.EntityManager);
             WiringSystem.Update(WorldIndex.EntityManager);
             SentinelSystem.Update(WorldIndex.EntityManager, _sentinelTrackers);
@@ -182,7 +182,7 @@ namespace VelorenPort.Server {
                         client.SendPreparedAsync(msg).GetAwaiter().GetResult();
                 }
             }
-            _dispatcher.Update((float)Clock.Dt.TotalSeconds);
+            _dispatcher.Update((float)Clock.Dt.TotalSeconds, _eventManager);
         }
 
         private void OnServerInfo(ServerInfo info) {


### PR DESCRIPTION
## Summary
- introduce `CreateItemDropEvent` type
- refactor `EventManager` to use generic event buses
- adapt `Dispatcher` and `GameServer` to pass events to systems
- make `LootSystem` emit `CreateItemDropEvent`
- update tests and documentation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615018bf6083289bf7b71e2af242bc