### PR TITLE
Update docs on persistence gap

### DIFF
--- a/VelorenPort/Server/MissingFeatures.md
+++ b/VelorenPort/Server/MissingFeatures.md
@@ -29,9 +29,10 @@ removing code.
 - **Agent and combat behaviours**: AI routines for NPCs and full combat rules
   remain missing. The current `NpcAiSystem` and `LootSystem` are placeholders
   that perform minimal actions.
-- **Database and migrations**: migration scripts exist but the SQLite database
-  layer from Rust is not yet ported. Character data is saved to disk only with
-  simple serialization.
+- **Database and migrations**: only `CharacterLoader` provides JSON-based
+  persistence. The database models and migrations from `server/src/persistence`
+  are not yet ported. A task is required to implement SQLite-based persistence
+  by running the SQL scripts in `VelorenPort/Server/Src/Migrations`.
 - **Plugins and extensibility**: `PluginManager` loads assemblies from
   `plugins/` but a stable API and WebAssembly support are absent.
 - **Real-time simulation**: the `Rtsim` module only records start time and does


### PR DESCRIPTION
## Summary
- clarify which persistence exists in the Server port
- mention need for SQLite and migrations

## Testing
- `dotnet test VelorenPort/VelorenPort.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686162c8f5048328a051ed59d355e591