### PR TITLE
Clarify missing login features

### DIFF
--- a/VelorenPort/Server/MissingFeatures.md
+++ b/VelorenPort/Server/MissingFeatures.md
@@ -56,7 +56,9 @@ removing code.
   release mode.
 - **Incomplete group and invite management**: features like group roles, loot sharing and invite timeouts remain unfinished. `GroupManager` and `InviteManager` provide only partial implementations.
 - **Simplified login and administration**: banlist and whitelist loading work,
-  but admin role assignment and CLI management have been reduced.
+  but admin role assignment and CLI management have been reduced. Token-based
+  authentication has not been implemented, admin role versions are incomplete,
+  and banlist migrations are missing, so bans do not carry over between versions.
 - **Spectator mode missing**: the server does not implement `InitializeSpectator` or silent spectator handling. Related events from `server/src/sys/msg/character_screen.rs` have not been ported.
 - **Missing weather and advanced real-time simulation**: the basic `rtsim` logic
   lacks the detailed weather system and time progression from the Rust server.


### PR DESCRIPTION
## Summary
- expand login bullet in MissingFeatures

## Testing
- `dotnet build VelorenPort/VelorenPort.sln -c Release` *(fails: CS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68617fa4e77c8328bdeb21323e35a841