### PR TITLE
Add extra site templates and stats

### DIFF
--- a/VelorenPort/World.Tests/CivGeneratorTests.cs
+++ b/VelorenPort/World.Tests/CivGeneratorTests.cs
@@ -65,4 +65,14 @@ public class CivGeneratorTests
         foreach (var (_, site) in index.Sites.Enumerate())
             Assert.True(site.Population.Count > 0);
     }
+
+    [Fact]
+    public void Generate_RecordsPopulationBirthEvent()
+    {
+        var (world, index) = World.Empty();
+        var stats = new SitesGenMeta(42);
+        CivGenerator.Generate(world, index, 1, stats);
+        var site = index.Sites.Items[0];
+        Assert.True(stats.GetEventCount(site.Name, GenStatEventKind.PopulationBirth) > 0);
+    }
 }

--- a/VelorenPort/World.Tests/PlotTemplateTests.cs
+++ b/VelorenPort/World.Tests/PlotTemplateTests.cs
@@ -1,0 +1,22 @@
+using VelorenPort.World.Site;
+using VelorenPort.NativeMath;
+
+namespace World.Tests;
+
+public class PlotTemplateTests
+{
+    [Fact]
+    public void Templates_ContainExpectedStructures()
+    {
+        Assert.True(PlotTemplates.Templates.ContainsKey(PlotKind.Tavern));
+        Assert.True(PlotTemplates.Templates.ContainsKey(PlotKind.GuardTower));
+        Assert.True(PlotTemplates.Templates.ContainsKey(PlotKind.Castle));
+
+        var tavern = PlotTemplates.Templates[PlotKind.Tavern];
+        Assert.True(tavern.Count >= 9);
+        Assert.Contains(new int2(1,1), tavern.Keys);
+
+        var tower = PlotTemplates.Templates[PlotKind.GuardTower];
+        Assert.Contains(new int2(0,0), tower.Keys);
+    }
+}

--- a/VelorenPort/World/Src/Civ/CivGenerator.cs
+++ b/VelorenPort/World/Src/Civ/CivGenerator.cs
@@ -29,12 +29,12 @@ namespace VelorenPort.World.Civ
                 var site = Site.SiteGenerator.Generate(rng, kind, pos, stats);
 
                 var siteId = index.Sites.Insert(site);
-                SpawnPopulation(index, site, siteId, rng);
+                SpawnPopulation(index, site, siteId, rng, stats);
             }
             stats?.Log();
         }
 
-        private static void SpawnPopulation(WorldIndex index, Site.Site site, Store<Site.Site>.Id siteId, Random rng)
+        private static void SpawnPopulation(WorldIndex index, Site.Site site, Store<Site.Site>.Id siteId, Random rng, SitesGenMeta? stats)
         {
             foreach (var _ in site.Plots)
             {
@@ -46,6 +46,7 @@ namespace VelorenPort.World.Civ
                 };
                 var npcId = index.Npcs.Insert(npc);
                 site.Population.Add(npcId);
+                stats?.RecordEvent(site.Name, GenStatEventKind.PopulationBirth);
             }
         }
     }

--- a/VelorenPort/World/Src/Site/PlotTemplates.cs
+++ b/VelorenPort/World/Src/Site/PlotTemplates.cs
@@ -64,6 +64,49 @@ namespace VelorenPort.World.Site
                 [new int2(0,2)] = Tile.Free(TileKind.Field),
                 [new int2(1,2)] = Tile.Free(TileKind.Field),
                 [new int2(2,2)] = Tile.Free(TileKind.Field)
+            },
+
+            // Basic watch tower with a 2x2 footprint and a door on the south side.
+            [PlotKind.GuardTower] = new Dictionary<int2, Tile>
+            {
+                [new int2(0,0)] = Tile.Free(TileKind.Tower),
+                [new int2(1,0)] = Tile.Free(TileKind.Tower),
+                [new int2(0,1)] = Tile.Free(TileKind.Tower),
+                [new int2(1,1)] = Tile.Free(TileKind.Tower),
+                [new int2(0,-1)] = Tile.Free(TileKind.Road)
+            },
+
+            // Simple 3x3 tavern structure.
+            [PlotKind.Tavern] = new Dictionary<int2, Tile>
+            {
+                [new int2(0,0)] = Tile.Free(TileKind.Building),
+                [new int2(1,0)] = Tile.Free(TileKind.Building),
+                [new int2(2,0)] = Tile.Free(TileKind.Building),
+                [new int2(0,1)] = Tile.Free(TileKind.Building),
+                [new int2(1,1)] = Tile.Free(TileKind.Building),
+                [new int2(2,1)] = Tile.Free(TileKind.Building),
+                [new int2(0,2)] = Tile.Free(TileKind.Building),
+                [new int2(1,2)] = Tile.Free(TileKind.Building),
+                [new int2(2,2)] = Tile.Free(TileKind.Building),
+                [new int2(1,-1)] = Tile.Free(TileKind.Road)
+            },
+
+            // Small square castle keep.
+            [PlotKind.Castle] = new Dictionary<int2, Tile>
+            {
+                [new int2(0,0)] = Tile.Free(TileKind.Castle),
+                [new int2(1,0)] = Tile.Free(TileKind.Castle),
+                [new int2(2,0)] = Tile.Free(TileKind.Castle),
+                [new int2(3,0)] = Tile.Free(TileKind.Castle),
+                [new int2(0,1)] = Tile.Free(TileKind.Castle),
+                [new int2(3,1)] = Tile.Free(TileKind.Castle),
+                [new int2(0,2)] = Tile.Free(TileKind.Castle),
+                [new int2(3,2)] = Tile.Free(TileKind.Castle),
+                [new int2(0,3)] = Tile.Free(TileKind.Castle),
+                [new int2(1,3)] = Tile.Free(TileKind.Castle),
+                [new int2(2,3)] = Tile.Free(TileKind.Castle),
+                [new int2(3,3)] = Tile.Free(TileKind.Castle),
+                [new int2(1,-1)] = Tile.Free(TileKind.Road)
             }
         };
     }

