### PR TITLE
Add placeholder events and teleport handling

### DIFF
--- a/VelorenPort/CoreEngine/Src/EventBus.cs
+++ b/VelorenPort/CoreEngine/Src/EventBus.cs
@@ -7,7 +7,7 @@ namespace VelorenPort.CoreEngine {
     /// Generic event bus that stores events until they are consumed.
     /// This mirrors the behaviour of the EventBus type in the Rust code.
     /// </summary>
-    public class EventBus<T>
+    public class EventBus<T> : IEventBus
     {
         private readonly Queue<T> _queue = new();
         private readonly object _lock = new();
@@ -69,6 +69,10 @@ namespace VelorenPort.CoreEngine {
             get { lock (_lock) { return _recvCount; } }
         }
 
+        public bool HasPending {
+            get { lock (_lock) { return _queue.Count > 0; } }
+        }
+
         /// <summary>
         /// Disposable emitter that batches events and appends them to the bus
         /// when disposed, replicating the RAII drop behaviour of Rust.
@@ -109,5 +113,11 @@ namespace VelorenPort.CoreEngine {
     public interface IEmitExt<in T> {
         void Emit(T ev);
         void EmitMany(IEnumerable<T> events);
+    }
+
+    /// <summary>Non-generic access to event bus internals for debug checks.</summary>
+    public interface IEventBus {
+        byte RecvCount { get; }
+        bool HasPending { get; }
     }
 }

--- a/VelorenPort/Server.Tests/EventManagerDebugTests.cs
+++ b/VelorenPort/Server.Tests/EventManagerDebugTests.cs
@@ -1,0 +1,22 @@
+using System;
+using VelorenPort.Server.Events;
+using VelorenPort.CoreEngine;
+using VelorenPort.NativeMath;
+
+namespace Server.Tests;
+
+public class EventManagerDebugTests
+{
+    [Fact]
+    public void DebugCheckThrowsOnUnconsumedEvents()
+    {
+        var manager = new EventManager();
+        using (var emitter = manager.GetEmitter<TeleportToPositionEvent>())
+        {
+            emitter.Emit(new TeleportToPositionEvent(new Uid(1), new float3(0,0,0)));
+        }
+#if DEBUG
+        Assert.Throws<InvalidOperationException>(() => manager.DebugCheckAllConsumed());
+#endif
+    }
+}

--- a/VelorenPort/Server.Tests/TeleporterSystemTests.cs
+++ b/VelorenPort/Server.Tests/TeleporterSystemTests.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using VelorenPort.NativeMath;
 using VelorenPort.Server;
 using VelorenPort.Server.Sys;
+using VelorenPort.Server.Events;
 using VelorenPort.Network;
 
 namespace Server.Tests;
@@ -21,7 +22,9 @@ public class TeleporterSystemTests
         client.SetPosition(new float3(0, 0, 0));
 
         var tp = new Teleporter { Position = new float3(0, 0, 0), Target = new float3(5, 5, 5) };
-        TeleporterSystem.Update(new[] { client }, new[] { tp });
+        var events = new EventManager();
+        TeleporterSystem.Update(new[] { client }, new[] { tp }, events);
+        TeleportEventSystem.Update(events, new[] { client });
 
         Assert.Equal(new float3(5, 5, 5), client.Position.Value);
     }

--- a/VelorenPort/Server/Src/Events/AdditionalEvents.cs
+++ b/VelorenPort/Server/Src/Events/AdditionalEvents.cs
@@ -1,0 +1,77 @@
+using VelorenPort.CoreEngine;
+using VelorenPort.NativeMath;
+
+namespace VelorenPort.Server.Events;
+
+/// <summary>
+/// Placeholder definitions for many server events from the Rust codebase.
+/// Only a few carry data at the moment. The rest are empty markers until
+/// their associated systems are ported.
+/// </summary>
+public readonly record struct ClientDisconnectEvent;
+public readonly record struct ClientDisconnectWithoutPersistenceEvent;
+public readonly record struct CommandEvent;
+public readonly record struct CreateSpecialEntityEvent;
+public readonly record struct CreateNpcEvent;
+public readonly record struct CreateShipEvent;
+public readonly record struct CreateObjectEvent;
+public readonly record struct ExplosionEvent;
+public readonly record struct BonkEvent;
+public readonly record struct HealthChangeEvent;
+public readonly record struct KillEvent;
+public readonly record struct HelpDownedEvent;
+public readonly record struct DownedEvent;
+public readonly record struct PoiseChangeEvent;
+public readonly record struct DeleteEvent;
+public readonly record struct DestroyEvent;
+public readonly record struct InventoryManipEvent;
+public readonly record struct GroupManipEvent;
+public readonly record struct RespawnEvent;
+public readonly record struct ShootEvent;
+public readonly record struct ThrowEvent;
+public readonly record struct ShockwaveEvent;
+public readonly record struct KnockbackEvent;
+public readonly record struct LandOnGroundEvent;
+public readonly record struct SetLanternEvent;
+public readonly record struct NpcInteractEvent;
+public readonly record struct DialogueEvent;
+public readonly record struct InviteResponseEvent;
+public readonly record struct InitiateInviteEvent;
+public readonly record struct ProcessTradeActionEvent;
+public readonly record struct MountEvent;
+public readonly record struct SetPetStayEvent;
+public readonly record struct PossessEvent;
+public readonly record struct InitializeCharacterEvent;
+public readonly record struct InitializeSpectatorEvent;
+public readonly record struct UpdateCharacterDataEvent;
+public readonly record struct ExitIngameEvent;
+public readonly record struct AuraEvent;
+public readonly record struct BuffEvent;
+public readonly record struct EnergyChangeEvent;
+public readonly record struct ComboChangeEvent;
+public readonly record struct ParryHookEvent;
+public readonly record struct RequestSiteInfoEvent;
+public readonly record struct MineBlockEvent;
+public readonly record struct TeleportToEvent;
+public readonly record struct SoundEvent;
+public readonly record struct CreateSpriteEvent;
+public readonly record struct TamePetEvent;
+public readonly record struct EntityAttackedHookEvent;
+public readonly record struct ChangeAbilityEvent;
+public readonly record struct UpdateMapMarkerEvent;
+public readonly record struct MakeAdminEvent;
+public readonly record struct DeleteCharacterEvent;
+public readonly record struct ChangeStanceEvent;
+public readonly record struct ChangeBodyEvent;
+public readonly record struct RemoveLightEmitterEvent;
+public readonly record struct StartTeleportingEvent;
+public readonly record struct ToggleSpriteLightEvent;
+public readonly record struct TransformEvent;
+public readonly record struct StartInteractionEvent;
+public readonly record struct RequestPluginsEvent;
+public readonly record struct CreateAuraEntityEvent;
+public readonly record struct RegrowHeadEvent;
+public readonly record struct SetBattleModeEvent;
+
+/// <summary>Event used by teleporters to move an entity instantly.</summary>
+public readonly record struct TeleportToPositionEvent(Uid Entity, float3 Position);

--- a/VelorenPort/Server/Src/Events/EventManager.cs
+++ b/VelorenPort/Server/Src/Events/EventManager.cs
@@ -29,5 +29,22 @@ namespace VelorenPort.Server.Events {
 
         public EventType[] DrainEvents() => Drain<EventType>().ToArray();
         public ChatEvent[] DrainChatEvents() => Drain<ChatEvent>().ToArray();
+
+#if DEBUG
+        /// <summary>
+        /// Ensures that all events queued this tick have been consumed by a handler.
+        /// Throws <see cref="InvalidOperationException"/> if any remain.
+        /// </summary>
+        public void DebugCheckAllConsumed()
+        {
+            foreach (var (ty, obj) in _busses)
+            {
+                if (obj is IEventBus bus && bus.HasPending)
+                    throw new InvalidOperationException($"Event of type {ty.Name} was not consumed");
+                if (obj is IEventBus bus2 && bus2.RecvCount > 1)
+                    throw new InvalidOperationException($"Event of type {ty.Name} handled multiple times");
+            }
+        }
+#endif
     }
 }

