### PR TITLE
Add climate data and storm velocity to WeatherMap

### DIFF
--- a/VelorenPort/World.Tests/StormSimulationTests.cs
+++ b/VelorenPort/World.Tests/StormSimulationTests.cs
@@ -15,7 +15,8 @@ public class StormSimulationTests
             Center = new int2(1,1),
             Radius = 1f,
             Intensity = 1f,
-            TimeLeft = 2f
+            TimeLeft = 2f,
+            Velocity = float2.zero
         };
         map.AddStorm(storm);
         var rng = new Random(1);
@@ -24,5 +25,23 @@ public class StormSimulationTests
         Assert.NotEmpty(map.LightningEvents);
         map.Tick(rng);
         Assert.Empty(map.ActiveStorms);
+    }
+
+    [Fact]
+    public void Storm_MovesAccordingToVelocity()
+    {
+        var map = WeatherMap.Generate(new int2(4,4), 1);
+        var storm = new WeatherMap.Storm
+        {
+            Center = new int2(0,0),
+            Radius = 1f,
+            Intensity = 1f,
+            TimeLeft = 3f,
+            Velocity = new float2(1f,0f)
+        };
+        map.AddStorm(storm);
+        var rng = new Random(1);
+        map.Tick(rng);
+        Assert.Equal(new int2(1,0), map.ActiveStorms[0].Center);
     }
 }

--- a/VelorenPort/World.Tests/WeatherMapPersistenceTests.cs
+++ b/VelorenPort/World.Tests/WeatherMapPersistenceTests.cs
@@ -10,6 +10,7 @@ public class WeatherMapPersistenceTests
     public void WeatherMap_SerializesAndLoads()
     {
         var map = WeatherMap.Generate(new int2(2, 2), 1);
+        map.Climate.Set(new int2(0,0), 0.75f);
         var path = Path.GetTempFileName();
         map.Save(path);
         var loaded = WeatherMap.Load(path);
@@ -20,6 +21,7 @@ public class WeatherMapPersistenceTests
             Assert.Equal(cell.Cloud, other.Cloud, 3);
             Assert.Equal(cell.Rain, other.Rain, 3);
         }
+        Assert.Equal(map.Climate.Get(new int2(0,0)), loaded.Climate.Get(new int2(0,0)), 3);
         File.Delete(path);
     }
 }


### PR DESCRIPTION
## Summary
- extend `WeatherMap` with a climate grid and storm velocity
- update save/load to persist climate info
- include seasonal and regional factors when ticking storms
- test storm movement and climate persistence

## Testing
- `dotnet test VelorenPort/World.Tests/World.Tests.csproj` *(fails: duplicate types and other build errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861879d7394832889644827f8c977fd