### PR TITLE
Add scheduler latency metrics and monitoring hooks

### DIFF
--- a/VelorenPort/Network/Src/MetricsCreator.Hooks.cs
+++ b/VelorenPort/Network/Src/MetricsCreator.Hooks.cs
@@ -1,0 +1,20 @@
+namespace VelorenPort.Network;
+
+using System;
+using Prometheus;
+
+internal static partial class MetricsCreator
+{
+    public static event Action<Counter, string>? CounterCreated;
+    public static event Action<Gauge, string>? GaugeCreated;
+    public static event Action<Histogram, string>? HistogramCreated;
+
+    static partial void OnCounterCreated(Counter counter, string name)
+        => CounterCreated?.Invoke(counter, name);
+
+    static partial void OnGaugeCreated(Gauge gauge, string name)
+        => GaugeCreated?.Invoke(gauge, name);
+
+    static partial void OnHistogramCreated(Histogram histogram, string name)
+        => HistogramCreated?.Invoke(histogram, name);
+}


### PR DESCRIPTION
## Summary
- track task waits and timeouts in `Scheduler`
- compute average delay and expose via new metric
- add Prometheus hooks for metric creation

## Testing
- `dotnet format VelorenPort/VelorenPort.sln --no-restore --include VelorenPort/Network/Src/Scheduler.cs VelorenPort/Network/Src/Metrics.cs VelorenPort/Network/Src/MetricsCreator.Hooks.cs`
- `dotnet test VelorenPort/VelorenPort.sln --verbosity minimal` *(fails: CharacterState.cs syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_686181846a1c8328a7c6553e2d04294b