### PR TITLE
Implement SQLite character persistence

### DIFF
--- a/VelorenPort/Server.Tests/CharacterLoaderTests.cs
+++ b/VelorenPort/Server.Tests/CharacterLoaderTests.cs
@@ -12,17 +12,31 @@ public class CharacterLoaderTests
     {
         var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(dir);
-        var path = Path.Combine(dir, "list.json");
-        var loader = new CharacterLoader(path);
-        loader.AddCharacter("p1", new CharacterId(1));
-        loader.AddCharacter("p1", new CharacterId(2));
-        loader.SaveAll();
+        var dbPath = Path.Combine(dir, "chars.sqlite");
+        var loader = new CharacterLoader(dbPath);
+        loader.AddCharacter("p1", new CharacterId(1), "a");
+        loader.AddCharacter("p1", new CharacterId(2), "b");
 
-        var loaded = new CharacterLoader(path);
-        loaded.LoadAll();
+        var loaded = new CharacterLoader(dbPath);
         var list = loaded.LoadCharacterList("p1");
         Assert.Equal(2, list.Count);
         Assert.Contains(list, id => id.Value == 1);
+        Directory.Delete(dir, true);
+    }
+
+    [Fact]
+    public void LegacyFileMigrates()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        var legacy = Path.Combine(dir, "character_list.json");
+        File.WriteAllText(legacy, "{\"p2\":[3,4]}");
+        var dbPath = Path.Combine(dir, "chars.sqlite");
+        var loader = new CharacterLoader(dbPath);
+        var list = loader.LoadCharacterList("p2");
+        Assert.Equal(2, list.Count);
+        Assert.Contains(list, id => id.Value == 3);
+        Assert.True(File.Exists(legacy + ".bak"));
         Directory.Delete(dir, true);
     }
 }

--- a/VelorenPort/Server/Server.csproj
+++ b/VelorenPort/Server/Server.csproj
@@ -6,10 +6,14 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Src/**/*.cs" />
+    <EmbeddedResource Include="Src/Migrations/*.sql" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CoreEngine\CoreEngine.csproj" />
     <ProjectReference Include="..\Network\Network.csproj" />
     <ProjectReference Include="..\World\World.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.6" />
   </ItemGroup>
 </Project>

--- a/VelorenPort/Server/Src/CharacterCreator.cs
+++ b/VelorenPort/Server/Src/CharacterCreator.cs
@@ -72,7 +72,7 @@ namespace VelorenPort.Server {
                 ActiveAbilities = ActiveAbilities.DefaultLimited(Player.BASE_ABILITY_LIMIT),
                 MapMarker = mapMarker,
             });
-            characterLoader?.AddCharacter(playerUuid, id);
+            characterLoader?.AddCharacter(playerUuid, id, characterAlias);
             return null;
         }
 

