### PR TITLE
Implement priority congestion control

### DIFF
--- a/VelorenPort/Network/Src/Network.cs
+++ b/VelorenPort/Network/Src/Network.cs
@@ -350,15 +350,19 @@ namespace VelorenPort.Network {
             _ = Task.Run(async () => {
                 while (true) {
                     var moved = false;
-                    while (a.TryDequeueOutgoing(out var am)) {
-                        b.PushIncoming(am);
-                        a.ReportSent(am.Data.Length);
-                        moved = true;
+                    while (a.Owner != null && a.Owner.TryDequeueOutgoing(out var sa, out var am)) {
+                        if (sa == a) {
+                            b.PushIncoming(am);
+                            a.ReportSent(am.Data.Length);
+                            moved = true;
+                        }
                     }
-                    while (b.TryDequeueOutgoing(out var bm)) {
-                        a.PushIncoming(bm);
-                        b.ReportSent(bm.Data.Length);
-                        moved = true;
+                    while (b.Owner != null && b.Owner.TryDequeueOutgoing(out var sb, out var bm)) {
+                        if (sb == b) {
+                            a.PushIncoming(bm);
+                            b.ReportSent(bm.Data.Length);
+                            moved = true;
+                        }
                     }
                     if (!moved)
                         await Task.Delay(10);

--- a/VelorenPort/Network/Src/Participant.cs
+++ b/VelorenPort/Network/Src/Participant.cs
@@ -25,6 +25,8 @@ namespace VelorenPort.Network {
         private readonly ConcurrentQueue<Stream>[] _incomingQueues = new ConcurrentQueue<Stream>[Stream.PriorityLevels];
         private int _currentIncomingPrio;
         private int _remainingIncomingWeight;
+        private int _currentOutgoingPrio;
+        private int _remainingOutgoingWeight;
         private readonly SemaphoreSlim _streamSignal = new(0);
         private readonly ConcurrentQueue<ParticipantEvent> _events = new();
         private readonly SemaphoreSlim _eventSignal = new(0);
@@ -99,6 +101,8 @@ namespace VelorenPort.Network {
                 _incomingQueues[i] = new ConcurrentQueue<Stream>();
             _currentIncomingPrio = 0;
             _remainingIncomingWeight = Stream.GetWeight(0);
+            _currentOutgoingPrio = 0;
+            _remainingOutgoingWeight = Stream.GetWeight(0);
             _metrics?.ParticipantConnected(Id);
             _bandwidthTimer = new Timer(_ =>
             {
@@ -248,6 +252,34 @@ namespace VelorenPort.Network {
             _currentIncomingPrio = (_currentIncomingPrio + 1) % _incomingQueues.Length;
             _remainingIncomingWeight = Stream.GetWeight(_currentIncomingPrio);
             stream = null!;
+            return false;
+        }
+
+        internal bool TryDequeueOutgoing(out Stream stream, out Message msg)
+        {
+            for (int i = 0; i < Stream.PriorityLevels; i++)
+            {
+                int prio = (_currentOutgoingPrio + i) % Stream.PriorityLevels;
+                foreach (var st in _streams.Values)
+                {
+                    if (st.Priority != prio) continue;
+                    if (st.TryDequeueOutgoing(out msg))
+                    {
+                        stream = st;
+                        _remainingOutgoingWeight--;
+                        if (_remainingOutgoingWeight <= 0)
+                        {
+                            _currentOutgoingPrio = (prio + 1) % Stream.PriorityLevels;
+                            _remainingOutgoingWeight = Stream.GetWeight(_currentOutgoingPrio);
+                        }
+                        return true;
+                    }
+                }
+            }
+            _currentOutgoingPrio = (_currentOutgoingPrio + 1) % Stream.PriorityLevels;
+            _remainingOutgoingWeight = Stream.GetWeight(_currentOutgoingPrio);
+            stream = null!;
+            msg = default!;
             return false;
         }
 


### PR DESCRIPTION
## Summary
- support per-priority congestion windows in `Stream`
- add outgoing stream scheduling in `Participant`
- update local relay to use participant scheduling
- test priority handling via MPSC connection

## Testing
- `dotnet test VelorenPort/VelorenPort.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619b7811548328964f5febc96ab3c6