### PR TITLE
Add Aabb geometry helpers

### DIFF
--- a/VelorenPort/CoreEngine.Tests/AabbTests.cs
+++ b/VelorenPort/CoreEngine.Tests/AabbTests.cs
@@ -27,4 +27,33 @@ public class AabbTests
         Assert.Equal(new int3(1,1,1), t.Min);
         Assert.Equal(new int3(6,5,5), t.Max);
     }
+
+    [Fact]
+    public void Intersection_ReturnsOverlap()
+    {
+        var a = new Aabb(new int3(0,0,0), new int3(5,5,5));
+        var b = new Aabb(new int3(3,2,1), new int3(6,7,4));
+        var i = a.Intersection(b);
+        Assert.Equal(new int3(3,2,1), i.Min);
+        Assert.Equal(new int3(5,5,4), i.Max);
+    }
+
+    [Fact]
+    public void Scale_MultipliesBounds()
+    {
+        var box = new Aabb(new int3(1,2,3), new int3(4,5,6));
+        var s = box.Scale(2);
+        Assert.Equal(new int3(2,4,6), s.Min);
+        Assert.Equal(new int3(8,10,12), s.Max);
+    }
+
+    [Fact]
+    public void Rotate_ComputesAxisAlignedBounds()
+    {
+        var box = new Aabb(new int3(0,0,0), new int3(1,2,3));
+        var rot = math.axisAngle(new float3(0f,0f,1f), math.PI * 0.5f);
+        var r = box.Rotate(rot);
+        Assert.Equal(new int3(-2,0,0), r.Min);
+        Assert.Equal(new int3(0,1,3), r.Max);
+    }
 }

--- a/VelorenPort/CoreEngine/Src/Aabb.cs
+++ b/VelorenPort/CoreEngine/Src/Aabb.cs
@@ -59,5 +59,50 @@ namespace VelorenPort.CoreEngine
         /// Return a new box translated by the given offset.
         /// </summary>
         public Aabb Translate(int3 offset) => new Aabb(Min + offset, Max + offset);
+
+        /// <summary>
+        /// Return the overlapping region between this box and <paramref name="other"/>.
+        /// </summary>
+        public Aabb Intersection(Aabb other) =>
+            new Aabb(math.max(Min, other.Min), math.min(Max, other.Max));
+
+        /// <summary>
+        /// Multiply the bounds of the box by a uniform scale factor.
+        /// </summary>
+        public Aabb Scale(int factor) => Scale(new int3(factor, factor, factor));
+
+        /// <summary>
+        /// Multiply the bounds of the box by a non-uniform scale factor.
+        /// </summary>
+        public Aabb Scale(int3 factor) => new Aabb(Min * factor, Max * factor);
+
+        /// <summary>
+        /// Rotate the box by <paramref name="rotation"/> around the origin and
+        /// return a new axis-aligned box that contains the result.
+        /// </summary>
+        public Aabb Rotate(quaternion rotation)
+        {
+            var corners = new int3[8]
+            {
+                new int3(Min.x, Min.y, Min.z),
+                new int3(Max.x, Min.y, Min.z),
+                new int3(Min.x, Max.y, Min.z),
+                new int3(Max.x, Max.y, Min.z),
+                new int3(Min.x, Min.y, Max.z),
+                new int3(Max.x, Min.y, Max.z),
+                new int3(Min.x, Max.y, Max.z),
+                new int3(Max.x, Max.y, Max.z)
+            };
+
+            int3 rotMin = (int3)math.round(math.rotate(rotation, (float3)corners[0]));
+            int3 rotMax = rotMin;
+            for (int i = 1; i < corners.Length; i++)
+            {
+                int3 r = (int3)math.round(math.rotate(rotation, (float3)corners[i]));
+                rotMin = math.min(rotMin, r);
+                rotMax = math.max(rotMax, r);
+            }
+            return new Aabb(rotMin, rotMax);
+        }
     }
 }

--- a/VelorenPort/CoreEngine/Src/NativeMath.cs
+++ b/VelorenPort/CoreEngine/Src/NativeMath.cs
@@ -77,6 +77,9 @@ namespace VelorenPort.NativeMath {
         public static int3 operator +(int3 a, int3 b) => new int3(a.x + b.x, a.y + b.y, a.z + b.z);
         public static int3 operator -(int3 a, int3 b) => new int3(a.x - b.x, a.y - b.y, a.z - b.z);
         public static int3 operator -(int3 v) => new int3(-v.x, -v.y, -v.z);
+        public static int3 operator *(int3 a, int b) => new int3(a.x * b, a.y * b, a.z * b);
+        public static int3 operator *(int b, int3 a) => a * b;
+        public static int3 operator *(int3 a, int3 b) => new int3(a.x * b.x, a.y * b.y, a.z * b.z);
         public static int3 operator /(int3 a, int b) => new int3(a.x / b, a.y / b, a.z / b);
         public static int3 operator /(int3 a, int3 b) => new int3(a.x / b.x, a.y / b.y, a.z / b.z);
     }
@@ -128,6 +131,7 @@ namespace VelorenPort.NativeMath {
         public static float4 floor(float4 v) => new float4(floor(v.x), floor(v.y), floor(v.z), floor(v.w));
         public static double2 floor(double2 v) => new double2(System.Math.Floor(v.x), System.Math.Floor(v.y));
         public static float ceil(float x) => System.MathF.Ceiling(x);
+        public static float3 ceil(float3 v) => new float3(ceil(v.x), ceil(v.y), ceil(v.z));
         public static int floorToInt(float x) => (int)System.MathF.Floor(x);
         public static float sqrt(float x) => System.MathF.Sqrt(x);
         public static float sin(float x) => System.MathF.Sin(x);
@@ -211,6 +215,7 @@ namespace VelorenPort.NativeMath {
         public static float2 lerp(float2 a, float2 b, float t) => a + (b - a) * t;
         public static float round(float v) => System.MathF.Round(v);
         public static float2 round(float2 v) => new float2(round(v.x), round(v.y));
+        public static float3 round(float3 v) => new float3(round(v.x), round(v.y), round(v.z));
         public static float pow(float a, float b) => System.MathF.Pow(a, b);
     }
 


### PR DESCRIPTION
## Summary
- add int3 multiplication and rounding helpers in math library
- implement intersection, scaling, and rotation for `Aabb`
- test new geometry helpers

## Testing
- `dotnet test VelorenPort/CoreEngine.Tests/CoreEngine.Tests.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861761a87548328baa567e119ef7ed9