### PR TITLE
Implement legacy handshake negotiation

### DIFF
--- a/VelorenPort/Network.Tests/HandshakeVersionTests.cs
+++ b/VelorenPort/Network.Tests/HandshakeVersionTests.cs
@@ -1,0 +1,47 @@
+using System;
+using VelorenPort.Network;
+
+namespace Network.Tests;
+
+public class HandshakeVersionTests
+{
+    [Fact]
+    public void TryParseAcceptsLegacyVersion()
+    {
+        var pid = Pid.NewPid();
+        var secret = Guid.NewGuid();
+        var headerSize = Handshake.MagicNumber.Length + Handshake.SupportedVersion.Length * 4;
+        var buffer = new byte[headerSize + 32];
+        Array.Copy(Handshake.MagicNumber, buffer, Handshake.MagicNumber.Length);
+        Buffer.BlockCopy(BitConverter.GetBytes(0u), 0, buffer, Handshake.MagicNumber.Length + 0, 4);
+        Buffer.BlockCopy(BitConverter.GetBytes(5u), 0, buffer, Handshake.MagicNumber.Length + 4, 4);
+        Buffer.BlockCopy(BitConverter.GetBytes(0u), 0, buffer, Handshake.MagicNumber.Length + 8, 4);
+        var pidBytes = pid.ToByteArray();
+        Array.Copy(pidBytes, 0, buffer, headerSize, 16);
+        var secBytes = secret.ToByteArray();
+        Array.Copy(secBytes, 0, buffer, headerSize + 16, 16);
+        Assert.True(Handshake.TryParse(buffer, out var rp, out var rs, out var feat, out var ver));
+        Assert.Equal(pid, rp);
+        Assert.Equal(secret, rs);
+        Assert.Equal(HandshakeFeatures.None, feat);
+        Assert.Equal(new uint[] {0u,5u,0u}, ver);
+    }
+
+    [Fact]
+    public void TryParseRejectsFutureVersion()
+    {
+        var pid = Pid.NewPid();
+        var secret = Guid.NewGuid();
+        var headerSize = Handshake.MagicNumber.Length + Handshake.SupportedVersion.Length * 4;
+        var buffer = new byte[headerSize + 32];
+        Array.Copy(Handshake.MagicNumber, buffer, Handshake.MagicNumber.Length);
+        Buffer.BlockCopy(BitConverter.GetBytes(0u), 0, buffer, Handshake.MagicNumber.Length + 0, 4);
+        Buffer.BlockCopy(BitConverter.GetBytes(9u), 0, buffer, Handshake.MagicNumber.Length + 4, 4);
+        Buffer.BlockCopy(BitConverter.GetBytes(0u), 0, buffer, Handshake.MagicNumber.Length + 8, 4);
+        var pidBytes = pid.ToByteArray();
+        Array.Copy(pidBytes, 0, buffer, headerSize, 16);
+        var secBytes = secret.ToByteArray();
+        Array.Copy(secBytes, 0, buffer, headerSize + 16, 16);
+        Assert.False(Handshake.TryParse(buffer, out _, out _, out _, out _));
+    }
+}


### PR DESCRIPTION
## Summary
- expand handshake to support legacy init packets and optional feature flags
- update version validation to allow older minors
- remove ACK stage to mirror Rust state machine
- add tests covering legacy version parsing

## Testing
- `dotnet build` *(fails: dotnet not installed)*
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68615936e3f88328988b322057cc5b0b