--- a/VelorenPort/World/Src/Site/SiteGenerator.cs
+++ b/VelorenPort/World/Src/Site/SiteGenerator.cs
@@ -40,7 +40,7 @@ public static class SiteGenerator
         stats?.Add(site.Name, ToStatKind(kind));
 
         // Initial plaza at the origin
-        AddPlot(site, PlotKind.Plaza, int2.zero, stats, GenStatPlotKind.InitialPlaza);
+        AddPlot(site, PlotKind.Plaza, int2.zero, stats);
 
         // Some roads heading outwards from the plaza
         foreach (var dir in WorldUtil.CARDINALS)
@@ -54,20 +54,33 @@ public static class SiteGenerator
         for (int i = 0; i < plotCount; i++)
         {
             var local = new int2(rng.Next(-4, 5), rng.Next(-4, 5));
-            PlotKind pk = (i % 3) switch
-            {
-                0 => PlotKind.House,
-                1 => PlotKind.Workshop,
-                _ => PlotKind.FarmField
-            };
-            AddPlot(site, pk, local, stats, GenStatPlotKind.House);
+            PlotKind pk;
+            int roll = rng.Next(0, 10);
+            if (roll < 3) pk = PlotKind.House;
+            else if (roll < 5) pk = PlotKind.Workshop;
+            else if (roll < 6) pk = PlotKind.FarmField;
+            else if (roll < 8) pk = PlotKind.Tavern;
+            else pk = PlotKind.GuardTower;
+            AddPlot(site, pk, local, stats);
         }
 
         return site;
     }
 
-    private static void AddPlot(Site site, PlotKind kind, int2 localPos, SitesGenMeta? stats, GenStatPlotKind statKind)
+    private static GenStatPlotKind MapStatKind(PlotKind kind) => kind switch
     {
+        PlotKind.Workshop or PlotKind.CoastalWorkshop or PlotKind.SavannahWorkshop => GenStatPlotKind.Workshop,
+        PlotKind.GuardTower or PlotKind.CliffTower => GenStatPlotKind.GuardTower,
+        PlotKind.Castle => GenStatPlotKind.Castle,
+        PlotKind.AirshipDock or PlotKind.CoastalAirshipDock or PlotKind.SavannahAirshipDock or PlotKind.CliffTownAirshipDock or PlotKind.DesertCityAirshipDock => GenStatPlotKind.AirshipDock,
+        PlotKind.Tavern => GenStatPlotKind.Tavern,
+        PlotKind.Plaza => GenStatPlotKind.Plaza,
+        _ => GenStatPlotKind.House
+    };
+
+    private static void AddPlot(Site site, PlotKind kind, int2 localPos, SitesGenMeta? stats)
+    {
+        var statKind = MapStatKind(kind);
         stats?.Attempt(site.Name, statKind);
         var plot = new Plot { LocalPos = localPos, Kind = kind };
         site.Plots.Add(plot);

--- a/VelorenPort/World/Src/Site/Stats/SiteGenerationStats.cs
+++ b/VelorenPort/World/Src/Site/Stats/SiteGenerationStats.cs
@@ -59,6 +59,8 @@ namespace VelorenPort.World.Site.Stats
         private readonly Dictionary<GenStatPlotKind, GenPlot> _stats = new();
         private readonly Dictionary<GenStatEventKind, uint> _events = new();
 
+        public IReadOnlyDictionary<GenStatEventKind, uint> Events => _events;
+
         public GenSite(GenStatSiteKind kind, string name)
         {
             Kind = kind;
@@ -130,6 +132,13 @@ namespace VelorenPort.World.Site.Stats
         {
             if (_sites.TryGetValue(name, out var site))
                 site.RecordEvent(kind);
+        }
+
+        public uint GetEventCount(string name, GenStatEventKind kind)
+        {
+            if (_sites.TryGetValue(name, out var site))
+                return site.Events.TryGetValue(kind, out var c) ? c : 0u;
+            return 0u;
         }
 
         private static bool GetBoolEnvVar(string name)


### PR DESCRIPTION
## Summary
- expand plot templates with tavern, guard tower, and castle
- map plot types to statistic kinds automatically
- record population birth events during civilisation generation
- expose event counts on stats metadata
- add tests for new templates and event recording

## Testing
- `dotnet test VelorenPort/VelorenPort.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686178696c8483289c85f99535bbdb32