### PR TITLE
Implement population event recording and trading routes

### DIFF
--- a/VelorenPort/World.Tests/CivEconTests.cs
+++ b/VelorenPort/World.Tests/CivEconTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using VelorenPort.World.Civ;
+using VelorenPort.World.Site;
 using Xunit;
 
 namespace World.Tests;
@@ -19,5 +21,21 @@ public class CivEconTests
         var (q, spent) = Econ.BuyUnits(rng, sell, 3f, 3f, 10f);
         Assert.Equal(3f, q, 3);
         Assert.True(spent >= 4f && spent <= 6f);
+    }
+
+    [Fact]
+    public void Tick_RecordsStageOrder()
+    {
+        var (world, index) = World.World.Empty();
+        var a = new Site.Site { Position = VelorenPort.NativeMath.int2.zero };
+        var b = new Site.Site { Position = new VelorenPort.NativeMath.int2(1, 0) };
+        var idA = index.Sites.Insert(a);
+        var idB = index.Sites.Insert(b);
+        index.Caravans.Add(new Caravan(new[] { idA, idB }));
+
+        index.EconomyContext.Tick(index, 1f);
+
+        var stages = index.EconomyContext.StageHistory.Select(s => s.Stage).ToArray();
+        Assert.Equal(new[] { EconomyStage.Deliveries, EconomyStage.TickSites, EconomyStage.UpdateMarkets }, stages);
     }
 }

--- a/VelorenPort/World.Tests/CivGeneratorTests.cs
+++ b/VelorenPort/World.Tests/CivGeneratorTests.cs
@@ -75,4 +75,21 @@ public class CivGeneratorTests
         var site = index.Sites.Items[0];
         Assert.True(stats.GetEventCount(site.Name, GenStatEventKind.PopulationBirth) > 0);
     }
+
+    [Fact]
+    public void Generate_CreatesTradingRoute()
+    {
+        var (world, index) = World.Empty();
+        CivGenerator.Generate(world, index, 3);
+        Assert.NotEmpty(index.TradingRoutes);
+        Assert.True(index.TradingRoutes[0].Sites.Count >= 3);
+    }
+
+    [Fact]
+    public void Generate_RecordsBirthEventsOnIndex()
+    {
+        var (world, index) = World.Empty();
+        CivGenerator.Generate(world, index, 1);
+        Assert.NotEmpty(index.PopulationEvents);
+    }
 }

--- a/VelorenPort/World/Src/Civ/CivGenerator.cs
+++ b/VelorenPort/World/Src/Civ/CivGenerator.cs
@@ -2,6 +2,7 @@ using System;
 using VelorenPort.CoreEngine;
 using VelorenPort.World.Site.Stats;
 using VelorenPort.NativeMath;
+using VelorenPort.World.Site;
 
 namespace VelorenPort.World.Civ
 {
@@ -19,6 +20,8 @@ namespace VelorenPort.World.Civ
             var rng = new Random((int)index.Seed);
             int2 mapSize = TerrainChunkSize.Blocks(world.Sim.GetSize());
 
+            var routeSites = new List<Store<Site.Site>.Id>();
+
             var kinds = Enum.GetValues<SiteKind>();
 
             for (int i = 0; i < count; i++)
@@ -29,8 +32,12 @@ namespace VelorenPort.World.Civ
                 var site = Site.SiteGenerator.Generate(rng, kind, pos, stats);
 
                 var siteId = index.Sites.Insert(site);
+                routeSites.Add(siteId);
                 SpawnPopulation(index, site, siteId, rng, stats);
             }
+            if (routeSites.Count > 1)
+                EconomySim.AddTradingRoute(index, new TradingRoute(routeSites));
+
             stats?.Log();
         }
 
@@ -47,6 +54,7 @@ namespace VelorenPort.World.Civ
                 var npcId = index.Npcs.Insert(npc);
                 site.Population.Add(npcId);
                 stats?.RecordEvent(site.Name, GenStatEventKind.PopulationBirth);
+                index.RecordPopulationEvent(new PopulationEvent(PopulationEventType.Birth, npcId, siteId));
             }
         }
     }

--- a/VelorenPort/World/Src/Site/Economy/Context.cs
+++ b/VelorenPort/World/Src/Site/Economy/Context.cs
@@ -55,6 +55,7 @@ public class EconomyContext
 
         LogStage(EconomyStage.UpdateMarkets);
         EconomySim.UpdateMarkets(index);
+        EconomySim.UpdatePopulation(index, dt);
         foreach (var (id, site) in index.Sites.Enumerate())
         {
             var dict = MarketPrices.GetValueOrDefault(id);

--- a/VelorenPort/World/Src/WorldIndex.cs
+++ b/VelorenPort/World/Src/WorldIndex.cs
@@ -30,6 +30,9 @@ namespace VelorenPort.World
         public Weather CurrentWeather { get; set; } = new Weather(0f, 0f, float2.zero);
         public Unity.Entities.EntityManager EntityManager { get; } = new Unity.Entities.EntityManager();
 
+        public void AddTradingRoute(Site.TradingRoute route) => TradingRoutes.Add(route);
+        public void RecordPopulationEvent(Site.PopulationEvent ev) => PopulationEvents.Add(ev);
+
         public WorldIndex(uint seed)
         {
             Seed = seed;


### PR DESCRIPTION
## Summary
- record trading routes and population events during civ generation
- expose helpers on `WorldIndex` for logging events
- keep population up to date in `EconomyContext.Tick`
- test new behaviour in generator and economy tests

## Testing
- `dotnet test VelorenPort/VelorenPort.sln --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861962fc58c8328bf0f69aecc05c48e