### PR TITLE
Add server management commands

### DIFF
--- a/VelorenPort/CLI/Src/Cli.cs
+++ b/VelorenPort/CLI/Src/Cli.cs
@@ -26,6 +26,8 @@ namespace VelorenPort.CLI {
         public abstract record BanCommand {
             public sealed record Add(string Username, string Reason) : BanCommand;
             public sealed record Remove(string Username) : BanCommand;
+            /// <summary>List all current bans.</summary>
+            public sealed record List : BanCommand;
         }
 
         public abstract record WhitelistCommand {
@@ -57,6 +59,12 @@ namespace VelorenPort.CLI {
             public sealed record ListPlayers : Message;
             public sealed record ListLogs : Message;
             public sealed record SendGlobalMsg(string Msg) : Message;
+            /// <summary>Request server statistics.</summary>
+            public sealed record Stats : Message;
+            /// <summary>Reload server configuration from disk.</summary>
+            public sealed record ReloadConfig : Message;
+            /// <summary>Return the current ban list.</summary>
+            public sealed record ListBans : Message;
         }
 
         public abstract record MessageReturn {
@@ -153,6 +161,7 @@ namespace VelorenPort.CLI {
             return sub switch {
                 "add" => new SharedCommand.Ban(ParseBanAdd(queue)),
                 "remove" => new SharedCommand.Ban(ParseBanRemove(queue)),
+                "list" => new SharedCommand.Ban(new BanCommand.List()),
                 _ => throw new ArgumentException($"Unknown ban command {sub}")
             };
         }
@@ -206,6 +215,10 @@ namespace VelorenPort.CLI {
                 throw new ArgumentException("ban remove requires <username>");
             string user = q.Dequeue();
             return new BanCommand.Remove(user);
+        }
+
+        private static BanCommand ParseBanList(Queue<string> q) {
+            return new BanCommand.List();
         }
 
         private static WhitelistCommand ParseWhitelistRemove(Queue<string> q) {
@@ -280,6 +293,9 @@ namespace VelorenPort.CLI {
                 "list-players" => new Message.ListPlayers(),
                 "list-logs" => new Message.ListLogs(),
                 "send-global-msg" => new Message.SendGlobalMsg(string.Join(' ', q)),
+                "stats" => new Message.Stats(),
+                "reload-config" => new Message.ReloadConfig(),
+                "list-bans" => new Message.ListBans(),
                 _ => throw new ArgumentException($"Unknown command {cmd}")
             };
         }

--- a/VelorenPort/CLI/Src/Main.cs
+++ b/VelorenPort/CLI/Src/Main.cs
@@ -65,6 +65,17 @@ namespace VelorenPort.CLI {
                 case Cli.Message.SendGlobalMsg(var text):
                     server.NotifyPlayers(text);
                     break;
+                case Cli.Message.Stats:
+                    Console.WriteLine(server.GetStats());
+                    break;
+                case Cli.Message.ReloadConfig:
+                    server.ReloadConfiguration();
+                    Console.WriteLine("Configuration reloaded");
+                    break;
+                case Cli.Message.ListBans:
+                    foreach (var b in server.BanListEntries())
+                        Console.WriteLine(b);
+                    break;
                 default:
                     Console.Error.WriteLine($"Unsupported command: {msg.GetType().Name}");
                     break;
@@ -113,6 +124,10 @@ namespace VelorenPort.CLI {
                             var r3 = lp.UsernameToUuid(user);
                             if (r3.IsOk)
                                 lp.UnbanUuid(r3.Value, user, new Banlist.BanInfo());
+                            break;
+                        case Cli.BanCommand.List:
+                            foreach (var (uuid, entry) in lp.Banlist.UuidBans())
+                                Console.WriteLine($"{uuid}:{entry.Current.Action.AsBan()?.GetInfo().Reason}");
                             break;
                     }
                     break;

--- a/VelorenPort/CoreEngine/Src/Cmd.cs
+++ b/VelorenPort/CoreEngine/Src/Cmd.cs
@@ -31,6 +31,14 @@ namespace VelorenPort.CoreEngine {
         SetWaypoint,
         Whisper,
         Team,
+        /// <summary>Ban a player by username with a reason.</summary>
+        Ban,
+        /// <summary>Remove a ban from a player.</summary>
+        Unban,
+        /// <summary>Display basic server statistics.</summary>
+        Stats,
+        /// <summary>Reload server configuration from disk.</summary>
+        ReloadConfig,
     }
 
     /// <summary>Simple registry mapping commands to their metadata.</summary>
@@ -46,6 +54,10 @@ namespace VelorenPort.CoreEngine {
             { ServerChatCommand.SetWaypoint, new ChatCommandData(Array.Empty<string>(), "Set a personal waypoint", false) },
             { ServerChatCommand.Whisper, new ChatCommandData(new[]{"uid","message"}, "Send a private message", false) },
             { ServerChatCommand.Team, new ChatCommandData(new[]{"message"}, "Send a message to your group", false) },
+            { ServerChatCommand.Ban, new ChatCommandData(new[]{"username","reason"}, "Ban a player", true) },
+            { ServerChatCommand.Unban, new ChatCommandData(new[]{"username"}, "Remove a player's ban", true) },
+            { ServerChatCommand.Stats, new ChatCommandData(Array.Empty<string>(), "Show server statistics", false) },
+            { ServerChatCommand.ReloadConfig, new ChatCommandData(Array.Empty<string>(), "Reload server configuration", true) },
         };
 
         public static ChatCommandData Data(ServerChatCommand cmd) => _data[cmd];

--- a/VelorenPort/Server.Tests/CliCommandTests.cs
+++ b/VelorenPort/Server.Tests/CliCommandTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using System.Reflection;
+using VelorenPort.CoreEngine;
+using VelorenPort.Server;
+
+namespace Server.Tests;
+
+public class CliCommandTests
+{
+    private static Client CreateClient()
+    {
+        var participant = (Participant)Activator.CreateInstance(
+            typeof(Participant), BindingFlags.NonPublic | BindingFlags.Instance,
+            new object?[] { Pid.NewPid(), new ConnectAddr.Mpsc(1), Guid.NewGuid(), null, null, null })!;
+        return (Client)Activator.CreateInstance(
+            typeof(Client), BindingFlags.NonPublic | BindingFlags.Instance,
+            new object?[] { participant })!;
+    }
+
+    [Fact]
+    public void ExecuteBan_AddsEntry()
+    {
+        var server = new GameServer(Pid.NewPid(), TimeSpan.FromMilliseconds(1), 1);
+        var client = CreateClient();
+        Cmd.Execute(ServerChatCommand.Ban, server, client, new[] { "cheater", "bad" });
+        var field = typeof(GameServer).GetField("_settings", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var settings = (VelorenPort.Server.Settings.Settings)field.GetValue(server)!;
+        Assert.NotEmpty(settings.Banlist.UuidBans());
+    }
+
+    [Fact]
+    public void ExecuteStats_ReturnsInfo()
+    {
+        var server = new GameServer(Pid.NewPid(), TimeSpan.FromMilliseconds(1), 1);
+        var client = CreateClient();
+        string stats = Cmd.Execute(ServerChatCommand.Stats, server, client, Array.Empty<string>());
+        Assert.Contains("players=0", stats);
+    }
+
+    [Fact]
+    public void ExecuteReloadConfig_LoadsFile()
+    {
+        var dir = VelorenPort.Server.DataDir.DefaultDataDirName;
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "settings.json");
+        File.WriteAllText(path, System.Text.Json.JsonSerializer.Serialize(new VelorenPort.Server.Settings.Settings { ServerName = "Custom" }));
+        var server = new GameServer(Pid.NewPid(), TimeSpan.FromMilliseconds(1), 1);
+        var client = CreateClient();
+        Cmd.Execute(ServerChatCommand.ReloadConfig, server, client, Array.Empty<string>());
+        var field = typeof(GameServer).GetField("_settings", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var settings = (VelorenPort.Server.Settings.Settings)field.GetValue(server)!;
+        Assert.Equal("Custom", settings.ServerName);
+    }
+}

--- a/VelorenPort/Server/Src/Cmd.cs
+++ b/VelorenPort/Server/Src/Cmd.cs
@@ -114,6 +114,26 @@ public static class Cmd
                     emitter.Emit(new ChatEvent(msg, true));
                 }
                 return gText;
+            case ServerChatCommand.Ban:
+                if (args.Length >= 2)
+                {
+                    var reason = string.Join(' ', args.Skip(1));
+                    server.BanPlayer(args[0], reason);
+                    return $"Banned {args[0]}";
+                }
+                return "Usage: /ban <username> <reason>";
+            case ServerChatCommand.Unban:
+                if (args.Length >= 1)
+                {
+                    server.UnbanPlayer(args[0]);
+                    return $"Unbanned {args[0]}";
+                }
+                return "Usage: /unban <username>";
+            case ServerChatCommand.Stats:
+                return server.GetStats();
+            case ServerChatCommand.ReloadConfig:
+                server.ReloadConfiguration();
+                return "Configuration reloaded";
             default:
                 return "Unknown command";
         }


### PR DESCRIPTION
## Summary
- add ban/unban, stats and reload-config commands
- support ban listing in CLI
- implement server-side actions for new commands
- handle new CLI messages
- add CLI tests for new commands

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686191583a54832896ff23afe04dec48