### PR TITLE
Add basic behavior tree based NPC AI

### DIFF
--- a/VelorenPort/Server.Tests/NpcAiSystemTests.cs
+++ b/VelorenPort/Server.Tests/NpcAiSystemTests.cs
@@ -15,6 +15,7 @@ public class NpcAiSystemTests
     {
         var em = new EntityManager();
         var npcEnt = StateExt.CreateNpc(em, new float3(0,0,0), "goblin");
+        NpcAiSystem.RegisterNpc(em, npcEnt);
 
         var participant = (Participant)Activator.CreateInstance(
             typeof(Participant), BindingFlags.NonPublic | BindingFlags.Instance,
@@ -27,5 +28,27 @@ public class NpcAiSystemTests
         NpcAiSystem.Update(em, new[] { client }, 1f);
 
         Assert.True(client.Health < 100f);
+    }
+
+
+    [Fact]
+    public void Update_ChasesTargetWhenOutOfRange()
+    {
+        var em = new EntityManager();
+        var npcEnt = StateExt.CreateNpc(em, new float3(0,0,0), "goblin");
+        NpcAiSystem.RegisterNpc(em, npcEnt);
+
+        var participant = (Participant)Activator.CreateInstance(
+            typeof(Participant), BindingFlags.NonPublic | BindingFlags.Instance,
+            new object?[] { Pid.NewPid(), new ConnectAddr.Mpsc(1), Guid.NewGuid(), null, null, null })!;
+        var client = (Client)Activator.CreateInstance(
+            typeof(Client), BindingFlags.NonPublic | BindingFlags.Instance,
+            new object?[] { participant })!;
+        client.SetPosition(new float3(5,0,0));
+
+        NpcAiSystem.Update(em, new[] { client }, 1f);
+
+        var pos = em.GetComponentData<Pos>(npcEnt).Value;
+        Assert.True(math.distance(pos, float3.zero) > 0f);
     }
 }

--- a/VelorenPort/Server.Tests/NpcSpawnerSystemTests.cs
+++ b/VelorenPort/Server.Tests/NpcSpawnerSystemTests.cs
@@ -23,7 +23,13 @@ public class NpcSpawnerSystemTests
         var points = new List<NpcSpawnerSystem.SpawnPoint> { sp };
         NpcSpawnerSystem.Update(em, points, 1f);
         int count = 0;
-        foreach (var _ in em.GetEntitiesWith<Npc>()) count++;
+        Entity spawned = default;
+        foreach (var e in em.GetEntitiesWith<Npc>())
+        {
+            count++;
+            spawned = e;
+        }
         Assert.Equal(1, count);
+        Assert.True(NpcAiSystem.IsRegistered(spawned));
     }
 }

