### PR TITLE
Add authentication checks to participant connections

### DIFF
--- a/VelorenPort/Network/README.md
+++ b/VelorenPort/Network/README.md
@@ -28,6 +28,15 @@ describir el tipo de cliente y los datos iniciales de registro que requiere el
 servidor. La lógica de validación de roles y permisos sigue la misma que en
 Rust gracias a los métodos `IsValidForRole`, `CanSpectate` y similares.
 
+### Authentication Flow
+
+`Participant` instances require non-empty `Credentials`. When a new connection
+is created via `Network.ConnectAsync` the caller supplies the credentials and a
+`ClientType`. Optionally an `AdminRole` can be passed to restrict the allowed
+client types. The constructor validates these values and throws an exception if
+the credentials are invalid or the client type is not permitted for the given
+role. This mirrors the Rust server's checks for privileged bots or spectators.
+
 ## Analysis of Remaining Migration Tasks
 
 Despite the `100%` mark that appears in older documents, the current C# module

--- a/VelorenPort/Network/Src/Participant.cs
+++ b/VelorenPort/Network/Src/Participant.cs
@@ -59,6 +59,7 @@ namespace VelorenPort.Network {
         private readonly Sid _streamOffset;
         private ulong _nextSidValue;
         public Credentials Credentials { get; }
+        public AdminRole? RoleRequirement { get; }
 
         internal Participant(
             Pid id,
@@ -81,6 +82,7 @@ namespace VelorenPort.Network {
             RemoteVersion = remoteVersion ?? Array.Empty<uint>();
             ClientType = clientType ?? new ClientType.Game();
             Credentials = credentials ?? new Credentials(string.Empty);
+            RoleRequirement = roleRequirement;
             if (!Credentials.IsValid)
                 throw new InvalidOperationException("Invalid credentials");
             if (!ClientType.IsValidForRole(roleRequirement))


### PR DESCRIPTION
## Summary
- validate credentials and required role when creating `Participant`
- expose optional authentication parameters in `Network.ConnectAsync`
- document basic authentication flow in `Network/README.md`

## Testing
- `dotnet test VelorenPort/Server.Tests/Server.Tests.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617ea9f19c8328b510a5bc4bb15ea9