### PR TITLE
Add unit tests for combat, inventory and time utils

### DIFF
--- a/VelorenPort/CoreEngine.Tests/CombatUtilsTests.cs
+++ b/VelorenPort/CoreEngine.Tests/CombatUtilsTests.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using VelorenPort.CoreEngine;
+using Xunit;
+
+namespace CoreEngine.Tests;
+
+public class CombatUtilsTests
+{
+    private class DummyTarget : IDamageable
+    {
+        public Uid Id { get; }
+        public float Health { get; set; }
+        public DummyTarget(Uid id, float health) { Id = id; Health = health; }
+    }
+
+    [Fact]
+    public void ApplyAttack_AddsMissingTarget()
+    {
+        var health = new Dictionary<Uid, float>();
+        var attack = new Attack(new Uid(1), new HitInfo(new Uid(2), 5f, DamageKind.Physical));
+        CombatUtils.ApplyAttack(health, attack);
+        Assert.Equal(-5f, health[new Uid(2)]);
+    }
+
+    [Fact]
+    public void ApplyAttack_RespectsResistances()
+    {
+        var health = new Dictionary<Uid, float> { [new Uid(3)] = 0f };
+        var attack = new Attack(new Uid(1), new HitInfo(new Uid(3), 10f, DamageKind.Fire));
+        var resist = new Resistances(0f);
+        resist[DamageKind.Fire] = 0.5f;
+        CombatUtils.ApplyAttack(health, attack, resist);
+        Assert.Equal(-5f, health[new Uid(3)]);
+    }
+
+    [Fact]
+    public void Apply_ToDamageable_LogsEvent()
+    {
+        var target = new DummyTarget(new Uid(4), 20f);
+        var attack = new Attack(new Uid(5), new HitInfo(target.Id, 10f, DamageKind.Physical));
+        var resist = new Resistances(0f);
+        resist[DamageKind.Physical] = 0.1f;
+        var log = new List<DamageEvent>();
+        CombatUtils.Apply(target, attack, resist, log);
+        Assert.Equal(11f, target.Health);
+        Assert.Single(log);
+        Assert.Equal(target.Id, log[0].Target);
+        Assert.InRange(log[0].Amount, 8.9f, 9.1f);
+    }
+}

--- a/VelorenPort/CoreEngine.Tests/ReducedInventoryTests.cs
+++ b/VelorenPort/CoreEngine.Tests/ReducedInventoryTests.cs
@@ -1,0 +1,28 @@
+using VelorenPort.CoreEngine;
+using VelorenPort.CoreEngine.comp;
+using Xunit;
+
+namespace CoreEngine.Tests;
+
+public class ReducedInventoryTests
+{
+    [Fact]
+    public void From_CopiesAllSlots()
+    {
+        var inv = new Inventory();
+        var slotA = new InvSlotId(0, 0);
+        var slotB = new InvSlotId(1, 2);
+        var itemA = new ItemDefinitionIdOwned.Simple("wood");
+        var itemB = new ItemDefinitionIdOwned.Simple("stone");
+        inv.Add(slotA, itemA, 3);
+        inv.Add(slotB, itemB, 1);
+
+        var reduced = ReducedInventory.From(inv);
+
+        Assert.Equal(2, reduced.Inventory.Count);
+        Assert.Equal(3u, reduced.Inventory[slotA].Amount);
+        Assert.Equal(itemA, reduced.Inventory[slotA].Name);
+        Assert.Equal(1u, reduced.Inventory[slotB].Amount);
+        Assert.Equal(itemB, reduced.Inventory[slotB].Name);
+    }
+}

--- a/VelorenPort/CoreEngine.Tests/TimeUtilityTests.cs
+++ b/VelorenPort/CoreEngine.Tests/TimeUtilityTests.cs
@@ -1,0 +1,27 @@
+using VelorenPort.CoreEngine;
+using VelorenPort.NativeMath;
+using Xunit;
+
+namespace CoreEngine.Tests;
+
+public class TimeUtilityTests
+{
+    [Fact]
+    public void TimeOfDay_DayWrapsAround()
+    {
+        var tod = new TimeOfDay(90000); // 25 hours
+        Assert.InRange(tod.Day, 3599, 3601);
+    }
+
+    [Fact]
+    public void Secs_MultiplicationOperators()
+    {
+        var secs = new Secs(10);
+        var doubleFirst = secs * 2;
+        var doubleSecond = 2 * secs;
+        Assert.Equal(20, doubleFirst.Value);
+        Assert.Equal(20, doubleSecond.Value);
+        secs.MultiplyAssign(0.5);
+        Assert.Equal(5, secs.Value);
+    }
+}


### PR DESCRIPTION
## Summary
- add CombatUtilsTests covering attack application and logging
- add ReducedInventoryTests verifying conversion from Inventory
- add TimeUtilityTests for day wrap logic and Secs operations

## Testing
- `dotnet test CoreEngine.Tests/CoreEngine.Tests.csproj --logger "console;verbosity=normal"`
- `dotnet test CoreEngine.Tests/CoreEngine.Tests.csproj --no-build --collect:"XPlat Code Coverage"`


------
https://chatgpt.com/codex/tasks/task_e_68617c9c665883288e7cad210f23bb3a