### PR TITLE
Implement layered client channels

### DIFF
--- a/VelorenPort/Server.Tests/ClientChannelTests.cs
+++ b/VelorenPort/Server.Tests/ClientChannelTests.cs
@@ -1,0 +1,55 @@
+using System.Threading.Tasks;
+using VelorenPort.Server;
+using VelorenPort.Network;
+
+namespace Server.Tests;
+
+public class ClientChannelTests
+{
+    [Fact]
+    public async Task ClientInitializesDefaultStreams()
+    {
+        var netA = new Network.Network(Pid.NewPid());
+        var netB = new Network.Network(Pid.NewPid());
+        const ulong channelId = 5678;
+
+        await netB.ListenAsync(new ListenAddr.Mpsc(channelId));
+        var connectTask = netA.ConnectAsync(new ConnectAddr.Mpsc(channelId));
+        var serverParticipant = await netB.ConnectedAsync();
+        var clientParticipant = await connectTask;
+
+        var client = await Client.CreateAsync(serverParticipant!);
+
+        // Accept opened streams on client side
+        for (int i = 0; i < 6; i++)
+            await clientParticipant.OpenedAsync();
+
+        Assert.True(client.TryGetStream(0, out var register));
+        Assert.Equal(Promises.Ordered | Promises.Consistency | Promises.Compressed, register.Promises);
+        Assert.Equal((byte)3, register.Priority);
+        Assert.Equal((ulong)500, register.GuaranteedBandwidth);
+
+        Assert.True(client.TryGetStream(1, out var charScreen));
+        Assert.Equal(register.Promises, charScreen.Promises);
+        Assert.Equal(register.Priority, charScreen.Priority);
+
+        Assert.True(client.TryGetStream(2, out var inGame));
+        Assert.Equal(register.Promises, inGame.Promises);
+        Assert.Equal((ulong)100_000, inGame.GuaranteedBandwidth);
+
+        Assert.True(client.TryGetStream(3, out var general));
+        Assert.Equal(register.Promises, general.Promises);
+
+        Assert.True(client.TryGetStream(4, out var ping));
+        Assert.Equal(Promises.Ordered | Promises.Consistency, ping.Promises);
+        Assert.Equal((byte)2, ping.Priority);
+
+        Assert.True(client.TryGetStream(5, out var terrain));
+        Assert.Equal(Promises.Ordered | Promises.Consistency, terrain.Promises);
+        Assert.Equal((byte)4, terrain.Priority);
+        Assert.Equal((ulong)20_000, terrain.GuaranteedBandwidth);
+
+        await netA.ShutdownAsync();
+        await netB.ShutdownAsync();
+    }
+}

--- a/VelorenPort/Server/Src/Client.cs
+++ b/VelorenPort/Server/Src/Client.cs
@@ -23,11 +23,35 @@ namespace VelorenPort.Server {
         public RegionSubscription RegionSubscription { get; }
         public ConnectAddr ConnectedFromAddr { get; }
         private readonly Dictionary<byte, Stream> _streams = new();
+
+        private static readonly StreamParams RegisterParams = new(
+            Promises.Ordered | Promises.Consistency | Promises.Compressed,
+            priority: 3,
+            guaranteedBandwidth: 500);
+
+        private static readonly StreamParams CharacterScreenParams = RegisterParams;
+
+        private static readonly StreamParams InGameParams = new(
+            Promises.Ordered | Promises.Consistency | Promises.Compressed,
+            priority: 3,
+            guaranteedBandwidth: 100_000);
+
+        private static readonly StreamParams GeneralParams = RegisterParams;
+
+        private static readonly StreamParams PingParams = new(
+            Promises.Ordered | Promises.Consistency,
+            priority: 2,
+            guaranteedBandwidth: 500);
+
+        private static readonly StreamParams TerrainParams = new(
+            Promises.Ordered | Promises.Consistency,
+            priority: 4,
+            guaranteedBandwidth: 20_000);
         public HashSet<int2> LoadedChunks { get; } = new();
         public PendingInvites PendingInvites { get; } = new();
         public Waypoint? Waypoint { get; set; }
 
-        internal Client(Participant participant) {
+        private Client(Participant participant) {
             Participant = participant;
             Uid = new Uid((ulong)participant.Id.Value);
             ConnectedFromAddr = participant.ConnectedFrom;
@@ -35,6 +59,21 @@ namespace VelorenPort.Server {
             Orientation = Ori.Identity;
             Presence = new Presence(new ViewDistances(8, 8), new PresenceKind.Spectator());
             RegionSubscription = RegionUtils.InitializeRegionSubscription(Position, Presence);
+        }
+
+        internal static async Task<Client> CreateAsync(Participant participant) {
+            var client = new Client(participant);
+            await client.InitializeStreamsAsync();
+            return client;
+        }
+
+        private async Task InitializeStreamsAsync() {
+            _streams[0] = await Participant.OpenStreamAsync(new Sid(0), RegisterParams);
+            _streams[1] = await Participant.OpenStreamAsync(new Sid(1), CharacterScreenParams);
+            _streams[2] = await Participant.OpenStreamAsync(new Sid(2), InGameParams);
+            _streams[3] = await Participant.OpenStreamAsync(new Sid(3), GeneralParams);
+            _streams[4] = await Participant.OpenStreamAsync(new Sid(4), PingParams);
+            _streams[5] = await Participant.OpenStreamAsync(new Sid(5), TerrainParams);
         }
 
         public void SetPosition(float3 pos) {
@@ -46,17 +85,14 @@ namespace VelorenPort.Server {
         }
 
         /// <summary>
-        /// Send a pre-serialized message to the client. Streams are lazily
-        /// created based on the <see cref="PreparedMsg.StreamId"/>.
+        /// Send a pre-serialized message to the client using the configured stream.
         /// </summary>
         public async Task SendPreparedAsync(PreparedMsg msg) {
-            if (!_streams.TryGetValue(msg.StreamId, out var stream)) {
-                stream = await Participant.OpenStreamAsync(
-                    new Sid(msg.StreamId),
-                    new StreamParams(Promises.Ordered | Promises.GuaranteedDelivery));
-                _streams[msg.StreamId] = stream;
-            }
+            if (!_streams.TryGetValue(msg.StreamId, out var stream))
+                throw new InvalidOperationException($"Stream {msg.StreamId} not initialized");
             await stream.SendAsync(msg.Message);
         }
+
+        public bool TryGetStream(byte id, out Stream stream) => _streams.TryGetValue(id, out stream);
     }
 }

--- a/VelorenPort/Server/Src/ConnectionHandler.cs
+++ b/VelorenPort/Server/Src/ConnectionHandler.cs
@@ -30,7 +30,8 @@ namespace VelorenPort.Server {
             while (!token.IsCancellationRequested) {
                 var participant = await _network.ConnectedAsync();
                 if (participant != null) {
-                    _pending.Enqueue(new Client(participant));
+                    var client = await Client.CreateAsync(participant);
+                    _pending.Enqueue(client);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- create default stream parameters for each client channel
- open all streams when constructing `Client`
- adjust connection handler to use new factory
- add helper to access streams
- add test verifying default channel setup

## Testing
- `dotnet test VelorenPort/VelorenPort.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861915f7c488328b9f181d25df79851