### PR TITLE
Add admin/ban persistence and CLI whitelist commands

### DIFF
--- a/VelorenPort/CLI/README.md
+++ b/VelorenPort/CLI/README.md
@@ -6,3 +6,7 @@ Herramientas de consola y utilidades para el servidor (`server-cli`).
 
 **Notas**:
 - Reescribir comandos y utilidades usando .NET `System.CommandLine` o similar.
+- Comandos disponibles:
+  - `admin add <usuario> <rol>` / `admin remove <usuario>`
+  - `ban add <usuario> <razón>` / `ban remove <usuario>`
+  - `whitelist add <usuario>` / `whitelist remove <usuario>`

--- a/VelorenPort/CLI/Src/Main.cs
+++ b/VelorenPort/CLI/Src/Main.cs
@@ -94,11 +94,11 @@ namespace VelorenPort.CLI {
                     switch (ac) {
                         case Cli.AdminCommand.Add(var user, var role):
                             var resAdd = lp.UsernameToUuid(user);
-                            if (resAdd.IsOk) lp.Admins.Grant(resAdd.Value, role);
+                            if (resAdd.IsOk) lp.GrantAdmin(resAdd.Value, role);
                             break;
                         case Cli.AdminCommand.Remove(var user):
                             var resRem = lp.UsernameToUuid(user);
-                            if (resRem.IsOk) lp.Admins.Revoke(resRem.Value);
+                            if (resRem.IsOk) lp.RevokeAdmin(resRem.Value);
                             break;
                     }
                     break;
@@ -107,17 +107,28 @@ namespace VelorenPort.CLI {
                         case Cli.BanCommand.Add(var user, var reason):
                             var r2 = lp.UsernameToUuid(user);
                             if (r2.IsOk)
-                                lp.Banlist.BanUuid(r2.Value, user, new Banlist.BanInfo(reason, null), null);
+                                lp.BanUuid(r2.Value, user, new Banlist.BanInfo { Reason = reason }, null);
                             break;
                         case Cli.BanCommand.Remove(var user):
                             var r3 = lp.UsernameToUuid(user);
                             if (r3.IsOk)
-                                lp.Banlist.UnbanUuid(r3.Value, user, new Banlist.BanInfo("", null));
+                                lp.UnbanUuid(r3.Value, user, new Banlist.BanInfo());
+                            break;
+                    }
+                    break;
+                case Cli.SharedCommand.Whitelist(var wc):
+                    switch (wc) {
+                        case Cli.WhitelistCommand.Add(var user):
+                            var w1 = lp.UsernameToUuid(user);
+                            if (w1.IsOk) lp.AddWhitelist(w1.Value);
+                            break;
+                        case Cli.WhitelistCommand.Remove(var user):
+                            var w2 = lp.UsernameToUuid(user);
+                            if (w2.IsOk) lp.RemoveWhitelist(w2.Value);
                             break;
                     }
                     break;
             }
-            lp.Save();
         }
     }
 }

--- a/VelorenPort/Server/Src/LoginProvider.cs
+++ b/VelorenPort/Server/Src/LoginProvider.cs
@@ -77,6 +77,36 @@ namespace VelorenPort.Server {
             _whitelist.Save(_whitelistPath);
         }
 
+        public void GrantAdmin(Guid uuid, AdminRole role) {
+            _admins.Grant(uuid, role);
+            Save();
+        }
+
+        public void RevokeAdmin(Guid uuid) {
+            _admins.Revoke(uuid);
+            Save();
+        }
+
+        public void BanUuid(Guid uuid, string username, BanInfo info, DateTime? endDate) {
+            _banlist.BanUuid(uuid, username, info, endDate);
+            Save();
+        }
+
+        public void UnbanUuid(Guid uuid, string username, BanInfo info) {
+            _banlist.UnbanUuid(uuid, username, info);
+            Save();
+        }
+
+        public void AddWhitelist(Guid uuid) {
+            _whitelist.Add(uuid);
+            Save();
+        }
+
+        public void RemoveWhitelist(Guid uuid) {
+            _whitelist.Remove(uuid);
+            Save();
+        }
+
         public PendingLogin Verify(string usernameOrToken) {
             var pending = new PendingLogin();
             if (_authServer != null) {

--- a/VelorenPort/Server/Src/Settings/Banlist.cs
+++ b/VelorenPort/Server/Src/Settings/Banlist.cs
@@ -11,11 +11,15 @@ namespace VelorenPort.Server.Settings {
     /// form. Entries are loaded from and saved to disk as JSON.
     /// </summary>
     public class Banlist {
-        public record BanInfo(string Reason, long? Until);
+        public class BanInfo {
+            public string Reason { get; set; } = string.Empty;
+            public long? Until { get; set; }
+            public AdminRole PerformedByRole { get; set; } = AdminRole.Admin;
+        }
 
         public record Ban(BanInfo Info, DateTime? EndDate) {
             public bool IsExpired(DateTime now) => EndDate.HasValue && EndDate.Value <= now;
-            public AdminRole PerformedByRole() => AdminRole.Admin;
+            public AdminRole PerformedByRole() => Info.PerformedByRole;
             public BanInfo GetInfo() => Info;
         }
 


### PR DESCRIPTION
## Summary
- persist admin, ban and whitelist edits on each update
- store the banning admin role for proper checks
- add whitelist management commands to CLI
- document available CLI commands

## Testing
- `dotnet test VelorenPort/VelorenPort.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686157c465448328a84002c7191fc084