### PR TITLE
Add Rust FFI and C# bindings example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,6 +4331,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "network-ffi"
+version = "0.1.0"
+
+[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
     "voxygen/egui",
     "world",
     "network",
-    "network/protocol",
+    "network/protocol", "network-ffi",
 ]
 
 ### LINTS ###

--- a/VelorenPort/Docs/Interoperabilidad.md
+++ b/VelorenPort/Docs/Interoperabilidad.md
@@ -4,9 +4,11 @@ Este documento recogerá pruebas para integrar módulos existentes en Rust media
 
 ## Estado actual
 
-Aún no se ha realizado ningún experimento de interoperabilidad. El código en C#
-no expone bindings ni define la ABI necesaria para enlazar con bibliotecas
-compiladas en Rust.
+Se añadió un pequeño experimento para exponer funciones de red escritas en
+Rust.  El crate `network-ffi` compila como biblioteca compartida y ofrece la
+función `vp_send_udp` para enviar datagramas.  En C# se creó la clase
+`RustBindings` que utiliza `DllImport` para invocar dicha función desde la
+assembly `Network`.
 
 ## Tareas pendientes
 
@@ -18,3 +20,26 @@ compiladas en Rust.
   codificación de mensajes y gestión de memoria).
 - Crear ejemplos mínimos que demuestren intercambio de datos entre C# y Rust.
 - Documentar la configuración del proyecto y los pasos de compilación cruzada.
+
+## Compilación de la biblioteca FFI
+
+```bash
+# Desde la raíz del repositorio
+cargo build --release -p network-ffi
+
+# En Windows se generará `network_ffi.dll` y en Linux `libnetwork_ffi.so`
+```
+
+### Ejemplo de uso en C#
+
+```csharp
+bool ok = UdpWrapper.Send("127.0.0.1:9876", "ping");
+```
+
+## Exploración Wasm
+
+Otra opción es compilar `network-ffi` a `wasm32-unknown-unknown` y utilizar
+`wasm-bindgen` para exponer una API JavaScript. Esta variante permitiría que un
+cliente ligero en navegadores reciba y envíe mensajes sin depender de plugins
+nativos. El empaquetado final podría integrarse en una aplicación WebGL de
+Unity o en un cliente ligero fuera del motor.

--- a/VelorenPort/Network/Src/RustBindings.cs
+++ b/VelorenPort/Network/Src/RustBindings.cs
@@ -1,0 +1,16 @@
+using System.Runtime.InteropServices;
+
+namespace VelorenPort.Network {
+    /// <summary>
+    /// Enlaces a funciones de networking implementadas en Rust mediante FFI.
+    /// </summary>
+    internal static class RustBindings {
+        private const string Dll = "network_ffi";
+
+        [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "vp_send_udp")]
+        internal static extern int SendUdp(string addr, byte[] data, ulong len);
+
+        [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "vp_network_ffi_version")]
+        internal static extern int Version();
+    }
+}

--- a/VelorenPort/Network/Src/UdpWrapper.cs
+++ b/VelorenPort/Network/Src/UdpWrapper.cs
@@ -1,0 +1,17 @@
+using System.Text;
+
+namespace VelorenPort.Network {
+    /// <summary>
+    /// Funciones utilitarias para interactuar con la biblioteca Rust.
+    /// </summary>
+    public static class UdpWrapper {
+        /// <summary>
+        /// Envia un mensaje UDP utilizando la implementacion Rust.
+        /// </summary>
+        public static bool Send(string address, string message) {
+            byte[] bytes = Encoding.UTF8.GetBytes(message);
+            int sent = RustBindings.SendUdp(address, bytes, (ulong)bytes.Length);
+            return sent == bytes.Length;
+        }
+    }
+}

--- a/network-ffi/Cargo.toml
+++ b/network-ffi/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "network-ffi"
+version = "0.1.0"
+edition = "2024"
+
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/network-ffi/src/lib.rs
+++ b/network-ffi/src/lib.rs
@@ -1,0 +1,33 @@
+use std::ffi::CStr;
+use std::net::UdpSocket;
+use std::os::raw::{c_char, c_int, c_uchar};
+
+/// Envia un datagrama UDP a la direccion especificada.
+/// Devuelve el numero de bytes enviados o -1 en caso de error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vp_send_udp(addr: *const c_char, data: *const c_uchar, len: usize) -> c_int {
+    if addr.is_null() || data.is_null() {
+        return -1;
+    }
+    // Convertir la direccion C a &str
+    let addr_cstr = CStr::from_ptr(addr);
+    let addr_str = match addr_cstr.to_str() {
+        Ok(s) => s,
+        Err(_) => return -1,
+    };
+    let socket = match UdpSocket::bind("0.0.0.0:0") {
+        Ok(s) => s,
+        Err(_) => return -1,
+    };
+    let slice = std::slice::from_raw_parts(data, len);
+    match socket.send_to(slice, addr_str) {
+        Ok(sent) => sent as c_int,
+        Err(_) => -1,
+    }
+}
+
+/// Devuelve la version de la capa FFI.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vp_network_ffi_version() -> c_int {
+    1
+}


### PR DESCRIPTION
## Summary
- create `network-ffi` crate exposing simple UDP helper functions
- connect `network-ffi` to workspace
- add `RustBindings` and `UdpWrapper` classes in C# to use `DllImport`
- document build and Wasm idea in `Docs/Interoperabilidad.md`

## Testing
- `cargo check -p network-ffi`
- `dotnet build VelorenPort/Network/Network.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616844ac448328ba3f84fc664a587d