### PR TITLE
Improve EventManager debug checks

### DIFF
--- a/VelorenPort/Server.Tests/EventManagerDebugTests.cs
+++ b/VelorenPort/Server.Tests/EventManagerDebugTests.cs
@@ -19,4 +19,33 @@ public class EventManagerDebugTests
         Assert.Throws<InvalidOperationException>(() => manager.DebugCheckAllConsumed());
 #endif
     }
+
+    [Fact]
+    public void DebugCheckPassesWhenEventsConsumedOnce()
+    {
+        var manager = new EventManager();
+        using (var emitter = manager.GetEmitter<TeleportToPositionEvent>())
+        {
+            emitter.Emit(new TeleportToPositionEvent(new Uid(1), float3.zero));
+        }
+        _ = manager.Drain<TeleportToPositionEvent>();
+#if DEBUG
+        manager.DebugCheckAllConsumed();
+#endif
+    }
+
+    [Fact]
+    public void DebugCheckThrowsOnMultipleConsumers()
+    {
+        var manager = new EventManager();
+        using (var emitter = manager.GetEmitter<TeleportToPositionEvent>())
+        {
+            emitter.Emit(new TeleportToPositionEvent(new Uid(1), float3.zero));
+        }
+        _ = manager.Drain<TeleportToPositionEvent>();
+        _ = manager.Drain<TeleportToPositionEvent>();
+#if DEBUG
+        Assert.Throws<InvalidOperationException>(() => manager.DebugCheckAllConsumed());
+#endif
+    }
 }


### PR DESCRIPTION
## Summary
- make debug handler check match rust logic
- test event manager's debug behaviour

## Testing
- `dotnet test VelorenPort/VelorenPort.sln` *(fails: Record member must be a readable instance property)*

------
https://chatgpt.com/codex/tasks/task_e_6861915bc66c8328bcd8f91a5df7b899