### PR TITLE
Add task for handshake porting

### DIFF
--- a/VelorenPort/Server/ProjectTasks.md
+++ b/VelorenPort/Server/ProjectTasks.md
@@ -87,3 +87,8 @@ This document tracks the main work items required to bring the C# server up to f
 - **C# files**: `Server/Src/LoginProvider.cs`, `Server/Src/Settings/AdminList.cs`
 - **Rust reference**: `server/src/login.rs` and admin persistence logic
 - **Summary**: Implement token validation and store admin role versions as noted under "Simplified login and administration" in `MissingFeatures.md`.
+
+## 18. Asynchronous handshake and server-info queries
+- **C# files**: `Server/Src/ConnectionHandler.cs`
+- **Rust reference**: `server/src/connection_handler.rs`
+- **Summary**: Port the connection handshake logic that negotiates client type and serves `ServerInfo` before spawning clients. The current handler lacks these asynchronous steps and simply enqueues participants.

--- a/VelorenPort/Server/Src/ConnectionHandler.cs
+++ b/VelorenPort/Server/Src/ConnectionHandler.cs
@@ -8,6 +8,12 @@ namespace VelorenPort.Server {
     /// Background task that listens for new participants and converts them
     /// into <see cref="Client"/> instances for the server to consume.
     /// </summary>
+    /// <remarks>
+    /// The current implementation is limited to a simple loop that enqueues
+    /// clients as soon as they connect. It does not perform the asynchronous
+    /// handshake or provide server-info queries found in the Rust
+    /// <c>connection_handler.rs</c>.
+    /// </remarks>
     public class ConnectionHandler {
         private readonly Network.Network _network;
         private readonly ConcurrentQueue<Client> _pending = new();


### PR DESCRIPTION
## Summary
- describe limitations in `ConnectionHandler.cs`
- add Project Tasks entry for asynchronous handshake implementation

## Testing
- `dotnet test VelorenPort/VelorenPort.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68618dbbdb6c83289975e1c5fe592d88