### PR TITLE
Align protocol messages with Rust

### DIFF
--- a/VelorenPort/Network/Src/Protocol/Event.cs
+++ b/VelorenPort/Network/Src/Protocol/Event.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace VelorenPort.Network.Protocol {
     /// <summary>
     /// Events exchanged between protocol implementations and channels.
@@ -7,5 +9,19 @@ namespace VelorenPort.Network.Protocol {
         public sealed record OpenStream(Sid Sid, byte Prio, Promises Promises, ulong GuaranteedBandwidth) : ProtocolEvent;
         public sealed record CloseStream(Sid Sid) : ProtocolEvent;
         public sealed record Message(byte[] Data, Sid Sid) : ProtocolEvent;
+
+        /// <summary>
+        /// Convert this high level event into a protocol frame.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown when converting a
+        /// <see cref="Message"/> event since it maps to multiple frames.</exception>
+        public OTFrame ToFrame() => this switch {
+            Shutdown => new OTFrame.Shutdown(),
+            OpenStream(var sid, var prio, var promises, var bw) =>
+                new OTFrame.OpenStream(sid, prio, promises, bw),
+            CloseStream(var sid) => new OTFrame.CloseStream(sid),
+            Message => throw new InvalidOperationException("Message events span multiple frames"),
+            _ => throw new InvalidOperationException()
+        };
     }
 }

--- a/VelorenPort/Network/Src/Protocol/Message.cs
+++ b/VelorenPort/Network/Src/Protocol/Message.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace VelorenPort.Network.Protocol {
     /// <summary>
     /// Container for protocol payloads exchanged over streams. Stores the
@@ -5,14 +8,53 @@ namespace VelorenPort.Network.Protocol {
     /// OTMessage/ITMessage structures.
     /// </summary>
     public class Message {
+        /// <summary>Maximum payload size of an individual data frame.</summary>
+        public const int FrameDataSize = 1400;
+
         public byte[] Data { get; }
         public ulong Mid { get; }
         public Sid Sid { get; }
+
+        private int _offset;
+        private bool _sentHeader;
 
         public Message(byte[] data, ulong mid, Sid sid) {
             Data = data;
             Mid = mid;
             Sid = sid;
+        }
+
+        /// <summary>
+        /// Enumerates protocol frames representing this message.
+        /// </summary>
+        public IEnumerable<OTFrame> Serialize() {
+            if (!_sentHeader) {
+                _sentHeader = true;
+                yield return new OTFrame.DataHeader(Mid, Sid, (ulong)Data.Length);
+            }
+
+            while (_offset < Data.Length) {
+                int toSend = Math.Min(FrameDataSize, Data.Length - _offset);
+                var chunk = new byte[toSend];
+                Array.Copy(Data, _offset, chunk, 0, toSend);
+                _offset += toSend;
+                yield return new OTFrame.Data(Mid, chunk);
+            }
+        }
+
+        /// <summary>
+        /// Create a complete message from a header and the following data frames.
+        /// </summary>
+        public static Message Deserialize(ITFrame.DataHeader header, IEnumerable<ITFrame.Data> chunks) {
+            var buffer = new byte[header.Length];
+            int offset = 0;
+            foreach (var c in chunks) {
+                int copy = Math.Min(c.Payload.Length, buffer.Length - offset);
+                Array.Copy(c.Payload, 0, buffer, offset, copy);
+                offset += copy;
+                if (offset >= buffer.Length) break;
+            }
+            return new Message(buffer, header.Mid, header.Sid);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `ToFrame()` helper on `ProtocolEvent` to map events to frames
- extend `Protocol.Message` with frame serialization helpers

## Testing
- `dotnet test VelorenPort/VelorenPort.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617cab5b7883288d05e45060f03341