### PR TITLE
Add task for token-based login

### DIFF
--- a/VelorenPort/Server/ProjectTasks.md
+++ b/VelorenPort/Server/ProjectTasks.md
@@ -82,3 +82,8 @@ This document tracks the main work items required to bring the C# server up to f
 - **C# files**: `Server/Src/InviteManager.cs`, `CoreEngine/Src/comp/GroupManager.cs`
 - **Rust reference**: `server/src/events/invite.rs`, `server/src/sys/loot.rs`
 - **Summary**: Implement group officer permissions, loot distribution modes and invite timeouts using these modules as starting points.
+
+## 17. Token-based authentication and admin role persistence
+- **C# files**: `Server/Src/LoginProvider.cs`, `Server/Src/Settings/AdminList.cs`
+- **Rust reference**: `server/src/login.rs` and admin persistence logic
+- **Summary**: Implement token validation and store admin role versions as noted under "Simplified login and administration" in `MissingFeatures.md`.


### PR DESCRIPTION
## Summary
- note missing token-based authentication and admin role saving
- reference simplified login bullet in server's missing features

## Testing
- `dotnet test VelorenPort/VelorenPort.sln --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68618aaf43fc832898688639a634e846