--- a/VelorenPort/Server/Src/Agent/BehaviorTree.cs
+++ b/VelorenPort/Server/Src/Agent/BehaviorTree.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using VelorenPort.NativeMath;
+using VelorenPort.CoreEngine;
+
+namespace VelorenPort.Server.Agent;
+
+public enum BehaviorStatus
+{
+    Success,
+    Failure,
+    Running
+}
+
+public interface IBehaviorNode
+{
+    BehaviorStatus Tick(EntityManager em, Entity entity, Npc npc, IEnumerable<Client> clients, float dt, BehaviorState state);
+}
+
+public sealed class BehaviorState
+{
+    public Client? Target;
+    public float AttackCooldown;
+    public float PatrolTimer;
+    public float2 WanderDir;
+}
+
+public sealed class BehaviorTree
+{
+    private readonly IBehaviorNode _root;
+    private readonly BehaviorState _state = new();
+
+    public BehaviorTree(IBehaviorNode root)
+    {
+        _root = root;
+    }
+
+    public void Tick(EntityManager em, Entity entity, Npc npc, IEnumerable<Client> clients, float dt)
+    {
+        if (_state.AttackCooldown > 0f)
+            _state.AttackCooldown -= dt;
+        if (_state.PatrolTimer > 0f)
+            _state.PatrolTimer -= dt;
+        _root.Tick(em, entity, npc, clients, dt, _state);
+    }
+}
+
+public sealed class SequenceNode : IBehaviorNode
+{
+    private readonly IBehaviorNode[] _children;
+
+    public SequenceNode(params IBehaviorNode[] children)
+    {
+        _children = children;
+    }
+
+    public BehaviorStatus Tick(EntityManager em, Entity entity, Npc npc, IEnumerable<Client> clients, float dt, BehaviorState state)
+    {
+        foreach (var child in _children)
+        {
+            var result = child.Tick(em, entity, npc, clients, dt, state);
+            if (result != BehaviorStatus.Success)
+                return result;
+        }
+        return BehaviorStatus.Success;
+    }
+}
+
+public sealed class SelectorNode : IBehaviorNode
+{
+    private readonly IBehaviorNode[] _children;
+
+    public SelectorNode(params IBehaviorNode[] children)
+    {
+        _children = children;
+    }
+
+    public BehaviorStatus Tick(EntityManager em, Entity entity, Npc npc, IEnumerable<Client> clients, float dt, BehaviorState state)
+    {
+        foreach (var child in _children)
+        {
+            var result = child.Tick(em, entity, npc, clients, dt, state);
+            if (result == BehaviorStatus.Success)
+                return BehaviorStatus.Success;
+            if (result == BehaviorStatus.Running)
+                return BehaviorStatus.Running;
+        }
+        return BehaviorStatus.Failure;
+    }
+}
+
+public sealed class ActionNode : IBehaviorNode
+{
+    private readonly Func<EntityManager, Entity, Npc, IEnumerable<Client>, float, BehaviorState, BehaviorStatus> _action;
+
+    public ActionNode(Func<EntityManager, Entity, Npc, IEnumerable<Client>, float, BehaviorState, BehaviorStatus> action)
+    {
+        _action = action;
+    }
+
+    public BehaviorStatus Tick(EntityManager em, Entity entity, Npc npc, IEnumerable<Client> clients, float dt, BehaviorState state)
+        => _action(em, entity, npc, clients, dt, state);
+}

