### PR TITLE
Add economy stages and trading events

### DIFF
--- a/VelorenPort/World.Tests/TradingFlowTests.cs
+++ b/VelorenPort/World.Tests/TradingFlowTests.cs
@@ -1,5 +1,6 @@
 using VelorenPort.World;
 using VelorenPort.World.Site;
+using VelorenPort.World.Site.Economy;
 using VelorenPort.NativeMath;
 using Xunit;
 
@@ -24,5 +25,25 @@ public class TradingFlowTests
         Assert.True(siteB.Economy.GetStock(new Good.Wood()) > 0f);
         Assert.NotEmpty(index.EconomyContext.Events);
         Assert.True(index.EconomyContext.MarketPrices.ContainsKey(idA));
+    }
+
+    [Fact]
+    public void WorldTick_RecordsTradePhases()
+    {
+        var (world, index) = World.World.Empty();
+        var siteA = new Site { Position = int2.zero };
+        var siteB = new Site { Position = new int2(5, 0) };
+        var idA = index.Sites.Insert(siteA);
+        var idB = index.Sites.Insert(siteB);
+        siteA.Economy.Produce(new Good.Food(), 2f);
+        index.Caravans.Add(new Caravan(new[] { idA, idB }));
+
+        world.Tick(1f);
+        world.Tick(1f);
+
+        Assert.Contains(index.EconomyContext.Events, e => e.Phase == EconomyContext.TradePhase.Plan);
+        Assert.Contains(index.EconomyContext.Events, e => e.Phase == EconomyContext.TradePhase.Execute);
+        Assert.Contains(index.EconomyContext.Events, e => e.Phase == EconomyContext.TradePhase.Collect);
+        Assert.NotEmpty(index.EconomyContext.StageHistory);
     }
 }

--- a/VelorenPort/World/Src/Civ/Econ.cs
+++ b/VelorenPort/World/Src/Civ/Econ.cs
@@ -7,6 +7,17 @@ namespace VelorenPort.World.Civ
     /// <summary>
     /// Minimal economic helper types translated from <c>econ.rs</c>.
     /// </summary>
+    public enum EconomyStage
+    {
+        Deliveries,
+        TickSites,
+        DistributeOrders,
+        TradeAtSites,
+        UpdateMarkets,
+    }
+
+    [Serializable]
+    public record StageEvent(EconomyStage Stage, float Time);
     public class SellOrder
     {
         public float Quantity { get; set; }

--- a/VelorenPort/World/Src/Site/Caravan.cs
+++ b/VelorenPort/World/Src/Site/Caravan.cs
@@ -43,22 +43,17 @@ public class Caravan
 
         // Load a small amount of food if available
         if (from.Economy.Consume(new Good.Food(), 1f))
+        {
             Load(new Good.Food(), 1f);
+            index.EconomyContext.PlanTrade(index, fromId, toId, new Good.Food(), 1f);
+        }
 
         // Deliver all cargo
         foreach (var kv in Cargo.ToList())
         {
             if (kv.Value <= 0f) continue;
-            if (EconomySim.TradeGoods(from, to, kv.Key, kv.Value))
-                index.EconomyContext.Events.Add(
-                    new Economy.EconomyContext.TradeEvent(
-                        Economy.EconomyContext.TradePhase.Execute,
-                        fromId,
-                        toId,
-                        kv.Key,
-                        kv.Value,
-                        from.Market.GetPrice(kv.Key),
-                        index.EconomyContext.Time));
+            if (index.EconomyContext.Trade(index, fromId, toId, kv.Key, kv.Value))
+                index.EconomyContext.CollectTrade(index, fromId, toId, kv.Key, kv.Value);
             Cargo[kv.Key] = 0f;
         }
 

--- a/VelorenPort/World/Src/World.cs
+++ b/VelorenPort/World/Src/World.cs
@@ -134,7 +134,7 @@ namespace VelorenPort.World
         /// <summary>Advance the simulation by the specified delta time.</summary>
         public void Tick(float dt)
         {
-            EconomySim.SimulateEconomy(Index, dt);
+            Index.EconomyContext.Tick(Index, dt);
 
             Sim.Tick(dt);
         }


### PR DESCRIPTION
## Summary
- extend Civ econ with stage tracking
- expand EconomyContext with trading phases and stage events
- update caravans to record plan and collect phases
- route world tick through EconomyContext so markets update
- test trading phases and stage history

## Testing
- `dotnet test VelorenPort/VelorenPort.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617ca7a0dc832883478fb4d8c2950a