### PR TITLE
Add Rust server integration helpers

### DIFF
--- a/VelorenPort/Network.Tests/QuicOptionsIntegrationTests.cs
+++ b/VelorenPort/Network.Tests/QuicOptionsIntegrationTests.cs
@@ -11,7 +11,6 @@ public class QuicOptionsIntegrationTests
     [Fact]
     public async Task ConnectsWithZeroRttEnabled()
     {
-        using var server = RustServerHarness.StartServer();
         var cfg = new QuicClientConfig
         {
             EnableZeroRtt = true,
@@ -19,8 +18,7 @@ public class QuicOptionsIntegrationTests
             MaxEarlyData = 64,
             IdleTimeout = TimeSpan.FromSeconds(5)
         };
-        var net = new Network(Pid.NewPid());
-        await net.ConnectAsync(new ConnectAddr.Quic(new IPEndPoint(IPAddress.Loopback, 14004), cfg, "quic"));
+        var (server, net) = await RustServerHarness.StartAndConnectQuicAsync(cfg);
         var p = await net.ConnectedAsync();
         Assert.NotNull(p);
         await net.ShutdownAsync();
@@ -30,14 +28,12 @@ public class QuicOptionsIntegrationTests
     [Fact]
     public async Task ConnectsWithMigrationEnabled()
     {
-        using var server = RustServerHarness.StartServer();
         var cfg = new QuicClientConfig
         {
             EnableConnectionMigration = true,
             IdleTimeout = TimeSpan.FromSeconds(5)
         };
-        var net = new Network(Pid.NewPid());
-        await net.ConnectAsync(new ConnectAddr.Quic(new IPEndPoint(IPAddress.Loopback, 14004), cfg, "quic"));
+        var (server, net) = await RustServerHarness.StartAndConnectQuicAsync(cfg);
         var p = await net.ConnectedAsync();
         Assert.NotNull(p);
         await net.ShutdownAsync();

--- a/VelorenPort/Network.Tests/RustServerHarness.cs
+++ b/VelorenPort/Network.Tests/RustServerHarness.cs
@@ -24,6 +24,45 @@ internal static class RustServerHarness
         return proc;
     }
 
+    public static async Task<(Process process, Network net)> StartAndConnectAsync(bool useQuic = false)
+    {
+        var proc = StartServer();
+        try
+        {
+            Network net = useQuic
+                ? await ConnectQuicOrSkipAsync()
+                : await ConnectOrSkipAsync();
+            return (proc, net);
+        }
+        catch
+        {
+            await StopServerAsync(proc);
+            throw;
+        }
+    }
+
+    public static async Task<(Process process, Network net)> StartAndConnectQuicAsync(QuicClientConfig config)
+    {
+        var proc = StartServer();
+        try
+        {
+            string host = Environment.GetEnvironmentVariable("RUST_SERVER_ADDR") ?? "127.0.0.1";
+            int port = 14004;
+            if (int.TryParse(Environment.GetEnvironmentVariable("RUST_SERVER_PORT"), out var envPort))
+                port = envPort;
+
+            var addr = new IPEndPoint(IPAddress.Parse(host), port);
+            var net = new Network(Pid.NewPid());
+            await net.ConnectAsync(new ConnectAddr.Quic(addr, config, "quic"));
+            return (proc, net);
+        }
+        catch
+        {
+            await StopServerAsync(proc);
+            throw;
+        }
+    }
+
     public static async Task StopServerAsync(Process proc)
     {
         if (!proc.HasExited)

--- a/VelorenPort/Network.Tests/RustServerIntegrationTests.cs
+++ b/VelorenPort/Network.Tests/RustServerIntegrationTests.cs
@@ -7,14 +7,16 @@ public class RustServerIntegrationTests
     [Fact]
     public async Task ConnectsToRustServerIfAvailable()
     {
-        var net = await RustServerHarness.ConnectOrSkipAsync();
+        var (server, net) = await RustServerHarness.StartAndConnectAsync();
         await net.ShutdownAsync();
+        await RustServerHarness.StopServerAsync(server);
     }
 
     [Fact]
     public async Task ConnectsToRustServerViaQuicIfAvailable()
     {
-        var net = await RustServerHarness.ConnectQuicOrSkipAsync();
+        var (server, net) = await RustServerHarness.StartAndConnectAsync(useQuic: true);
         await net.ShutdownAsync();
+        await RustServerHarness.StopServerAsync(server);
     }
 }

--- a/VelorenPort/Network.Tests/RustServerProtocolTests.cs
+++ b/VelorenPort/Network.Tests/RustServerProtocolTests.cs
@@ -9,9 +9,11 @@ public class RustServerProtocolTests
     [Fact]
     public async Task HandshakeNegotiation()
     {
-        using var server = RustServerHarness.StartServer();
-        var net = await RustServerHarness.ConnectOrSkipAsync();
+        var (server, net) = await RustServerHarness.StartAndConnectAsync();
         Assert.NotEmpty(net.LocalPid.ToByteArray());
+        var participant = await net.ConnectedAsync();
+        Assert.NotNull(participant);
+        Assert.NotEmpty(participant!.RemoteVersion);
         await net.ShutdownAsync();
         await RustServerHarness.StopServerAsync(server);
     }
@@ -19,8 +21,7 @@ public class RustServerProtocolTests
     [Fact]
     public async Task StreamReliability()
     {
-        using var server = RustServerHarness.StartServer();
-        var net = await RustServerHarness.ConnectOrSkipAsync();
+        var (server, net) = await RustServerHarness.StartAndConnectAsync();
         var p = await net.ConnectedAsync();
         var s = await p!.OpenStreamAsync(p.NextSid(), new StreamParams(Promises.Ordered | Promises.GuaranteedDelivery));
         await s.SendAsync("ping");
@@ -34,8 +35,7 @@ public class RustServerProtocolTests
     [Fact]
     public async Task QuicConnectionOptions()
     {
-        using var server = RustServerHarness.StartServer();
-        var net = await RustServerHarness.ConnectQuicOrSkipAsync();
+        var (server, net) = await RustServerHarness.StartAndConnectAsync(useQuic: true);
         await net.ShutdownAsync();
         await RustServerHarness.StopServerAsync(server);
     }


### PR DESCRIPTION
## Summary
- update `RustServerHarness` with helper methods to start the server and connect
- exercise these helpers in Rust server protocol and integration tests
- test QUIC options using the new harness helpers

## Testing
- `dotnet build VelorenPort/Network.Tests/Network.Tests.csproj -c Release -v minimal` *(fails: UdpHandshakeStream override errors)*
- `dotnet test VelorenPort/Network.Tests/Network.Tests.csproj -c Release -v minimal` *(fails: UdpHandshakeStream override errors)*

------
https://chatgpt.com/codex/tasks/task_e_686187b1b9c08328a7b213581e3e9533