### PR TITLE
Expand WeatherJob and integrate with WorldSim

### DIFF
--- a/VelorenPort/Server.Tests/WeatherJobIntegrationTests.cs
+++ b/VelorenPort/Server.Tests/WeatherJobIntegrationTests.cs
@@ -1,0 +1,27 @@
+using System;
+using VelorenPort.Server.Weather;
+using VelorenPort.World;
+using VelorenPort.NativeMath;
+using VelorenPort.CoreEngine;
+
+namespace Server.Tests;
+
+public class WeatherJobIntegrationTests
+{
+    [Fact]
+    public void Tick_UpdatesWorldSimViaCallback()
+    {
+        var job = new WeatherJob();
+        var sim = new WorldSim(0, new int2(1, 1));
+        job.WeatherChanged += sim.ApplyGlobalWeather;
+        var current = new Weather(0f, 0f, float2.zero);
+        var target = new Weather(1f, 1f, new float2(1f, 0f));
+        job.StartTransition(target, TimeSpan.FromSeconds(1), current, DateTime.UtcNow - TimeSpan.FromSeconds(2));
+        bool changed = job.Tick(ref current);
+        Assert.True(changed);
+        Assert.Equal(target, current);
+        var cell = sim.Weather.Grid.Get(int2.zero);
+        Assert.Equal(target.Cloud, cell.Cloud, 3);
+        Assert.Equal(target.Rain, cell.Rain, 3);
+    }
+}

--- a/VelorenPort/World.Tests/WeatherMapPersistenceTests.cs
+++ b/VelorenPort/World.Tests/WeatherMapPersistenceTests.cs
@@ -1,0 +1,25 @@
+using System.IO;
+using VelorenPort.World.Sim;
+using VelorenPort.NativeMath;
+
+namespace World.Tests;
+
+public class WeatherMapPersistenceTests
+{
+    [Fact]
+    public void WeatherMap_SerializesAndLoads()
+    {
+        var map = WeatherMap.Generate(new int2(2, 2), 1);
+        var path = Path.GetTempFileName();
+        map.Save(path);
+        var loaded = WeatherMap.Load(path);
+        Assert.Equal(map.Grid.Size, loaded.Grid.Size);
+        foreach (var (pos, cell) in map.Grid.Iterate())
+        {
+            var other = loaded.Grid.Get(pos);
+            Assert.Equal(cell.Cloud, other.Cloud, 3);
+            Assert.Equal(cell.Rain, other.Rain, 3);
+        }
+        File.Delete(path);
+    }
+}

--- a/VelorenPort/World/Src/Sim/WeatherMap.cs
+++ b/VelorenPort/World/Src/Sim/WeatherMap.cs
@@ -60,6 +60,13 @@ public class WeatherMap
     /// <summary>Interpolate weather at <paramref name="worldPos"/>.</summary>
     public Weather GetWeather(float2 worldPos) => _grid.GetInterpolated(worldPos);
 
+    /// <summary>Set every cell to the provided <paramref name="weather"/>.</summary>
+    public void ApplyGlobalWeather(Weather weather)
+    {
+        foreach (var (pos, _) in _grid.Iterate())
+            _grid.Set(pos, weather);
+    }
+
     private class WeatherDto
     {
         public int2 Size { get; set; }


### PR DESCRIPTION
## Summary
- extend `WeatherJob` with effect settings and a physics model
- notify listeners when weather changes
- apply global weather to `WorldSim` and use it in chunk generation
- allow external weather updates on the weather map
- hook the server to propagate weather to the simulation
- test weather event callbacks and weather map persistence

## Testing
- `dotnet test VelorenPort/CoreEngine.Tests/CoreEngine.Tests.csproj` *(fails: RegionPersistenceTests.HistoryManager_RotatesSnapshots)*

------
https://chatgpt.com/codex/tasks/task_e_68616a79a82083288e5ca0b29cfa1229