### PR TITLE
Add compressed biome volumes and terrain brush

### DIFF
--- a/VelorenPort/CoreEngine.Tests/BiomeVolumeTests.cs
+++ b/VelorenPort/CoreEngine.Tests/BiomeVolumeTests.cs
@@ -1,0 +1,31 @@
+using System.Linq;
+using VelorenPort.CoreEngine;
+using VelorenPort.CoreEngine.Terrain;
+using VelorenPort.CoreEngine.Volumes;
+using VelorenPort.NativeMath;
+
+namespace CoreEngine.Tests;
+
+public class BiomeVolumeTests
+{
+    [Fact]
+    public void CompressedBiome_Conversions()
+    {
+        CompressedBiome c = BiomeKind.Forest;
+        BiomeKind b = c;
+        Assert.Equal(BiomeKind.Forest, b);
+    }
+
+    [Fact]
+    public void RoundTrip_Compression()
+    {
+        var vol = new BiomeVolume(new int3(2,2,1), BiomeKind.Void);
+        vol.Set(new int3(0,0,0), BiomeKind.Forest);
+        vol.Set(new int3(1,0,0), BiomeKind.Desert);
+        var shared = vol.ToShared();
+        var back = BiomeVolume.FromShared(shared);
+        var list1 = vol.Cells().Select(c => c.Biome).ToArray();
+        var list2 = back.Cells().Select(c => c.Biome).ToArray();
+        Assert.Equal(list1, list2);
+    }
+}

--- a/VelorenPort/CoreEngine.Tests/BrushTests.cs
+++ b/VelorenPort/CoreEngine.Tests/BrushTests.cs
@@ -1,0 +1,26 @@
+using VelorenPort.CoreEngine.Terrain;
+using VelorenPort.CoreEngine;
+using VelorenPort.NativeMath;
+
+namespace CoreEngine.Tests;
+
+public class BrushTests
+{
+    [Fact]
+    public void FillBox_WritesExpectedCells()
+    {
+        var vol = new Vol<int>(new int3(3,3,1));
+        Brush.FillBox(vol, int3.zero, new int3(2,2,1), 7);
+        Assert.Equal(7, vol.Get(new int3(1,1,0)));
+        Assert.Equal(0, vol.Get(new int3(2,2,0)));
+    }
+
+    [Fact]
+    public void FillSphere_WritesWithinRadius()
+    {
+        var vol = new Vol<int>(new int3(5,5,5));
+        Brush.FillSphere(vol, new int3(2,2,2), 1, 9);
+        Assert.Equal(9, vol.Get(new int3(2,2,2)));
+        Assert.Equal(0, vol.Get(new int3(0,0,0)));
+    }
+}

--- a/VelorenPort/CoreEngine/Src/terrain/BoxEditor.cs
+++ b/VelorenPort/CoreEngine/Src/terrain/BoxEditor.cs
@@ -1,0 +1,32 @@
+using System;
+using VelorenPort.NativeMath;
+
+namespace VelorenPort.CoreEngine.Terrain;
+
+/// <summary>
+/// Axis-aligned box editor that fills a region with the provided value.
+/// </summary>
+[Serializable]
+public class BoxEditor<T> : ITerrainEditor<T>
+{
+    private readonly int3 _size;
+    private readonly T _value;
+
+    public BoxEditor(int3 size, T value)
+    {
+        _size = size;
+        _value = value;
+    }
+
+    public void Apply(IWriteVol<T> volume, int3 origin)
+    {
+        for (int x = 0; x < _size.x; x++)
+        for (int y = 0; y < _size.y; y++)
+        for (int z = 0; z < _size.z; z++)
+        {
+            var pos = origin + new int3(x, y, z);
+            if (volume.InBounds(pos))
+                volume.Set(pos, _value);
+        }
+    }
+}

