### PR TITLE
Add C# query client with discovery hooks

### DIFF
--- a/VelorenPort/CoreEngine/Src/states/ForcedMovement.cs
+++ b/VelorenPort/CoreEngine/Src/states/ForcedMovement.cs
@@ -34,7 +34,7 @@ public static class ForcedMovementExt
         ForcedMovement.Sideways m => m with { Strength = m.Strength * scalar },
         ForcedMovement.DirectedReverse m => m with { Strength = m.Strength * scalar },
         ForcedMovement.AntiDirectedForward m => m with { Strength = m.Strength * scalar },
-        ForcedMovement.Leap m => m with { Vertical = m.Vertical * scalar, Forward = m.Forward * scalar },
+        ForcedMovement.Leap m => m with { Vertical = m.Vertical * scalar, ForwardAmount = m.ForwardAmount * scalar },
 
         ForcedMovement.Hover m => m,
         _ => fm

--- a/VelorenPort/Server.Tests/QueryClientTests.cs
+++ b/VelorenPort/Server.Tests/QueryClientTests.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using VelorenPort.Server;
+using VelorenPort.Server.Sys;
+
+namespace Server.Tests;
+
+public class QueryClientTests {
+    static int FreePort() {
+        var l = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        l.Start();
+        int p = ((IPEndPoint)l.LocalEndpoint).Port;
+        l.Stop();
+        return p;
+    }
+
+    [Fact]
+    public async Task ClientFetchesServerInfo() {
+        int port = FreePort();
+        var info = new ServerInfo(1, 2, 0, 10, BattleMode.PvE);
+        var server = new QueryServer(new IPEndPoint(IPAddress.Loopback, port), info, 10);
+        using var cts = new CancellationTokenSource();
+        var task = server.RunAsync(cts.Token);
+
+        var client = new QueryClient(new IPEndPoint(IPAddress.Loopback, port));
+        var (resp, _) = await client.ServerInfoAsync();
+        Assert.Equal(info.PlayerCap, resp.PlayerCap);
+        Assert.Equal(info.BattleMode, resp.BattleMode);
+
+        cts.Cancel();
+        await task;
+    }
+}

