### PR TITLE
Integrate resources into pathfinding heuristics

### DIFF
--- a/VelorenPort/World/MissingFeatures.md
+++ b/VelorenPort/World/MissingFeatures.md
@@ -24,6 +24,7 @@ This document lists the major subsystems from the original Rust `world` crate th
 - Basic sink filling prevents tiny inland basins after erosion.
 - Weather grid tracks cloud cover and rain via `WeatherMap` with save/load helpers.
 - River data for chunks can be persisted via `WorldSim.SaveRivers` and `WorldSim.LoadRivers`.
+- Chunk resources integrate with pathfinding via `SearchCfg.ResourceCosts`, enabling AI to seek or avoid resources.
 
 ## Missing or Incomplete Features
 
@@ -52,7 +53,6 @@ This document lists the major subsystems from the original Rust `world` crate th
 - Storms with lightning are implemented, but regional climate simulation remains pending.
 
 ### Resources and Pathfinding
-- Integration of chunk resources with AI and navigation data.
 - More complex heuristics for pathfinding.
 - Modules from `sim/map` and extended pathfinding helpers.
 

--- a/VelorenPort/World/Src/ChunkResource.cs
+++ b/VelorenPort/World/Src/ChunkResource.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace VelorenPort.World {
     /// <summary>
@@ -18,5 +19,28 @@ namespace VelorenPort.World {
         Wood,
         Gem,
         Ore
+    }
+
+    /// <summary>
+    /// Helper utilities for working with <see cref="ChunkResource"/> values.
+    /// These defaults can be used by AI and pathfinding systems when no
+    /// specific cost configuration is supplied.
+    /// </summary>
+    public static class ChunkResourceUtil {
+        /// <summary>Default weighting when resources influence path cost.</summary>
+        public static readonly System.Collections.Generic.Dictionary<ChunkResource, float> DefaultWeights = new()
+        {
+            [ChunkResource.Grass] = 1f,
+            [ChunkResource.Flower] = 0.5f,
+            [ChunkResource.Fruit] = -1f,
+            [ChunkResource.Vegetable] = -1f,
+            [ChunkResource.Mushroom] = -0.5f,
+            [ChunkResource.Loot] = -5f,
+            [ChunkResource.Plant] = 0.5f,
+            [ChunkResource.Stone] = 2f,
+            [ChunkResource.Wood] = -0.5f,
+            [ChunkResource.Gem] = -4f,
+            [ChunkResource.Ore] = -2f,
+        };
     }
 }

--- a/VelorenPort/World/Src/Pathfinding.cs
+++ b/VelorenPort/World/Src/Pathfinding.cs
@@ -59,6 +59,12 @@ namespace VelorenPort.World {
             _mapSize = TryMapSize(land.Size);
         }
 
+        /// <summary>
+        /// Expose resource information for external AI systems.
+        /// </summary>
+        public System.Collections.Generic.Dictionary<ChunkResource, float> GetResources(int2 chunkPos)
+            => _land.GetChunkResources(chunkPos);
+
         private static MapSizeLg? TryMapSize(int2 size)
         {
             if (size.x <= 0 || size.y <= 0)
@@ -129,11 +135,14 @@ namespace VelorenPort.World {
             if (_extraCost != null)
                 extra += _extraCost(next);
 
-            if (Cfg.ResourceCosts != null)
+            Dictionary<ChunkResource, float>? weights = Cfg.ResourceCosts;
+            if (weights == null)
+                weights = ChunkResourceUtil.DefaultWeights;
+            if (weights != null)
             {
                 var res = _land.GetChunkResources(next);
                 foreach (var kv in res)
-                    if (Cfg.ResourceCosts.TryGetValue(kv.Key, out var w))
+                    if (weights.TryGetValue(kv.Key, out var w))
                         extra += kv.Value * w;
             }
 


### PR DESCRIPTION
## Summary
- document support for resource-aware navigation
- provide default resource weights for AI/pathfinding
- expose resource data through `Searcher`
- apply default weights when no custom cost map is supplied

## Testing
- `dotnet test VelorenPort/VelorenPort.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686187992f988328856e309d6881b028