--- a/VelorenPort/Server/Src/GameServer.cs
+++ b/VelorenPort/Server/Src/GameServer.cs
@@ -93,7 +93,8 @@ namespace VelorenPort.Server {
                 InviteTimeout.Update(_clients);
                 ChatSystem.Update(ev, _chatExporter, _autoMod, _clients, _groupManager);
                 WeatherSystem.Update(WorldIndex, _weatherJob, _clients);
-                TeleporterSystem.Update(_clients, _teleporters);
+                TeleporterSystem.Update(_clients, _teleporters, ev);
+                TeleportEventSystem.Update(ev, _clients);
                 PortalSystem.Update(WorldIndex.EntityManager, _clients, dt);
                 NpcSpawnerSystem.Update(WorldIndex.EntityManager, _npcSpawnPoints, dt);
                 NpcAiSystem.Update(WorldIndex.EntityManager, _clients, dt);
@@ -179,7 +180,8 @@ namespace VelorenPort.Server {
             InviteTimeout.Update(_clients);
             ChatSystem.Update(_eventManager, _chatExporter, _autoMod, _clients, _groupManager);
             WeatherSystem.Update(WorldIndex, _weatherJob, _clients);
-            TeleporterSystem.Update(_clients, _teleporters);
+            TeleporterSystem.Update(_clients, _teleporters, _eventManager);
+            TeleportEventSystem.Update(_eventManager, _clients);
             PortalSystem.Update(WorldIndex.EntityManager, _clients, (float)Clock.Dt.TotalSeconds);
             NpcSpawnerSystem.Update(WorldIndex.EntityManager, _npcSpawnPoints, (float)Clock.Dt.TotalSeconds);
             NpcAiSystem.Update(WorldIndex.EntityManager, _clients, (float)Clock.Dt.TotalSeconds);
@@ -203,6 +205,9 @@ namespace VelorenPort.Server {
                 }
             }
             _dispatcher.Update((float)Clock.Dt.TotalSeconds, _eventManager);
+#if DEBUG
+            _eventManager.DebugCheckAllConsumed();
+#endif
         }
 
         private void OnServerInfo(ServerInfo info) {

--- a/VelorenPort/Server/Src/Sys/TeleportEventSystem.cs
+++ b/VelorenPort/Server/Src/Sys/TeleportEventSystem.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Linq;
+using VelorenPort.Server.Events;
+using VelorenPort.CoreEngine;
+
+namespace VelorenPort.Server.Sys;
+
+/// <summary>
+/// Applies <see cref="TeleportToPositionEvent"/>s emitted by other systems.
+/// </summary>
+public static class TeleportEventSystem
+{
+    public static void Update(EventManager events, IEnumerable<Client> clients)
+    {
+        var map = clients.ToDictionary(c => c.Uid);
+        foreach (var ev in events.Drain<TeleportToPositionEvent>())
+        {
+            if (map.TryGetValue(ev.Entity, out var client))
+                client.SetPosition(ev.Position);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add placeholder server events mirroring the Rust project
- update `EventBus` with debug interface
- implement debug check in `EventManager`
- update `TeleporterSystem` to emit teleport events
- add `TeleportEventSystem` and consume events in `GameServer`
- extend tests for new behaviour

## Testing
- `dotnet test VelorenPort/Server.Tests/Server.Tests.csproj --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686157c313cc8328acfbecb8013a1bc1