### PR TITLE
Consume ChunkSupplement in terrain sync

### DIFF
--- a/VelorenPort/Server.Tests/TerrainSyncIntegrationTests.cs
+++ b/VelorenPort/Server.Tests/TerrainSyncIntegrationTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using VelorenPort.NativeMath;
+using VelorenPort.Server;
+using VelorenPort.Server.Sys;
+using VelorenPort.Server.Rtsim;
+using VelorenPort.World;
+
+namespace Server.Tests;
+
+public class TerrainSyncIntegrationTests
+{
+    private static Client CreateClient()
+    {
+        var participant = (Participant)Activator.CreateInstance(
+            typeof(Participant), BindingFlags.NonPublic | BindingFlags.Instance,
+            new object?[] { Pid.NewPid(), new ConnectAddr.Mpsc(1), Guid.NewGuid(), null, null, null })!;
+        return (Client)Activator.CreateInstance(
+            typeof(Client), BindingFlags.NonPublic | BindingFlags.Instance,
+            new object?[] { participant })!;
+    }
+
+    [Fact]
+    public void Update_LoadsSupplementData()
+    {
+        var index = new WorldIndex(0);
+        var client = CreateClient();
+        var serialize = new ChunkSerialize();
+        var spawns = new List<NpcSpawnerSystem.SpawnPoint>();
+        var sim = new RtSim();
+
+        TerrainSync.Update(index, client, serialize, spawns, sim);
+
+        var sup = index.Map.GetSupplement(new int2(0,0));
+        Assert.NotNull(sup);
+        Assert.Equal(sup!.SpawnPoints.Count, spawns.Count);
+        Assert.Equal(sup.ResourceDeposits.Count, sim.ResourceCounter);
+    }
+}
+

--- a/VelorenPort/Server/Src/GameServer.cs
+++ b/VelorenPort/Server/Src/GameServer.cs
@@ -212,7 +212,7 @@ namespace VelorenPort.Server
                     client.Presence,
                     client.RegionSubscription);
 
-                TerrainSync.Update(WorldIndex, client, _chunkSerialize);
+                TerrainSync.Update(WorldIndex, client, _chunkSerialize, _npcSpawnPoints, _rtsim);
             }
 
             InviteTimeout.Update(_clients);


### PR DESCRIPTION
## Summary
- use `ChunkSupplement` when loading terrain
- register NPC spawn points and update resource counter
- test integration of terrain sync with supplement data

## Testing
- `cargo test -p veloren-common-base --quiet`
- `dotnet test VelorenPort/World.Tests/World.Tests.csproj` *(fails: double3 and Random missing)*
- `dotnet test VelorenPort/Server.Tests/Server.Tests.csproj` *(fails: compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68617423b254832899734e7feef0848d