### PR TITLE
Implement region persistence and dynamic lod

### DIFF
--- a/VelorenPort/Server.Tests/RegionPersistenceIntegrationTests.cs
+++ b/VelorenPort/Server.Tests/RegionPersistenceIntegrationTests.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using VelorenPort.CoreEngine;
+using VelorenPort.NativeMath;
+
+namespace Server.Tests;
+
+public class RegionPersistenceIntegrationTests
+{
+    [Fact]
+    public void RegionMap_PersistsAcrossRestarts()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        var map = new RegionMap(dir);
+        var uid = new Uid(99);
+        map.Set(uid, new int2(1, 2));
+        map.Flush();
+
+        var loaded = new RegionMap(dir);
+        var pos = loaded.GetRegion(uid);
+        Assert.True(pos.HasValue);
+        Assert.Equal(new int2(1, 2), pos!.Value);
+        Directory.Delete(dir, true);
+    }
+}

--- a/VelorenPort/Server/Src/Lod.cs
+++ b/VelorenPort/Server/Src/Lod.cs
@@ -28,5 +28,21 @@ namespace VelorenPort.Server {
         }
 
         public Zone Zone(int2 zonePos) => Zones.TryGetValue(zonePos, out var zone) ? zone : EMPTY_ZONE;
+
+        public Zone GetOrCreateZone(World.World world, int2 zonePos)
+        {
+            if (!Zones.TryGetValue(zonePos, out var zone))
+            {
+                zone = world.GetLodZone(zonePos);
+                Zones[zonePos] = zone;
+            }
+            return zone;
+        }
+
+        public void UpdateForClient(Client client, World.World world)
+        {
+            foreach (var key in client.RegionSubscription.Regions)
+                GetOrCreateZone(world, key);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- persist RegionMap data to per-region files
- add modified tracking to Region
- dynamically create LOD zones as clients move
- test RegionMap persistence across restarts

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet test VelorenPort/VelorenPort.sln` *(fails: UdpHandshakeStream overrides missing)*

------
https://chatgpt.com/codex/tasks/task_e_68618dcd0d308328aac3559d1d403b7f