### PR TITLE
Add navmesh builder and tests

### DIFF
--- a/VelorenPort/World.Tests/PathfindingTests.cs
+++ b/VelorenPort/World.Tests/PathfindingTests.cs
@@ -167,4 +167,24 @@ public class PathfindingTests
         Assert.DoesNotContain(new int2(1,0), path!.Nodes);
         Assert.DoesNotContain(new int2(1,1), path!.Nodes);
     }
+
+    [Fact]
+    public void BuildNavMesh_FlagsWaterAsBlocked()
+    {
+        var sim = new WorldSim(0, new int2(3,3));
+        var chunk = sim.Get(new int2(1,1))!;
+        chunk.WaterAlt = chunk.Alt + 10f;
+        sim.Set(new int2(1,1), chunk);
+
+        var mesh = Pathfinding.BuildNavMesh(sim);
+        var searcher = new Searcher(
+            Land.FromSim(sim),
+            new SearchCfg(0f, 0f),
+            navMesh: mesh);
+
+        var path = searcher.Search(new int2(0,1), new int2(2,1));
+
+        Assert.NotNull(path);
+        Assert.DoesNotContain(new int2(1,1), path!.Nodes);
+    }
 }

--- a/VelorenPort/World/Src/Pathfinding.cs
+++ b/VelorenPort/World/Src/Pathfinding.cs
@@ -184,4 +184,36 @@ namespace VelorenPort.World {
 
         public static float EstimateCost(int2 a, int2 b) => math.length((float2)(a - b));
     }
+
+    /// <summary>
+    /// Utility helpers for pathfinding structures.
+    /// </summary>
+    public static class Pathfinding
+    {
+        /// <summary>
+        /// Build a simple navmesh directly from <see cref="WorldSim"/> data.
+        /// Chunks with water above the surface or with gradient larger than
+        /// <paramref name="maxGradient"/> are considered non walkable.
+        /// </summary>
+        public static NavMesh BuildNavMesh(WorldSim sim, float maxGradient = 1f)
+        {
+            var size = sim.GetSize();
+            var grid = new NavGrid(size);
+            for (int y = 0; y < size.y; y++)
+            for (int x = 0; x < size.x; x++)
+            {
+                var pos = new int2(x, y);
+                var chunk = sim.Get(pos);
+                bool blocked = true;
+                if (chunk != null)
+                {
+                    float grad = sim.GetGradientApprox(TerrainChunkSize.CposToWposCenter(pos)) ?? 0f;
+                    blocked = chunk.WaterAlt > chunk.Alt || grad > maxGradient;
+                }
+                grid.SetBlocked(pos, blocked);
+            }
+
+            return NavMesh.Generate(grid);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- implement simple navmesh builder using WorldSim terrain
- allow Searcher to use navmesh
- test navmesh building from simulation

## Testing
- `dotnet test VelorenPort/World.Tests/World.Tests.csproj` *(fails: project build errors)*

------
https://chatgpt.com/codex/tasks/task_e_686196374e08832898a13ff49ebf15f3