--- a/VelorenPort/Server/Src/GameServer.cs
+++ b/VelorenPort/Server/Src/GameServer.cs
@@ -50,6 +50,7 @@ namespace VelorenPort.Server {
         private readonly SentinelSystem.Trackers _sentinelTrackers = new();
         private readonly Ecs.Dispatcher _dispatcher = new();
         private QueryServer? _queryServer;
+        private QueryClient? _discoveryClient;
         private ulong _tick;
 
         /// <summary>Returns the connected clients.</summary>
@@ -124,6 +125,8 @@ namespace VelorenPort.Server {
             var connectionTask = _connections.RunAsync(addr, token);
             CancellationTokenSource? queryCts = null;
             Task? queryTask = null;
+            CancellationTokenSource? discoveryCts = null;
+            Task? discoveryTask = null;
             if (_settings.EnableQueryServer) {
                 queryCts = CancellationTokenSource.CreateLinkedTokenSource(token);
                 var info = new ServerInfo(
@@ -137,6 +140,11 @@ namespace VelorenPort.Server {
                     info,
                     _settings.QueryServerRatelimit);
                 queryTask = _queryServer.RunAsync(queryCts.Token);
+            }
+            if (_settings.EnableDiscovery) {
+                discoveryCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+                _discoveryClient = new QueryClient(ParseEndpoint(_settings.DiscoveryAddress));
+                discoveryTask = DiscoveryLoopAsync(_discoveryClient, discoveryCts.Token);
             }
             while (!token.IsCancellationRequested) {
                 Clock.Tick();
@@ -153,6 +161,8 @@ namespace VelorenPort.Server {
             }
             if (queryCts != null) queryCts.Cancel();
             if (queryTask != null) await queryTask;
+            if (discoveryCts != null) discoveryCts.Cancel();
+            if (discoveryTask != null) await discoveryTask;
             await connectionTask;
             _terrainPersistence.Dispose();
             _metricsExporter.Dispose();
@@ -232,5 +242,23 @@ namespace VelorenPort.Server {
         /// <summary>Returns simple identifiers for all connected clients.</summary>
         public IEnumerable<string> GetOnlinePlayerNames() =>
             _clients.Select(c => c.Participant.Id.Value.ToString());
+
+        static IPEndPoint ParseEndpoint(string str) {
+            if (!str.Contains("://")) str = "udp://" + str;
+            var uri = new Uri(str);
+            var addresses = Dns.GetHostAddresses(uri.Host);
+            return new IPEndPoint(addresses[0], uri.Port);
+        }
+
+        static async Task DiscoveryLoopAsync(QueryClient client, CancellationToken token) {
+            while (!token.IsCancellationRequested) {
+                try {
+                    await client.ServerInfoAsync();
+                } catch { }
+                try {
+                    await Task.Delay(TimeSpan.FromSeconds(10), token);
+                } catch { break; }
+            }
+        }
     }
 }

--- a/VelorenPort/Server/Src/QueryClient.cs
+++ b/VelorenPort/Server/Src/QueryClient.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using System.Threading;
+using VelorenPort.Server.Sys;
+
+namespace VelorenPort.Server {
+    public enum QueryClientError {
+        Io,
+        InvalidResponse,
+        Timeout,
+        ChallengeFailed
+    }
+
+    class QueryClient {
+        readonly IPEndPoint _addr;
+        ClientInitData? _init;
+        const int MAX_REQUEST_RETRIES = 5;
+        const int TIMEOUT_SECONDS = 2;
+
+        record ClientInitData(ulong P, ushort ServerMaxVersion);
+
+        public QueryClient(IPEndPoint addr) {
+            _addr = addr;
+        }
+
+        public async Task<(ServerInfo Info, TimeSpan Ping)> ServerInfoAsync() {
+            var (info, ping) = await SendQueryAsync(QueryServerRequest.ServerInfo);
+            return (info, ping);
+        }
+
+        async Task<(ServerInfo, TimeSpan)> SendQueryAsync(QueryServerRequest request) {
+            using var socket = new UdpClient(_addr.AddressFamily);
+            if (_addr.AddressFamily == AddressFamily.InterNetwork)
+                socket.Client.Bind(new IPEndPoint(IPAddress.Any, 0));
+            else
+                socket.Client.Bind(new IPEndPoint(IPAddress.IPv6Any, 0));
+
+            for (int i = 0; i < MAX_REQUEST_RETRIES; i++) {
+                byte[] req;
+                if (_init != null) {
+                    req = QueryProtocol.SerializeRequest(_init.P, request);
+                } else {
+                    req = QueryProtocol.SerializeRequest(0, QueryServerRequest.Init);
+                }
+
+                var sentAt = DateTime.UtcNow;
+                try {
+                    await socket.SendAsync(req, req.Length, _addr);
+                } catch (Exception) {
+                    throw new QueryClientException(QueryClientError.Io);
+                }
+
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(TIMEOUT_SECONDS));
+                Task<UdpReceiveResult> recvTask = socket.ReceiveAsync(cts.Token);
+                try {
+                    var res = await recvTask;
+                    var data = res.Buffer;
+                    if (QueryProtocol.TryParseInfoResponse(data, out var info)) {
+                        return (info, DateTime.UtcNow - sentAt);
+                    }
+                    if (QueryProtocol.TryParseInitResponse(data, out var p)) {
+                        _init = new ClientInitData(p, QueryProtocol.VERSION);
+                        continue;
+                    }
+                    throw new QueryClientException(QueryClientError.InvalidResponse);
+                } catch (OperationCanceledException) {
+                    throw new QueryClientException(QueryClientError.Timeout);
+                }
+            }
+            throw new QueryClientException(QueryClientError.ChallengeFailed);
+        }
+    }
+
+    class QueryClientException : Exception {
+        public QueryClientError Error { get; }
+        public QueryClientException(QueryClientError error) {
+            Error = error;
+        }
+    }
+}

--- a/VelorenPort/Server/Src/Settings/Settings.cs
+++ b/VelorenPort/Server/Src/Settings/Settings.cs
@@ -14,6 +14,8 @@ namespace VelorenPort.Server.Settings {
         public bool EnableQueryServer { get; set; } = false;
         public int QueryServerPort { get; set; } = 14006;
         public ushort QueryServerRatelimit { get; set; } = 120;
+        public bool EnableDiscovery { get; set; } = false;
+        public string DiscoveryAddress { get; set; } = "127.0.0.1:14006";
 
         public AdminList Admins { get; set; } = new();
         public Banlist Banlist { get; set; } = new();


### PR DESCRIPTION
## Summary
- implement `QueryClient` mirroring Rust query client
- allow optional discovery loop in `GameServer`
- expose discovery settings
- fix typo in forced movement
- add unit test for query client

## Testing
- `dotnet build VelorenPort/VelorenPort.sln` *(fails: float3x3 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686157c1da8483289261f4607b007c6a