### PR TITLE
Add wildlife behaviour states and resource deposit tracking

### DIFF
--- a/VelorenPort/World.Tests/WildlifeBehaviourTests.cs
+++ b/VelorenPort/World.Tests/WildlifeBehaviourTests.cs
@@ -1,0 +1,35 @@
+using VelorenPort.World;
+using VelorenPort.NativeMath;
+
+namespace World.Tests;
+
+public class WildlifeBehaviourTests
+{
+    [Fact]
+    public void WildlifeEntity_StateTransitions()
+    {
+        var entity = new WildlifeEntity(int3.zero, FaunaKind.Wolf);
+        entity.Tick(1.1f);
+        Assert.Equal(FaunaBehaviourState.Roaming, entity.State);
+        entity.Tick(60f);
+        Assert.Equal(FaunaBehaviourState.Despawn, entity.State);
+    }
+
+    [Fact]
+    public void ResourceLayer_WritesDepositsToSupplement()
+    {
+        var ctx = new LayerContext { ChunkPos = int2.zero, Noise = new Noise(0) };
+        var chunk = new Chunk(int2.zero, Block.Earth);
+        LayerManager.Apply(LayerType.Resource, ctx, chunk);
+        Assert.Equal(ctx.Supplement.ResourceBlocks.Count, ctx.Supplement.ResourceDeposits.Count);
+        Assert.True(ctx.Supplement.ResourceBlocks.Count > 0);
+    }
+
+    [Fact]
+    public void GenerateChunkWithSupplement_StoresWildlifeEntities()
+    {
+        var (chunk, sup) = TerrainGenerator.GenerateChunkWithSupplement(int2.zero, new Noise(1));
+        Assert.Equal(sup.Wildlife.Count, sup.WildlifeEntities.Count);
+        Assert.Equal(sup.ResourceBlocks.Count, sup.ResourceDeposits.Count);
+    }
+}

--- a/VelorenPort/World/Src/Canvas.cs
+++ b/VelorenPort/World/Src/Canvas.cs
@@ -142,9 +142,16 @@ namespace VelorenPort.World {
         public void WriteSupplementData(ChunkSupplement supplement)
         {
             foreach (var pos in _resourceBlocks)
+            {
                 supplement.ResourceBlocks.Add(pos);
+                var kind = _chunk[pos.x, pos.y, pos.z].Kind;
+                supplement.ResourceDeposits.Add(new ResourceDeposit(pos, kind));
+            }
             foreach (var spawn in _faunaSpawns)
+            {
                 supplement.Wildlife.Add(spawn);
+                supplement.WildlifeEntities.Add(new WildlifeEntity(spawn.Position, spawn.Kind));
+            }
             foreach (var pos in _spawns)
                 supplement.SpawnPoints.Add(pos);
         }

--- a/VelorenPort/World/Src/ChunkSupplement.cs
+++ b/VelorenPort/World/Src/ChunkSupplement.cs
@@ -12,7 +12,9 @@ namespace VelorenPort.World {
         public List<object> Entities { get; } = new();
         public Dictionary<ChunkResource, int> RtsimMaxResources { get; } = new();
         public List<int3> ResourceBlocks { get; } = new();
+        public List<ResourceDeposit> ResourceDeposits { get; } = new();
         public List<FaunaSpawn> Wildlife { get; } = new();
+        public List<WildlifeEntity> WildlifeEntities { get; } = new();
         public List<int3> SpawnPoints { get; } = new();
 
         public void AddEntity(object entity) => Entities.Add(entity);

--- a/VelorenPort/World/Src/Layer/ResourceLayer.cs
+++ b/VelorenPort/World/Src/Layer/ResourceLayer.cs
@@ -14,11 +14,14 @@ public static class ResourceLayer
                 chunk.Position.x * Chunk.Size.x + x,
                 chunk.Position.y * Chunk.Size.y + y,
                 z);
-            float n = ctx.Noise.Ore(wpos * 0.12f);
-            if (n > 0.86f)
+            float n = ctx.Noise.Ore(wpos * 0.1f);
+            if (n > 0.85f)
             {
-                BlockKind kind = n > 0.93f ? BlockKind.GlowingRock : BlockKind.GlowingWeakRock;
+                BlockKind kind = n > 0.95f ? BlockKind.GlowingRock : BlockKind.GlowingWeakRock;
                 chunk[x, y, z] = new Block(kind);
+                var pos = new int3(x, y, z);
+                ctx.Supplement.ResourceBlocks.Add(pos);
+                ctx.Supplement.ResourceDeposits.Add(new ResourceDeposit(pos, kind));
             }
         }
     }

