### PR TITLE
Add map sampling utilities and altitude-aware pathfinding

### DIFF
--- a/VelorenPort/World.Tests/PathfindingTests.cs
+++ b/VelorenPort/World.Tests/PathfindingTests.cs
@@ -85,4 +85,22 @@ public class PathfindingTests
         Assert.NotNull(path);
         Assert.DoesNotContain(new int2(1,0), path!.Nodes);
     }
+
+    [Fact]
+    public void Searcher_AvoidsHighAltitude_WhenWeighted()
+    {
+        var sim = new WorldSim(0, new int2(3,3));
+        var high = sim.Get(new int2(1,1))!;
+        high.Alt = 50f;
+        sim.Set(new int2(1,1), high);
+
+        var searcher = new Searcher(
+            Land.FromSim(sim),
+            new SearchCfg(0f, 0f, 0f, 1f));
+
+        var path = searcher.Search(new int2(0,1), new int2(2,1));
+
+        Assert.NotNull(path);
+        Assert.DoesNotContain(new int2(1,1), path!.Nodes);
+    }
 }

--- a/VelorenPort/World/Src/Pathfinding.cs
+++ b/VelorenPort/World/Src/Pathfinding.cs
@@ -12,11 +12,13 @@ namespace VelorenPort.World {
         public float PathDiscount;
         public float GradientAversion;
         public float EdgeAversion;
+        public float AltCostWeight;
 
-        public SearchCfg(float pathDiscount, float gradientAversion, float edgeAversion = 0f) {
+        public SearchCfg(float pathDiscount, float gradientAversion, float edgeAversion = 0f, float altCostWeight = 0f) {
             PathDiscount = pathDiscount;
             GradientAversion = gradientAversion;
             EdgeAversion = edgeAversion;
+            AltCostWeight = altCostWeight;
         }
     }
 
@@ -102,6 +104,13 @@ namespace VelorenPort.World {
                     mult *= math.max(0f, 1f - Cfg.PathDiscount);
 
                 float cost = baseCost * mult + extra;
+                if (Cfg.AltCostWeight > 0f)
+                {
+                    int2 curWpos = TerrainChunkSize.CposToWposCenter(pos);
+                    float altA = _land.GetSurfaceAltApprox(curWpos);
+                    float altB = _land.GetSurfaceAltApprox(wpos);
+                    cost += math.abs(altA - altB) * Cfg.AltCostWeight;
+                }
 
                 yield return (next, cost);
             }

--- a/VelorenPort/World/Src/Sim/Map.cs
+++ b/VelorenPort/World/Src/Sim/Map.cs
@@ -1,0 +1,158 @@
+using System;
+using VelorenPort.NativeMath;
+using VelorenPort.CoreEngine;
+
+namespace VelorenPort.World.Sim
+{
+    /// <summary>
+    /// Configuration for map sampling. Mirrors a subset of the Rust MapConfig
+    /// structure used when rendering world overview maps.
+    /// </summary>
+    [Serializable]
+    public struct MapConfig
+    {
+        public MapSizeLg MapSizeLg;
+        public int2 Dimensions;
+        public double3 Focus;
+        public float Gain;
+
+        public bool IsBasement;
+        public bool IsWater;
+        public bool IsIce;
+        public bool IsShaded;
+        public bool IsTemperature;
+        public bool IsHumidity;
+
+        public static MapConfig Orthographic(MapSizeLg mapSizeLg, float startZ, float endZ)
+        {
+            return new MapConfig
+            {
+                MapSizeLg = mapSizeLg,
+                Dimensions = mapSizeLg.Chunks,
+                Focus = new double3(0, 0, startZ),
+                Gain = endZ - startZ,
+                IsBasement = false,
+                IsWater = true,
+                IsIce = true,
+                IsShaded = true,
+                IsTemperature = false,
+                IsHumidity = false,
+            };
+        }
+
+        public MapSizeLg GetMapSizeLg() => MapSizeLg;
+    }
+
+    /// <summary>
+    /// Kind of connection between two chunks.
+    /// Currently only rivers are represented.
+    /// </summary>
+    public enum ConnectionKind
+    {
+        River
+    }
+
+    /// <summary>
+    /// Connection metadata for a neighboring chunk edge.
+    /// </summary>
+    public struct Connection
+    {
+        public ConnectionKind Kind;
+        public float2 SplineDerivative;
+        public float Width;
+
+        public Connection(ConnectionKind kind, float2 derivative, float width)
+        {
+            Kind = kind;
+            SplineDerivative = derivative;
+            Width = width;
+        }
+    }
+
+    /// <summary>
+    /// Minimal per-chunk sample used by map generation.
+    /// </summary>
+    public struct MapSample
+    {
+        public Rgb<byte> Rgb;
+        public double Alt;
+        public int2 DownhillWpos;
+        public Connection?[]? Connections;
+    }
+
+    /// <summary>
+    /// Helper sampling utilities inspired by world/src/sim/map.rs.
+    /// </summary>
+    public static class Map
+    {
+        public static float SampleWpos(MapConfig cfg, WorldSim sim, int2 wpos)
+        {
+            var chunk = sim.GetWpos(wpos);
+            float alt = WorldDefaults.CONFIG.SeaLevel;
+            if (chunk != null)
+            {
+                alt = cfg.IsBasement ? chunk.Basement : chunk.Alt;
+                if (cfg.IsWater)
+                    alt = Math.Max(alt, chunk.WaterAlt);
+            }
+
+            return (alt - (float)cfg.Focus.z) / cfg.Gain;
+        }
+
+        public static MapSample SamplePos(MapConfig cfg, WorldSim sim, int2 cpos)
+        {
+            var chunk = sim.Get(cpos);
+            float alt = WorldDefaults.CONFIG.SeaLevel;
+            float basement = alt;
+            float waterAlt = alt;
+            int2 downhill = TerrainChunkSize.CposToWpos(cpos + int2.one);
+            RiverKind? riverKind = null;
+            float2 spline = float2.zero;
+            if (chunk != null)
+            {
+                alt = chunk.Alt;
+                basement = chunk.Basement;
+                waterAlt = chunk.WaterAlt;
+                downhill = chunk.Downhill ?? downhill;
+                riverKind = chunk.River.Kind;
+                spline = chunk.River.SplineDerivative;
+            }
+
+            float chosenAlt = cfg.IsBasement ? basement : alt;
+            float normAlt = (chosenAlt - (float)cfg.Focus.z) / cfg.Gain;
+            float normWater = (Math.Max(chosenAlt, waterAlt) - (float)cfg.Focus.z) / cfg.Gain;
+            normAlt = math.clamp(normAlt, 0f, 1f);
+            normWater = math.clamp(normWater, 0f, 1f);
+
+            byte shade = (byte)(normAlt * 255);
+            var rgb = new Rgb<byte>(shade, shade, shade);
+
+            Connection?[]? connections = null;
+            if (riverKind == RiverKind.River && cfg.IsWater)
+            {
+                connections = new Connection?[8];
+                int2 dpos = TerrainChunkSize.WposToCpos(downhill);
+                for (int i = 0; i < WorldUtil.NEIGHBORS.Length; i++)
+                {
+                    if (dpos - cpos == WorldUtil.NEIGHBORS[i])
+                    {
+                        connections[i] = new Connection(
+                            ConnectionKind.River,
+                            spline,
+                            TerrainChunkSize.RectSize.x);
+                    }
+                }
+            }
+
+            double finalAlt = cfg.IsWater ? Math.Max(normAlt, normWater) : normAlt;
+
+            return new MapSample
+            {
+                Rgb = rgb,
+                Alt = finalAlt,
+                DownhillWpos = downhill,
+                Connections = connections
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- port basic map sampling as `Map` module
- support weighted altitude cost in `Searcher`
- test high altitude avoidance with new search config

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861505820a8832890f43b1746b992af