### PR TITLE
Update MissingFeatures about agent crate

### DIFF
--- a/VelorenPort/Server/MissingFeatures.md
+++ b/VelorenPort/Server/MissingFeatures.md
@@ -27,8 +27,10 @@ removing code.
 - **Item system**: there is no equivalent to `server/src/sys/item.rs`; item
   merging, deletion, and loot ownership are unimplemented.
 - **Agent and combat behaviours**: AI routines for NPCs and full combat rules
-  remain missing. The current `NpcAiSystem` and `LootSystem` are placeholders
-  that perform minimal actions.
+  remain missing. The Rust `agent` crate (e.g., `server/agent/src`) has not been
+  ported, so sophisticated NPC behaviour trees and combat decisions are
+  absent. The current `NpcAiSystem` and `LootSystem` are placeholders that
+  perform minimal actions.
 - **Database and migrations**: only `CharacterLoader` provides JSON-based
   persistence. The database models and migrations from `server/src/persistence`
   are not yet ported. A task is required to implement SQLite-based persistence


### PR DESCRIPTION
## Summary
- note that the Rust `agent` crate has not been ported in `Server/MissingFeatures.md`

## Testing
- `dotnet build VelorenPort/VelorenPort.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861683e33788328a322c707e40af23d