### PR TITLE
Add merchant store and reputation pricing

### DIFF
--- a/VelorenPort/CoreEngine.Tests/MerchantStoreTests.cs
+++ b/VelorenPort/CoreEngine.Tests/MerchantStoreTests.cs
@@ -1,0 +1,40 @@
+using System.IO;
+using VelorenPort.CoreEngine;
+using VelorenPort.CoreEngine.Store;
+
+namespace CoreEngine.Tests;
+
+public class MerchantStoreTests
+{
+    [Fact]
+    public void SaveAndLoadInventory()
+    {
+        var store = new MerchantStore();
+        var item = new ItemDefinitionIdOwned.Simple("wood");
+        store.AddItem(item, 3, 2f);
+        string path = Path.GetTempFileName();
+        store.Save(path);
+
+        var loaded = new MerchantStore();
+        loaded.Load(path);
+        File.Delete(path);
+
+        Assert.True(loaded.Catalog.TryGet(item, out var data));
+        Assert.Equal((3u, 2f), data);
+    }
+
+    [Fact]
+    public void Buy_RespectsReputation()
+    {
+        var store = new MerchantStore();
+        var item = new ItemDefinitionIdOwned.Simple("wood");
+        store.AddItem(item, 5, 10f);
+        store.AdjustReputation(0.5f); // 5% discount
+
+        Assert.True(store.TryGetPrice(item, 2, out var price));
+        Assert.Equal(19f, price, 1);
+        Assert.True(store.Buy(item, 2));
+        Assert.True(store.Catalog.TryGet(item, out var data));
+        Assert.Equal(3u, data.Amount);
+    }
+}

--- a/VelorenPort/CoreEngine.Tests/TradeReputationTests.cs
+++ b/VelorenPort/CoreEngine.Tests/TradeReputationTests.cs
@@ -1,0 +1,35 @@
+using VelorenPort.CoreEngine;
+
+namespace CoreEngine.Tests;
+
+public class TradeReputationTests
+{
+    [Fact]
+    public void ApplyReputation_ModifiesPrice()
+    {
+        float basePrice = 10f;
+        var cheaper = TradeUtils.ApplyReputation(basePrice, 1f);
+        var expensive = TradeUtils.ApplyReputation(basePrice, -1f);
+        Assert.True(cheaper < basePrice);
+        Assert.True(expensive > basePrice);
+    }
+
+    [Fact]
+    public void SitePrices_Balance_WithReputation()
+    {
+        var prices = new SitePrices();
+        prices.AddPrice(new Good.Wood(), 5f);
+
+        var inv = new ReducedInventory();
+        var slot = new InvSlotId(0, 0);
+        inv.Inventory[slot] = new ReducedInventoryItem(new ItemDefinitionIdOwned.Simple("log"), 1);
+        TradePricing.Instance.Register(new ItemDefinitionIdOwned.Simple("log"), new[] { (1f, (Good)new Good.Wood()) });
+
+        var offers = new[] { new Dictionary<InvSlotId, uint>(), new Dictionary<InvSlotId, uint>() };
+        offers[0][slot] = 1;
+        var inventories = new ReducedInventory?[] { inv, inv };
+        var neutral = prices.Balance(offers, inventories, 0, reduce: false, reputation: 0f)!.Value;
+        var positive = prices.Balance(offers, inventories, 0, reduce: false, reputation: 1f)!.Value;
+        Assert.True(positive < neutral);
+    }
+}

--- a/VelorenPort/CoreEngine/Src/store/StoreCatalog.cs
+++ b/VelorenPort/CoreEngine/Src/store/StoreCatalog.cs
@@ -1,17 +1,34 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace VelorenPort.CoreEngine.Store;
 
 /// <summary>
 /// Dynamic mapping of store items to their available quantities and prices.
 /// </summary>
+[Serializable]
 public class StoreCatalog
 {
-    private readonly Dictionary<ItemDefinitionIdOwned, (uint Amount, float Price)> _items = new();
+    [Serializable]
+    public record StoreEntry(uint Amount, float Price);
+
+    public Dictionary<ItemDefinitionIdOwned, StoreEntry> Items { get; } = new();
 
     public void Add(ItemDefinitionIdOwned item, uint amount, float price)
-        => _items[item] = (amount, price);
+        => Items[item] = new StoreEntry(amount, price);
 
     public bool TryGet(ItemDefinitionIdOwned item, out (uint Amount, float Price) data)
-        => _items.TryGetValue(item, out data);
+    {
+        if (Items.TryGetValue(item, out var entry))
+        {
+            data = (entry.Amount, entry.Price);
+            return true;
+        }
+        data = default;
+        return false;
+    }
+
+    public IEnumerable<(ItemDefinitionIdOwned Item, uint Amount, float Price)> Entries()
+        => Items.Select(kv => (kv.Key, kv.Value.Amount, kv.Value.Price));
 }


### PR DESCRIPTION
## Summary
- extend StoreCatalog with serializable entries
- implement MerchantStore with dynamic catalog and reputation-based pricing
- add reputation-aware price helpers in Trade
- add tests for merchant inventory and reputation pricing

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet test VelorenPort/CoreEngine.Tests/CoreEngine.Tests.csproj` *(fails: CS1003 in CharacterState.cs)*

------
https://chatgpt.com/codex/tasks/task_e_686183b8331c83288e281fa8c92d9617