### PR TITLE
Add simplified airship travel routes

### DIFF
--- a/VelorenPort/World.Tests/AirshipTravelTests.cs
+++ b/VelorenPort/World.Tests/AirshipTravelTests.cs
@@ -1,0 +1,47 @@
+using VelorenPort.World;
+using VelorenPort.World.Civ;
+using VelorenPort.World.Site;
+using VelorenPort.NativeMath;
+
+namespace World.Tests;
+
+public class AirshipTravelTests
+{
+    [Fact]
+    public void RouteGeneration_CreatesConnectionBetweenSites()
+    {
+        var (world, index) = World.Empty();
+        var siteA = new Site { Position = new int2(0, 0) };
+        siteA.Plots.Add(new Plot { Kind = PlotKind.AirshipDock });
+        var siteB = new Site { Position = new int2(100, 0) };
+        siteB.Plots.Add(new Plot { Kind = PlotKind.AirshipDock });
+        var idA = index.Sites.Insert(siteA);
+        var idB = index.Sites.Insert(siteB);
+
+        index.Airships.GenerateRoutes(world.Sim, index.Sites);
+
+        Assert.Single(index.Airships.Routes);
+        var route = index.Airships.Routes[0];
+        Assert.Contains(idA, route.Sites);
+        Assert.Contains(idB, route.Sites);
+        Assert.True(route.Distance > 0);
+    }
+
+    [Fact]
+    public void Approaches_HaveValidDirection()
+    {
+        var (world, index) = World.Empty();
+        var siteA = new Site { Position = new int2(0, 0) };
+        siteA.Plots.Add(new Plot { Kind = PlotKind.AirshipDock });
+        var siteB = new Site { Position = new int2(50, 50) };
+        siteB.Plots.Add(new Plot { Kind = PlotKind.AirshipDock });
+        index.Sites.Insert(siteA);
+        index.Sites.Insert(siteB);
+
+        index.Airships.GenerateRoutes(world.Sim, index.Sites);
+        var route = index.Airships.Routes[0];
+        var approach = route.Approaches[0];
+        Assert.NotEqual(Dir.Zero, approach.AirshipDirection);
+        Assert.True(route.TravelTime > 0f);
+    }
+}

--- a/VelorenPort/World/Src/Civ/AirshipTravel.cs
+++ b/VelorenPort/World/Src/Civ/AirshipTravel.cs
@@ -4,6 +4,7 @@ using VelorenPort.World.Site;
 using VelorenPort.World.Site.Util;
 using VelorenPort.CoreEngine;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace VelorenPort.World.Civ
 {
@@ -47,12 +48,20 @@ namespace VelorenPort.World.Civ
         public Store<Site.Site>.Id[] Sites { get; } = new Store<Site.Site>.Id[2];
         public AirshipDockingApproach[] Approaches { get; } = new AirshipDockingApproach[2];
         public uint Distance { get; init; }
+        public float TravelTime { get; init; }
     }
 
     [Serializable]
     public class Airships
     {
+        private const float CruiseSpeed = 200f;
         public Dictionary<uint, AirshipRoute> Routes { get; } = new();
+
+        public IEnumerable<AirshipRoute> RoutesFrom(Store<Site.Site>.Id id)
+            => Routes.Values.Where(r => r.Sites[0] == id || r.Sites[1] == id);
+
+        public AirshipRoute? GetRoute(uint id)
+            => Routes.TryGetValue(id, out var r) ? r : null;
 
         /// <summary>Create a trivial route between two sites.</summary>
         public void CreateRoute(uint id, Store<Site.Site>.Id a, Store<Site.Site>.Id b)
@@ -85,7 +94,66 @@ namespace VelorenPort.World.Civ
             {
                 Sites = { [0] = a, [1] = b },
                 Approaches = { [0] = approachA, [1] = approachB },
-                Distance = 0u
+                Distance = 0u,
+                TravelTime = 0f
+            };
+        }
+
+        /// <summary>
+        /// Generate simple airship routes connecting all sites with an airship dock.
+        /// </summary>
+        public void GenerateRoutes(WorldSim sim, Store<Site.Site> sites)
+        {
+            Routes.Clear();
+
+            var docks = new List<(Store<Site.Site>.Id id, float3 pos)>();
+            foreach (var (id, site) in sites.Enumerate())
+            {
+                if (!site.Plots.Any(p => p.Kind.ToString().Contains("AirshipDock")))
+                    continue;
+                float alt = sim.GetSurfaceAltApprox(site.Position);
+                docks.Add((id, new float3(site.Position.x + 0.5f, site.Position.y + 0.5f, alt + 10f)));
+            }
+
+            uint routeId = 0;
+            for (int i = 0; i < docks.Count; i++)
+                for (int j = i + 1; j < docks.Count; j++)
+                {
+                    var a = docks[i];
+                    var b = docks[j];
+                    Routes[routeId++] = BuildRoute(a.id, b.id, a.pos, b.pos);
+                }
+        }
+
+        private static AirshipDockingApproach BuildApproach(float3 from, float3 to, Store<Site.Site>.Id dest)
+        {
+            var dirVec = math.normalize(to - from);
+            var dir = Dir.FromUnnormalized(dirVec) ?? Dir.Y;
+            return new AirshipDockingApproach
+            {
+                DockPos = new AirshipDockingPosition(0, to),
+                AirshipPos = to,
+                AirshipDirection = dir,
+                DockCenter = to.xy,
+                Height = 100f,
+                ApproachInitialPos = from.xy,
+                ApproachFinalPos = to.xy,
+                Side = AirshipDockingSide.Starboard,
+                SiteId = dest
+            };
+        }
+
+        private static AirshipRoute BuildRoute(Store<Site.Site>.Id a, Store<Site.Site>.Id b, float3 posA, float3 posB)
+        {
+            float dist = math.distance(posA.xy, posB.xy);
+            var approachAB = BuildApproach(posA, posB, b);
+            var approachBA = BuildApproach(posB, posA, a);
+            return new AirshipRoute
+            {
+                Sites = { [0] = a, [1] = b },
+                Approaches = { [0] = approachAB, [1] = approachBA },
+                Distance = (uint)dist,
+                TravelTime = dist / CruiseSpeed
             };
         }
     }