--- a/VelorenPort/CoreEngine/Src/terrain/Brush.cs
+++ b/VelorenPort/CoreEngine/Src/terrain/Brush.cs
@@ -1,0 +1,27 @@
+using VelorenPort.NativeMath;
+
+namespace VelorenPort.CoreEngine.Terrain;
+
+/// <summary>
+/// Utility helpers for editing terrain volumes.
+/// </summary>
+public static class Brush
+{
+    /// <summary>
+    /// Fill a sphere in <paramref name="volume"/> with <paramref name="value"/>.
+    /// </summary>
+    public static void FillSphere<T>(IWriteVol<T> volume, int3 origin, int radius, T value)
+    {
+        var editor = new SphereEditor<T>(radius, value);
+        editor.Apply(volume, origin);
+    }
+
+    /// <summary>
+    /// Fill an axis-aligned box in <paramref name="volume"/>.
+    /// </summary>
+    public static void FillBox<T>(IWriteVol<T> volume, int3 origin, int3 size, T value)
+    {
+        var editor = new BoxEditor<T>(size, value);
+        editor.Apply(volume, origin);
+    }
+}

--- a/VelorenPort/CoreEngine/Src/volumes/BiomeVolume.cs
+++ b/VelorenPort/CoreEngine/Src/volumes/BiomeVolume.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using VelorenPort.NativeMath;
+using VelorenPort.CoreEngine.Terrain;
+
+namespace VelorenPort.CoreEngine.Volumes;
+
+/// <summary>
+/// 3D volume storing <see cref="BiomeKind"/> values with helpers to
+/// serialize to a compressed representation.
+/// </summary>
+[Serializable]
+public class BiomeVolume
+{
+    private readonly Vol<BiomeKind> _vol;
+
+    public BiomeVolume(int3 size, BiomeKind fill)
+    {
+        _vol = new Vol<BiomeKind>(size);
+        _vol.Fill(fill);
+    }
+
+    public int3 Size => _vol.Size;
+
+    public IEnumerable<(int3 Pos, BiomeKind Biome)> Cells() => _vol.Cells();
+
+    public BiomeKind Get(int3 pos) => _vol.Get(pos);
+
+    public void Set(int3 pos, BiomeKind value) => _vol.Set(pos, value);
+
+    public SharedBiomeVolume ToShared()
+    {
+        var list = new List<CompressedBiome>();
+        foreach (var (_, biome) in _vol.Cells())
+            list.Add((CompressedBiome)biome);
+        var compressed = TerrainCompressor.Compress(list);
+        return new SharedBiomeVolume(_vol.Size, compressed);
+    }
+
+    public static BiomeVolume FromShared(SharedBiomeVolume shared)
+    {
+        var vol = new BiomeVolume(shared.Size, BiomeKind.Void);
+        var data = TerrainCompressor.Decompress(shared.Data);
+        int idx = 0;
+        foreach (var pos in new DefaultPosEnumerator(int3.zero, vol.Size))
+        {
+            if (idx >= data.Count) break;
+            vol.Set(pos, (BiomeKind)data[idx]);
+            idx++;
+        }
+        return vol;
+    }
+}
+
+/// <summary>
+/// Serializable representation of a <see cref="BiomeVolume"/> using run-length
+/// encoding via <see cref="TerrainCompressor"/>.
+/// </summary>
+[Serializable]
+public class SharedBiomeVolume
+{
+    public int3 Size { get; set; }
+    public List<(CompressedBiome Value, int Count)> Data { get; set; }
+
+    public SharedBiomeVolume(int3 size, List<(CompressedBiome Value, int Count)> data)
+    {
+        Size = size;
+        Data = data;
+    }
+}

--- a/VelorenPort/CoreEngine/Src/volumes/CompressedBiome.cs
+++ b/VelorenPort/CoreEngine/Src/volumes/CompressedBiome.cs
@@ -1,0 +1,23 @@
+using System;
+using VelorenPort.CoreEngine;
+
+namespace VelorenPort.CoreEngine.Volumes;
+
+/// <summary>
+/// Byte-sized representation of a <see cref="BiomeKind"/> for compact storage.
+/// </summary>
+[Serializable]
+public struct CompressedBiome
+{
+    public byte Value;
+
+    public static implicit operator CompressedBiome(BiomeKind biome)
+    {
+        return new CompressedBiome { Value = (byte)biome };
+    }
+
+    public static implicit operator BiomeKind(CompressedBiome cb)
+    {
+        return (BiomeKind)cb.Value;
+    }
+}


### PR DESCRIPTION
## Summary
- implement compressed biome structures under volumes
- add BiomeVolume with RLE serialization via TerrainCompressor
- provide BoxEditor and Brush helpers for terrain editing
- test biome compression and brush utilities

## Testing
- `dotnet test VelorenPort/VelorenPort.sln -c Release --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861971defc08328981dc65c6f879870