### PR TITLE
Implement terrain file rotation

### DIFF
--- a/VelorenPort/CoreEngine/Src/volumes/BiomeVolume.cs
+++ b/VelorenPort/CoreEngine/Src/volumes/BiomeVolume.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using VelorenPort.NativeMath;
+using System.Linq;
 using VelorenPort.CoreEngine.Terrain;
 
 namespace VelorenPort.CoreEngine.Volumes;
@@ -40,7 +41,7 @@ public class BiomeVolume
     public static BiomeVolume FromShared(SharedBiomeVolume shared)
     {
         var vol = new BiomeVolume(shared.Size, BiomeKind.Void);
-        var data = TerrainCompressor.Decompress(shared.Data);
+        var data = TerrainCompressor.Decompress(shared.Data).ToList();
         int idx = 0;
         foreach (var pos in new DefaultPosEnumerator(int3.zero, vol.Size))
         {

--- a/VelorenPort/Server.Tests/TerrainRotationIntegrationTests.cs
+++ b/VelorenPort/Server.Tests/TerrainRotationIntegrationTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using System.Linq;
+using VelorenPort.NativeMath;
+using VelorenPort.Server;
+using VelorenPort.World;
+
+namespace Server.Tests;
+
+public class TerrainRotationIntegrationTests
+{
+    [Fact]
+    public void SavesRotateWhenLimitExceeded()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        var tp = new TerrainPersistence(dir, rotationLimit: 2);
+        var key = new int2(0, 0);
+        var pos = new int3(1, 1, 0);
+
+        for (int i = 0; i < 3; i++)
+        {
+            tp.SetBlock(pos, Block.Filled(BlockKind.Rock, 1, 1, 1));
+            tp.UnloadChunk(key);
+        }
+
+        var files = Directory.GetFiles(Path.Combine(dir, "terrain"), "chunk_0_0.dat*");
+        Assert.Contains(Path.Combine(dir, "terrain", "chunk_0_0.dat"), files);
+        Assert.Contains(Path.Combine(dir, "terrain", "chunk_0_0.dat.1"), files);
+        Assert.Contains(Path.Combine(dir, "terrain", "chunk_0_0.dat.2"), files);
+        Assert.Equal(3, files.Length);
+        Directory.Delete(dir, true);
+    }
+}

--- a/VelorenPort/Server/Src/GameServer.cs
+++ b/VelorenPort/Server/Src/GameServer.cs
@@ -75,7 +75,9 @@ namespace VelorenPort.Server
             _connections = new ConnectionHandler(Network);
             _settings = new Settings.Settings();
             _dispatcher = new Ecs.Dispatcher(_settings.DispatcherWorkers);
-            _terrainPersistence = new TerrainPersistence(DataDir.DefaultDataDirName);
+            _terrainPersistence = new TerrainPersistence(
+                DataDir.DefaultDataDirName,
+                _settings.TerrainArchiveLimit);
             _infoBroadcaster = new ServerInfoBroadcaster(OnServerInfo);
             _inviteManager = new InviteManager(this);
             (_chatCache, _chatExporter) = Chat.ChatCache.Create(TimeSpan.FromMinutes(1));
@@ -269,6 +271,7 @@ namespace VelorenPort.Server
         public void ReloadConfiguration()
         {
             _settings = Settings.Settings.Load(DataDir.DefaultDataDirName);
+            _terrainPersistence.RotationLimit = _settings.TerrainArchiveLimit;
         }
 
         /// <summary>Enumerate current bans for CLI display.</summary>

--- a/VelorenPort/Server/Src/Settings/Settings.cs
+++ b/VelorenPort/Server/Src/Settings/Settings.cs
@@ -18,6 +18,11 @@ namespace VelorenPort.Server.Settings {
         public bool EnableDiscovery { get; set; } = false;
         public string DiscoveryAddress { get; set; } = "127.0.0.1:14006";
 
+        /// <summary>
+        /// Number of archived terrain files to keep. Zero disables rotation.
+        /// </summary>
+        public int TerrainArchiveLimit { get; set; } = 0;
+
         public AdminList Admins { get; set; } = new();
         public Banlist Banlist { get; set; } = new();
         public Whitelist Whitelist { get; set; } = new();


### PR DESCRIPTION
## Summary
- add a rotation limit parameter to `TerrainPersistence`
- expose rotation setting with `TerrainArchiveLimit`
- pass rotation limit through `GameServer`
- fix `BiomeVolume` deserialization helper for tests
- test terrain file rotation

## Testing
- `dotnet build VelorenPort/VelorenPort.sln` *(fails: UdpHandshakeStream override errors)*

------
https://chatgpt.com/codex/tasks/task_e_68619b633ea08328849ef64eef4e58aa