--- a/VelorenPort/World/Src/World.cs
+++ b/VelorenPort/World/Src/World.cs
@@ -5,24 +5,29 @@ using VelorenPort.NativeMath;
 using VelorenPort.World.Site;
 using VelorenPort.CoreEngine;
 using VelorenPort.World.Layer;
+using VelorenPort.World.Civ;
 
-namespace VelorenPort.World {
+namespace VelorenPort.World
+{
     /// <summary>
     /// Entry point of the world module. Provides a subset of the original
     /// functionality of <c>world/src/lib.rs</c>.
     /// </summary>
     [Serializable]
-    public class World {
+    public class World
+    {
         public WorldSim Sim { get; }
         public WorldIndex Index { get; }
 
-        private World(WorldSim sim, WorldIndex index) {
+        private World(WorldSim sim, WorldIndex index)
+        {
             Sim = sim;
             Index = index;
         }
 
         /// <summary>Generate a new world using the given seed.</summary>
-        public static (World world, WorldIndex index) Generate(uint seed) {
+        public static (World world, WorldIndex index) Generate(uint seed)
+        {
             var index = new WorldIndex(seed);
             var sim = new WorldSim(seed, new int2(256, 256));
             var world = new World(sim, index);
@@ -118,7 +123,8 @@ namespace VelorenPort.World {
         /// <summary>
         /// Sample a world column at the given world position using the internal simulation.
         /// </summary>
-        public ColumnSample? SampleColumn(int2 wpos) {
+        public ColumnSample? SampleColumn(int2 wpos)
+        {
             var land = GetLand();
             return land.ColumnSample(wpos, Index);
         }
@@ -126,7 +132,8 @@ namespace VelorenPort.World {
         public Noise Noise => Index.Noise;
 
         /// <summary>Advance the simulation by the specified delta time.</summary>
-        public void Tick(float dt) {
+        public void Tick(float dt)
+        {
             EconomySim.SimulateEconomy(Index, dt);
             Sim.Tick(dt);
         }
@@ -140,7 +147,8 @@ namespace VelorenPort.World {
         /// <summary>Get a map of altitudes around a chunk position.</summary>
         public float[,] GetAltitudeMap(int2 cpos, int radius) => Sim.GetAltitudeMap(cpos, radius);
 
-        public Site.Site CreateSite(int2 position) {
+        public Site.Site CreateSite(int2 position)
+        {
             var rng = new Random((int)math.hash(position));
             string name = Site.NameGen.Generate(rng);
             var site = new Site.Site { Position = position, Name = name };
@@ -255,6 +263,12 @@ namespace VelorenPort.World {
 
             return best;
         }
+
+        public IEnumerable<AirshipRoute> GetAirshipRoutes()
+            => Index.Airships.Routes.Values;
+
+        public IEnumerable<AirshipRoute> GetAirshipRoutesFrom(Store<Site.Site>.Id id)
+            => Index.Airships.RoutesFrom(id);
 
     }
 }

--- a/VelorenPort/World/Src/WorldIndex.cs
+++ b/VelorenPort/World/Src/WorldIndex.cs
@@ -2,14 +2,17 @@ using System;
 using VelorenPort.CoreEngine;
 using VelorenPort.NativeMath;
 using VelorenPort.World.Site;
+using VelorenPort.World.Civ;
 
 
-namespace VelorenPort.World {
+namespace VelorenPort.World
+{
     /// <summary>
     /// Simplified index keeping track of global world state.
     /// </summary>
     [Serializable]
-    public class WorldIndex {
+    public class WorldIndex
+    {
         public uint Seed { get; private set; }
         public float Time { get; set; }
         public Noise Noise { get; private set; }
@@ -18,13 +21,15 @@ namespace VelorenPort.World {
         public Store<VelorenPort.CoreEngine.Npc> Npcs { get; } = new();
         public List<Site.TradingRoute> TradingRoutes { get; } = new();
         public List<Site.PopulationEvent> PopulationEvents { get; } = new();
+        public Airships Airships { get; } = new();
 
         private ulong _nextUid;
         public Uid AllocateUid() => new Uid(_nextUid++);
         public Weather CurrentWeather { get; set; } = new Weather(0f, 0f, float2.zero);
         public Unity.Entities.EntityManager EntityManager { get; } = new Unity.Entities.EntityManager();
 
-        public WorldIndex(uint seed) {
+        public WorldIndex(uint seed)
+        {
             Seed = seed;
             Noise = new Noise(seed);
         }

--- a/VelorenPort/World/Src/WorldSim.cs
+++ b/VelorenPort/World/Src/WorldSim.cs
@@ -6,13 +6,16 @@ using VelorenPort.NativeMath;
 using VelorenPort.CoreEngine;
 using VelorenPort.World.Sim;
 using VelorenPort.World.Util;
+using VelorenPort.World.Civ;
 
-namespace VelorenPort.World {
+namespace VelorenPort.World
+{
     /// <summary>
     /// Core world simulation. Most functionality is pending port from Rust.
     /// </summary>
     [Serializable]
-    public class WorldSim {
+    public class WorldSim
+    {
         private readonly Noise _noise;
         private readonly int2 _size;
         private readonly Dictionary<int2, SimChunk> _chunks = new();
@@ -24,7 +27,8 @@ namespace VelorenPort.World {
         private Sim.WeatherMap _weather;
         private readonly Random _rng;
 
-        public WorldSim(uint seed, int2 size) {
+        public WorldSim(uint seed, int2 size)
+        {
             _noise = new Noise(seed);
             _size = size;
             _structureGen = new StructureGen2d(seed, 24, 10);
@@ -40,7 +44,8 @@ namespace VelorenPort.World {
 
         public int2 GetSize() => _size;
 
-        public T GetInterpolated<T>(int2 wpos, Func<SimChunk, T> f) where T : struct {
+        public T GetInterpolated<T>(int2 wpos, Func<SimChunk, T> f) where T : struct
+        {
             var chunk = GetWpos(wpos);
             return chunk == null ? default : f(chunk);
         }
@@ -54,12 +59,14 @@ namespace VelorenPort.World {
 
         public float? GetAltApprox(int2 wpos) => GetWpos(wpos)?.Alt;
 
-        public SimChunk? Get(int2 chunkPos) {
+        public SimChunk? Get(int2 chunkPos)
+        {
             if (_chunks.TryGetValue(chunkPos, out var chunk)) return chunk;
             return GenerateChunk(chunkPos);
         }
 
-        public void Set(int2 chunkPos, SimChunk chunk) {
+        public void Set(int2 chunkPos, SimChunk chunk)
+        {
             _chunks[chunkPos] = chunk;
         }
 
@@ -69,7 +76,8 @@ namespace VelorenPort.World {
 
         public SimChunk? GetWpos(int2 wpos) => Get(TerrainChunkSize.WposToCpos(wpos));
 
-        public float? GetGradientApprox(int2 wpos) {
+        public float? GetGradientApprox(int2 wpos)
+        {
             const int SAMP_RES = 8;
             var altx0 = GetAltApprox(wpos - new int2(SAMP_RES, 0)) ?? 0f;
             var altx1 = GetAltApprox(wpos + new int2(SAMP_RES, 0)) ?? 0f;
@@ -185,7 +193,8 @@ namespace VelorenPort.World {
         }
 
         /// <summary>Advance simulation state. Currently only ticks regions.</summary>
-        public void Tick(float dt) {
+        public void Tick(float dt)
+        {
             _regions.Tick();
             _humidity.Diffuse();
             _weather.Tick(_rng);
@@ -195,14 +204,16 @@ namespace VelorenPort.World {
 
         }
 
-        public float[,] GetAltitudeMap(int2 cpos, int radius) {
+        public float[,] GetAltitudeMap(int2 cpos, int radius)
+        {
             int size = radius * 2 + 1;
             var map = new float[size, size];
             for (int dy = -radius; dy <= radius; dy++)
-            for (int dx = -radius; dx <= radius; dx++) {
-                var pos = cpos + new int2(dx, dy);
-                map[dx + radius, dy + radius] = Get(pos)?.Alt ?? 0f;
-            }
+                for (int dx = -radius; dx <= radius; dx++)
+                {
+                    var pos = cpos + new int2(dx, dy);
+                    map[dx + radius, dy + radius] = Get(pos)?.Alt ?? 0f;
+                }
             return map;
         }
 
@@ -227,17 +238,17 @@ namespace VelorenPort.World {
         public IEnumerable<RegionInfo> GetNearRegions(int2 chunkPos, int radius)
         {
             for (int y = -radius; y <= radius; y++)
-            for (int x = -radius; x <= radius; x++)
-            {
-                var pos = chunkPos + new int2(x, y);
-                float dist = math.length(new float2(x, y));
-                uint seed = (uint)math.hash(pos);
-                yield return new RegionInfo(
-                    pos,
-                    pos * TerrainChunkSize.RectSize,
-                    dist,
-                    seed);
-            }
+                for (int x = -radius; x <= radius; x++)
+                {
+                    var pos = chunkPos + new int2(x, y);
+                    float dist = math.length(new float2(x, y));
+                    uint seed = (uint)math.hash(pos);
+                    yield return new RegionInfo(
+                        pos,
+                        pos * TerrainChunkSize.RectSize,
+                        dist,
+                        seed);
+                }
         }
 
         public Lottery<ForestKind?> MakeForestLottery(int2 wpos)
@@ -337,10 +348,12 @@ namespace VelorenPort.World {
             return math.normalize(res);
         }
 
-        private SimChunk GenerateChunk(int2 chunkPos) {
+        private SimChunk GenerateChunk(int2 chunkPos)
+        {
             var worldPos = TerrainChunkSize.CposToWposCenter(chunkPos);
             float baseAlt = _noise.CaveFbm(new float3(worldPos.x * 0.01f, worldPos.y * 0.01f, 0));
-            var chunk = new SimChunk {
+            var chunk = new SimChunk
+            {
                 Alt = baseAlt * 32f,
                 Basement = baseAlt * 31f,
                 WaterAlt = 0f,
@@ -348,7 +361,7 @@ namespace VelorenPort.World {
                 Temp = _noise.Cave(new float3(worldPos, 1)) * 0.5f,
                 Humidity = _noise.Scatter(new float3(worldPos, 2)) * 0.5f + 0.5f,
                 Rockiness = math.abs(_noise.Cave(new float3(worldPos, 3))),
-                TreeDensity = math.saturate(_noise.Scatter(new float3(worldPos,4)) * 0.5f + 0.5f),
+                TreeDensity = math.saturate(_noise.Scatter(new float3(worldPos, 4)) * 0.5f + 0.5f),
                 ForestKind = ForestKind.Oak,
                 SpawnRate = 1f,
                 River = new RiverData(),
@@ -364,5 +377,8 @@ namespace VelorenPort.World {
             _regions.Get(chunkPos).AddEvent("generated");
             return chunk;
         }
+
+        public IEnumerable<AirshipRoute> GetAirshipRoutes(WorldIndex index)
+            => index.Airships.Routes.Values;
     }
 }


### PR DESCRIPTION
## Summary
- implement minimal airship route generation and docking
- expose querying helpers on `World` and `WorldSim`
- track routes in `WorldIndex`
- add basic unit tests for route creation and approach maths

## Testing
- `dotnet format --include "World/Src/Civ/AirshipTravel.cs" "World/Src/WorldIndex.cs" "World/Src/World.cs" "World/Src/WorldSim.cs" "World.Tests/AirshipTravelTests.cs" --no-restore`
- `dotnet build World.Tests/World.Tests.csproj` *(fails: type or namespace name 'float3x3' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_6861610c68588328820c1eda2bdfdd84