--- a/VelorenPort/World/Src/Layer/WildlifeLayer.cs
+++ b/VelorenPort/World/Src/Layer/WildlifeLayer.cs
@@ -29,7 +29,10 @@ public static class WildlifeLayer
             if (n > 0.85f)
             {
                 FaunaKind kind = (FaunaKind)((int)(n * 10) % 4 + 1);
-                chunk.AddWildlife(new FaunaSpawn((int3)wpos, kind));
+                var spawn = new FaunaSpawn((int3)wpos, kind);
+                chunk.AddWildlife(spawn);
+                ctx.Supplement.Wildlife.Add(spawn);
+                ctx.Supplement.WildlifeEntities.Add(new WildlifeEntity(spawn.Position, spawn.Kind));
             }
         }
     }

--- a/VelorenPort/World/Src/ResourceDeposit.cs
+++ b/VelorenPort/World/Src/ResourceDeposit.cs
@@ -1,0 +1,21 @@
+using System;
+using VelorenPort.NativeMath;
+
+namespace VelorenPort.World
+{
+    /// <summary>
+    /// Information about a resource block generated within a chunk.
+    /// </summary>
+    [Serializable]
+    public struct ResourceDeposit
+    {
+        public int3 Position { get; set; }
+        public BlockKind Kind { get; set; }
+
+        public ResourceDeposit(int3 position, BlockKind kind)
+        {
+            Position = position;
+            Kind = kind;
+        }
+    }
+}

--- a/VelorenPort/World/Src/TerrainGenerator.cs
+++ b/VelorenPort/World/Src/TerrainGenerator.cs
@@ -43,7 +43,10 @@ namespace VelorenPort.World {
             Layer.LayerManager.Apply(Layer.LayerType.Wildlife, ctx, chunk);
 
             foreach (var spawn in chunk.Wildlife)
+            {
                 supplement.Wildlife.Add(spawn);
+                supplement.WildlifeEntities.Add(new WildlifeEntity(spawn.Position, spawn.Kind));
+            }
 
             // collect resource blocks after layers have run
             for (int x = 0; x < Chunk.Size.x; x++)
@@ -51,7 +54,11 @@ namespace VelorenPort.World {
             for (int z = 0; z < Chunk.Height; z++)
             {
                 if (chunk[x, y, z].GetRtsimResource() != null)
-                    supplement.ResourceBlocks.Add(new int3(x, y, z));
+                {
+                    var pos = new int3(x, y, z);
+                    supplement.ResourceBlocks.Add(pos);
+                    supplement.ResourceDeposits.Add(new ResourceDeposit(pos, chunk[x, y, z].Kind));
+                }
             }
 
             return (chunk, supplement);

--- a/VelorenPort/World/Src/WildlifeEntity.cs
+++ b/VelorenPort/World/Src/WildlifeEntity.cs
@@ -1,0 +1,65 @@
+using System;
+using VelorenPort.NativeMath;
+
+namespace VelorenPort.World
+{
+    /// <summary>
+    /// Runtime representation of a fauna entity with a simple
+    /// behaviour state machine.
+    /// </summary>
+    [Serializable]
+    public class WildlifeEntity
+    {
+        public FaunaKind Kind { get; }
+        public int3 Position { get; private set; }
+        public FaunaBehaviourState State { get; private set; }
+        private float _age;
+        private readonly Random _rng = new();
+
+        public WildlifeEntity(int3 position, FaunaKind kind)
+        {
+            Position = position;
+            Kind = kind;
+            State = FaunaBehaviourState.Spawning;
+            _age = 0f;
+        }
+
+        /// <summary>Advance the behaviour state machine.</summary>
+        public void Tick(float dt)
+        {
+            _age += dt;
+            switch (State)
+            {
+                case FaunaBehaviourState.Spawning:
+                    if (_age > 1f)
+                        State = FaunaBehaviourState.Roaming;
+                    break;
+                case FaunaBehaviourState.Roaming:
+                    if (_age > 60f)
+                    {
+                        State = FaunaBehaviourState.Despawn;
+                        break;
+                    }
+                    Roam();
+                    break;
+                case FaunaBehaviourState.Despawn:
+                    break;
+            }
+        }
+
+        private void Roam()
+        {
+            int dx = (int)Math.Round(_rng.NextFloat2(-1f, 1f).x);
+            int dy = (int)Math.Round(_rng.NextFloat2(-1f, 1f).y);
+            Position += new int3(dx, dy, 0);
+        }
+    }
+
+    /// <summary>Simple behaviour states for wildlife.</summary>
+    public enum FaunaBehaviourState
+    {
+        Spawning,
+        Roaming,
+        Despawn
+    }
+}


### PR DESCRIPTION
## Summary
- implement `WildlifeEntity` with basic spawning/roaming/despawn state machine
- capture wildlife entities and ore deposits in `ChunkSupplement`
- expand wildlife and resource layers to populate supplement data
- record deposits and wildlife entities in canvas and terrain generator
- add unit tests for wildlife behaviour and resource persistence

## Testing
- `dotnet test VelorenPort/World.Tests/World.Tests.csproj -c Release` *(fails: Type 'SiteKindExtensions' already defines a member called 'Meta' with the same parameter types)*

------
https://chatgpt.com/codex/tasks/task_e_6861684343e08328805e31413bcc742c