--- a/VelorenPort/Server/Src/Agent/NpcBehaviorFactory.cs
+++ b/VelorenPort/Server/Src/Agent/NpcBehaviorFactory.cs
@@ -1,0 +1,125 @@
+using VelorenPort.NativeMath;
+using VelorenPort.CoreEngine;
+
+namespace VelorenPort.Server.Agent;
+
+public static class NpcBehaviorFactory
+{
+    private const float DetectionRange = 10f;
+    private const float AttackRange = 2f;
+    private const float AttackDamage = 5f;
+    private const float AttackCooldown = 1f;
+    private const float ChaseSpeed = 3f;
+    private const float WanderSpeed = 1f;
+
+    public static BehaviorTree CreateDefault()
+    {
+        return new BehaviorTree(
+            new SelectorNode(
+                new SequenceNode(
+                    new ActionNode(AcquireTarget),
+                    new SelectorNode(
+                        new SequenceNode(
+                            new ActionNode(TargetInRange),
+                            new ActionNode(Attack)
+                        ),
+                        new ActionNode(Chase)
+                    )
+                ),
+                new ActionNode(Patrol)
+            )
+        );
+    }
+
+    private static BehaviorStatus AcquireTarget(EntityManager em, Entity entity, Npc npc, IEnumerable<Client> clients, float dt, BehaviorState state)
+    {
+        if (state.Target != null)
+        {
+            var dist = math.distance(state.Target.Position.Value, em.GetComponentData<Pos>(entity).Value);
+            if (dist <= DetectionRange)
+                return BehaviorStatus.Success;
+        }
+
+        Client? best = null;
+        float bestDist = DetectionRange;
+        var pos = em.GetComponentData<Pos>(entity).Value;
+        foreach (var c in clients)
+        {
+            var d = math.distance(c.Position.Value, pos);
+            if (d <= bestDist)
+            {
+                bestDist = d;
+                best = c;
+            }
+        }
+        state.Target = best;
+        return best != null ? BehaviorStatus.Success : BehaviorStatus.Failure;
+    }
+
+    private static BehaviorStatus TargetInRange(EntityManager em, Entity entity, Npc npc, IEnumerable<Client> clients, float dt, BehaviorState state)
+    {
+        if (state.Target == null)
+            return BehaviorStatus.Failure;
+        var pos = em.GetComponentData<Pos>(entity).Value;
+        var dist = math.distance(state.Target.Position.Value, pos);
+        return dist <= AttackRange ? BehaviorStatus.Success : BehaviorStatus.Failure;
+    }
+
+    private static BehaviorStatus Attack(EntityManager em, Entity entity, Npc npc, IEnumerable<Client> clients, float dt, BehaviorState state)
+    {
+        if (state.Target == null)
+            return BehaviorStatus.Failure;
+        if (state.AttackCooldown > 0f)
+            return BehaviorStatus.Running;
+        npc.EnterCombat();
+        CombatUtils.Apply(state.Target, new Attack(npc.Id, new HitInfo(state.Target.Uid, AttackDamage, DamageKind.Physical)), null);
+        state.AttackCooldown = AttackCooldown;
+        return BehaviorStatus.Success;
+    }
+
+    private static BehaviorStatus Chase(EntityManager em, Entity entity, Npc npc, IEnumerable<Client> clients, float dt, BehaviorState state)
+    {
+        if (state.Target == null)
+            return BehaviorStatus.Failure;
+        var pos = em.GetComponentData<Pos>(entity);
+        var dir = math.normalize(state.Target.Position.Value - pos.Value);
+        var vel = new Vel(dir * ChaseSpeed);
+        pos = new Pos(pos.Value + vel.Value * dt);
+        em.SetComponentData(entity, pos);
+        if (em.HasComponent<Vel>(entity))
+            em.SetComponentData(entity, vel);
+        else
+            em.AddComponentData(entity, vel);
+        var yaw = math.atan2(dir.x, dir.z);
+        var rot = math.axisAngle(new float3(0f, 1f, 0f), yaw);
+        if (em.HasComponent<Ori>(entity))
+            em.SetComponentData(entity, new Ori(rot));
+        return BehaviorStatus.Running;
+    }
+
+    private static BehaviorStatus Patrol(EntityManager em, Entity entity, Npc npc, IEnumerable<Client> clients, float dt, BehaviorState state)
+    {
+        var pos = em.GetComponentData<Pos>(entity);
+        if (state.PatrolTimer <= 0f)
+        {
+            var rand = new Random((uint)entity.Index + (uint)math.floor(pos.Value.x));
+            state.WanderDir = rand.NextFloat2(-1f, 1f);
+            if (math.lengthsq(state.WanderDir) > 0f)
+                state.WanderDir = math.normalize(state.WanderDir);
+            state.PatrolTimer = 2f;
+        }
+        var move = new float3(state.WanderDir.x, 0f, state.WanderDir.y) * WanderSpeed * dt;
+        pos = new Pos(pos.Value + move);
+        var vel = new Vel(move / dt);
+        em.SetComponentData(entity, pos);
+        if (em.HasComponent<Vel>(entity))
+            em.SetComponentData(entity, vel);
+        else
+            em.AddComponentData(entity, vel);
+        var yaw = math.atan2(state.WanderDir.x, state.WanderDir.y);
+        var rot = math.axisAngle(new float3(0f, 1f, 0f), yaw);
+        if (em.HasComponent<Ori>(entity))
+            em.SetComponentData(entity, new Ori(rot));
+        return BehaviorStatus.Running;
+    }
+}

--- a/VelorenPort/Server/Src/Sys/NpcSpawnerSystem.cs
+++ b/VelorenPort/Server/Src/Sys/NpcSpawnerSystem.cs
@@ -30,6 +30,7 @@ public static class NpcSpawnerSystem
             {
                 sp.Timer = sp.Interval;
                 var ent = StateExt.CreateNpc(em, sp.Position, "mob");
+                NpcAiSystem.RegisterNpc(em, ent);
                 sp.Spawned.Add(ent);
             }
         }


### PR DESCRIPTION
## Summary
- implement a simple behavior tree framework for the server
- port minimal NPC combat and movement logic using the new tree
- hook up spawner to register NPCs with the AI system
- extend unit tests for NPC AI and spawning

## Testing
- `dotnet test VelorenPort/VelorenPort.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68618aa32f28832881454331996066fc