### PR TITLE
Fix events documentation

### DIFF
--- a/VelorenPort/Server/MissingFeatures.md
+++ b/VelorenPort/Server/MissingFeatures.md
@@ -46,8 +46,11 @@ removing code.
   has been recreated. A `QueryClient` lives under `Src/QueryClient.cs` but lacks
   full version negotiation and integration tests. Query/discovery still does not
   completely match the Rust implementation.
-- **Incomplete events module**: only a handful of types from `server/src/events/*`
-  are available and the event bus does not check if events are consumed.
+ - **Incomplete events module**: only a few event classes like
+   `AdditionalEvents.cs`, `ChatEvent.cs` and `CreateItemDropEvent.cs` are
+   currently exposed. Many event types from `server/src/events/*` are still
+   missing, and the event bus does not verify that events are consumed as the
+   Rust version does.
 - **Simplified login and administration**: banlist and whitelist loading work,
   but admin role assignment and CLI management have been reduced.
 - **Missing weather and advanced real-time simulation**: the basic `rtsim` logic


### PR DESCRIPTION
## Summary
- clarify gaps in the server events module

## Testing
- `dotnet test VelorenPort/VelorenPort.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686165bcd46483288804a248642c66b1