### PR TITLE
Add economy context and trading flow

### DIFF
--- a/VelorenPort/World.Tests/TradingFlowTests.cs
+++ b/VelorenPort/World.Tests/TradingFlowTests.cs
@@ -1,0 +1,28 @@
+using VelorenPort.World;
+using VelorenPort.World.Site;
+using VelorenPort.NativeMath;
+using Xunit;
+
+namespace World.Tests;
+
+public class TradingFlowTests
+{
+    [Fact]
+    public void WorldTick_UpdatesEconomyAndCaravans()
+    {
+        var (world, index) = World.World.Empty();
+        var siteA = new Site { Position = int2.zero };
+        var siteB = new Site { Position = new int2(5, 0) };
+        var idA = index.Sites.Insert(siteA);
+        var idB = index.Sites.Insert(siteB);
+        siteA.Economy.Produce(new Good.Wood(), 4f);
+        index.Caravans.Add(new Caravan(new[] { idA, idB }));
+
+        for (int i = 0; i < 3; i++)
+            world.Tick(1f);
+
+        Assert.True(siteB.Economy.GetStock(new Good.Wood()) > 0f);
+        Assert.NotEmpty(index.EconomyContext.Events);
+        Assert.True(index.EconomyContext.MarketPrices.ContainsKey(idA));
+    }
+}

--- a/VelorenPort/World/Src/Site/Caravan.cs
+++ b/VelorenPort/World/Src/Site/Caravan.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using VelorenPort.NativeMath;
 using VelorenPort.CoreEngine;
+using VelorenPort.World.Site.Economy;
 
 namespace VelorenPort.World.Site;
 
@@ -48,7 +49,16 @@ public class Caravan
         foreach (var kv in Cargo.ToList())
         {
             if (kv.Value <= 0f) continue;
-            EconomySim.TradeGoods(from, to, kv.Key, kv.Value);
+            if (EconomySim.TradeGoods(from, to, kv.Key, kv.Value))
+                index.EconomyContext.Events.Add(
+                    new Economy.EconomyContext.TradeEvent(
+                        Economy.EconomyContext.TradePhase.Execute,
+                        fromId,
+                        toId,
+                        kv.Key,
+                        kv.Value,
+                        from.Market.GetPrice(kv.Key),
+                        index.EconomyContext.Time));
             Cargo[kv.Key] = 0f;
         }
 

--- a/VelorenPort/World/Src/World.cs
+++ b/VelorenPort/World/Src/World.cs
@@ -127,7 +127,8 @@ namespace VelorenPort.World {
 
         /// <summary>Advance the simulation by the specified delta time.</summary>
         public void Tick(float dt) {
-            EconomySim.SimulateEconomy(Index, dt);
+            EconomySim.SimulateCaravans(Index, Index.Caravans, dt);
+            Index.EconomyContext.Tick(Index, dt);
             Sim.Tick(dt);
         }
 

--- a/VelorenPort/World/Src/WorldIndex.cs
+++ b/VelorenPort/World/Src/WorldIndex.cs
@@ -18,6 +18,8 @@ namespace VelorenPort.World {
         public Store<VelorenPort.CoreEngine.Npc> Npcs { get; } = new();
         public List<Site.TradingRoute> TradingRoutes { get; } = new();
         public List<Site.PopulationEvent> PopulationEvents { get; } = new();
+        public List<Site.Caravan> Caravans { get; } = new();
+        public Site.Economy.EconomyContext EconomyContext { get; } = new();
 
         private ulong _nextUid;
         public Uid AllocateUid() => new Uid(_nextUid++);


### PR DESCRIPTION
## Summary
- track market prices and trades in `EconomyContext`
- allow caravans to emit trade events
- store caravans and economy context in `WorldIndex`
- tick caravans and economy context from `World`
- test that world ticking moves goods and records events

## Testing
- `dotnet test VelorenPort/VelorenPort.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615f6c91b08328b589eb96f2466780