### PR TITLE
Add Rust server protocol tests

### DIFF
--- a/VelorenPort/Network.Tests/RustServerHarness.cs
+++ b/VelorenPort/Network.Tests/RustServerHarness.cs
@@ -6,8 +6,32 @@ using VelorenPort.Network;
 
 namespace Network.Tests;
 
+using System.Diagnostics;
+
 internal static class RustServerHarness
 {
+    public static Process StartServer()
+    {
+        var psi = new ProcessStartInfo("cargo", "test-server -- --non-interactive --no-auth")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = TestUtils.GetRepoRoot(),
+        };
+        var proc = Process.Start(psi)!;
+        Task.Delay(5000).Wait();
+        return proc;
+    }
+
+    public static async Task StopServerAsync(Process proc)
+    {
+        if (!proc.HasExited)
+        {
+            proc.Kill();
+            await proc.WaitForExitAsync();
+        }
+    }
     public static async Task<Network> ConnectOrSkipAsync()
     {
         string host = Environment.GetEnvironmentVariable("RUST_SERVER_ADDR") ?? "127.0.0.1";

--- a/VelorenPort/Network.Tests/RustServerProtocolTests.cs
+++ b/VelorenPort/Network.Tests/RustServerProtocolTests.cs
@@ -1,0 +1,42 @@
+using System.Threading.Tasks;
+using VelorenPort.Network;
+using Xunit;
+
+namespace Network.Tests;
+
+public class RustServerProtocolTests
+{
+    [Fact]
+    public async Task HandshakeNegotiation()
+    {
+        using var server = RustServerHarness.StartServer();
+        var net = await RustServerHarness.ConnectOrSkipAsync();
+        Assert.NotEmpty(net.LocalPid.ToByteArray());
+        await net.ShutdownAsync();
+        await RustServerHarness.StopServerAsync(server);
+    }
+
+    [Fact]
+    public async Task StreamReliability()
+    {
+        using var server = RustServerHarness.StartServer();
+        var net = await RustServerHarness.ConnectOrSkipAsync();
+        var p = await net.ConnectedAsync();
+        var s = await p!.OpenStreamAsync(p.NextSid(), new StreamParams(Promises.Ordered | Promises.GuaranteedDelivery));
+        await s.SendAsync("ping");
+        var echo = await p.OpenedAsync();
+        var msg = await echo.RecvAsync<(string, string)>();
+        Assert.Equal("ping", msg?.Item2);
+        await net.ShutdownAsync();
+        await RustServerHarness.StopServerAsync(server);
+    }
+
+    [Fact]
+    public async Task QuicConnectionOptions()
+    {
+        using var server = RustServerHarness.StartServer();
+        var net = await RustServerHarness.ConnectQuicOrSkipAsync();
+        await net.ShutdownAsync();
+        await RustServerHarness.StopServerAsync(server);
+    }
+}

--- a/VelorenPort/Network.Tests/TestUtils.cs
+++ b/VelorenPort/Network.Tests/TestUtils.cs
@@ -13,4 +13,16 @@ internal static class TestUtils
         listener.Stop();
         return port;
     }
+
+    public static string GetRepoRoot()
+    {
+        var psi = new System.Diagnostics.ProcessStartInfo("git", "rev-parse --show-toplevel")
+        {
+            RedirectStandardOutput = true,
+            UseShellExecute = false
+        };
+        using var proc = System.Diagnostics.Process.Start(psi)!;
+        proc.WaitForExit();
+        return proc.StandardOutput.ReadLine() ?? string.Empty;
+    }
 }


### PR DESCRIPTION
## Summary
- add helper to start/stop the Rust server via cargo alias
- enable repo discovery in TestUtils
- add integration tests verifying handshake, reliability and quic support

## Testing
- `dotnet test VelorenPort/VelorenPort.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616a8259f48328b56fc21f8fc883eb