--- a/VelorenPort/Server/Src/Persistence/CharacterLoader.cs
+++ b/VelorenPort/Server/Src/Persistence/CharacterLoader.cs
@@ -1,63 +1,58 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using Microsoft.Data.Sqlite;
 using VelorenPort.CoreEngine;
 
 namespace VelorenPort.Server.Persistence {
     /// <summary>
-    /// Simplified character loader that works with the in-memory
-    /// <see cref="CharacterUpdater"/>. Database support is planned
-    /// but not yet implemented.
+    /// Character list persistence backed by SQLite. Older JSON files are
+    /// automatically imported on first run.
     /// </summary>
     public class CharacterLoader {
-        private readonly Dictionary<string, List<CharacterId>> _characters = new();
-        private readonly string _savePath;
+        private readonly Database _db;
+        private readonly string _legacyPath;
 
-        public CharacterLoader(string? savePath = null) {
-            _savePath = savePath ?? Path.Combine(DataDir.DefaultDataDirName, "character_list.json");
+        public CharacterLoader(string? dbPath = null) {
+            var path = dbPath ?? Path.Combine(DataDir.DefaultDataDirName, "characters.sqlite");
+            _legacyPath = Path.Combine(Path.GetDirectoryName(path)!, "character_list.json");
+            _db = new Database(path);
+            MigrateLegacy();
+        }
+
+        private void MigrateLegacy() {
+            if (!File.Exists(_legacyPath)) return;
+            var json = File.ReadAllText(_legacyPath);
+            var data = JsonSerializer.Deserialize<Dictionary<string, List<long>>>(json);
+            if (data == null) return;
+            foreach (var (player, ids) in data) {
+                foreach (var id in ids) {
+                    AddCharacter(player, new CharacterId(id), "legacy");
+                }
+            }
+            File.Move(_legacyPath, _legacyPath + ".bak", true);
         }
 
         public IReadOnlyList<CharacterId> LoadCharacterList(string playerUuid) {
-            return _characters.TryGetValue(playerUuid, out var list)
-                ? list
-                : (IReadOnlyList<CharacterId>)System.Array.Empty<CharacterId>();
+            var list = new List<CharacterId>();
+            using var cmd = _db.Connection.CreateCommand();
+            cmd.CommandText = "SELECT id FROM character WHERE player_uuid = $p";
+            cmd.Parameters.AddWithValue("$p", playerUuid);
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read()) list.Add(new CharacterId(reader.GetInt64(0)));
+            return list;
         }
 
-        public void AddCharacter(string playerUuid, CharacterId id) {
-            if (!_characters.TryGetValue(playerUuid, out var list)) {
-                list = new List<CharacterId>();
-                _characters[playerUuid] = list;
-            }
-            list.Add(id);
+        public void AddCharacter(string playerUuid, CharacterId id, string alias) {
+            using var cmd = _db.Connection.CreateCommand();
+            cmd.CommandText = "INSERT INTO character(id, player_uuid, alias) VALUES($id,$player,$alias)";
+            cmd.Parameters.AddWithValue("$id", id.Value);
+            cmd.Parameters.AddWithValue("$player", playerUuid);
+            cmd.Parameters.AddWithValue("$alias", alias);
+            cmd.ExecuteNonQuery();
         }
 
-        public void SaveAll() {
-            Directory.CreateDirectory(Path.GetDirectoryName(_savePath)!);
-            var serializable = new Dictionary<string, List<long>>();
-            foreach (var (player, chars) in _characters) {
-                var ids = new List<long>();
-                foreach (var c in chars)
-                    ids.Add(c.Value);
-                serializable[player] = ids;
-            }
-            var json = JsonSerializer.Serialize(serializable, new JsonSerializerOptions { WriteIndented = true });
-            File.WriteAllText(_savePath, json);
-        }
-
-        public void LoadAll() {
-            if (!File.Exists(_savePath))
-                return;
-            var json = File.ReadAllText(_savePath);
-            var data = JsonSerializer.Deserialize<Dictionary<string, List<long>>>(json);
-            if (data == null)
-                return;
-            _characters.Clear();
-            foreach (var (player, ids) in data) {
-                var list = new List<CharacterId>();
-                foreach (var id in ids)
-                    list.Add(new CharacterId(id));
-                _characters[player] = list;
-            }
-        }
+        public void SaveAll() { }
+        public void LoadAll() { }
     }
 }

--- a/VelorenPort/Server/Src/Persistence/Database.cs
+++ b/VelorenPort/Server/Src/Persistence/Database.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Data.Sqlite;
+
+namespace VelorenPort.Server.Persistence {
+    /// <summary>
+    /// Simple SQLite context that applies SQL scripts embedded in the
+    /// assembly. It mimics the rust implementation enough for
+    /// CharacterLoader.
+    /// </summary>
+    public sealed class Database : IDisposable {
+        public SqliteConnection Connection { get; }
+
+        public Database(string path) {
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            var builder = new SqliteConnectionStringBuilder { DataSource = path };
+            Connection = new SqliteConnection(builder.ConnectionString);
+            Connection.Open();
+            RunMigrations();
+        }
+
+        private void RunMigrations() {
+            using var tx = Connection.BeginTransaction();
+            Connection.Execute("CREATE TABLE IF NOT EXISTS migrations (version INTEGER PRIMARY KEY)");
+            var applied = new HashSet<int>();
+            using (var cmd = Connection.CreateCommand()) {
+                cmd.Transaction = tx;
+                cmd.CommandText = "SELECT version FROM migrations";
+                using var reader = cmd.ExecuteReader();
+                while (reader.Read()) {
+                    applied.Add(reader.GetInt32(0));
+                }
+            }
+
+            var assembly = Assembly.GetExecutingAssembly();
+            var prefix = typeof(Database).Namespace + ".Migrations.";
+            var resources = assembly.GetManifestResourceNames()
+                .Where(r => r.StartsWith(prefix) && r.EndsWith(".sql"))
+                .OrderBy(r => r);
+            foreach (var res in resources) {
+                var name = res.Substring(prefix.Length);
+                if (name.StartsWith("V") && int.TryParse(name.Split("__")[0][1..], out var version)) {
+                    if (applied.Contains(version)) continue;
+                    using var stream = assembly.GetManifestResourceStream(res)!;
+                    using var reader = new StreamReader(stream);
+                    var sql = reader.ReadToEnd();
+                    using var cmd = Connection.CreateCommand();
+                    cmd.Transaction = tx;
+                    cmd.CommandText = sql;
+                    cmd.ExecuteNonQuery();
+                    using var insert = Connection.CreateCommand();
+                    insert.Transaction = tx;
+                    insert.CommandText = "INSERT INTO migrations(version) VALUES($v)";
+                    insert.Parameters.AddWithValue("$v", version);
+                    insert.ExecuteNonQuery();
+                }
+            }
+            tx.Commit();
+        }
+
+        public void Dispose() => Connection.Dispose();
+    }
+
+    static class SqliteExtensions {
+        public static int Execute(this SqliteConnection conn, string sql) {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            return cmd.ExecuteNonQuery();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `Database` context that runs embedded SQL migrations
- store character lists in SQLite and migrate any JSON data
- embed SQL files in the server project
- adjust character creation and unit tests for new API

## Testing
- `dotnet test Server.Tests/Server.Tests.csproj` *(fails: World project build errors)*

------
https://chatgpt.com/codex/tasks/task_e_68618aa448a08328b591f2fee6d5d5d0