### PR TITLE
Port util helpers from Rust

### DIFF
--- a/VelorenPort/CoreEngine/Src/MathUtil.cs
+++ b/VelorenPort/CoreEngine/Src/MathUtil.cs
@@ -22,6 +22,17 @@ namespace VelorenPort.CoreEngine
         }
 
         /// <summary>
+        /// Faster but less smooth variant of <see cref="Close"/>.
+        /// Matches the behaviour of <c>close_fast</c> from the Rust project.
+        /// </summary>
+        public static float CloseFast(float x, float target, float falloff, int falloffStrength)
+        {
+            float t = (x - target) / falloff;
+            float value = 1f - math.pow(t, falloffStrength * 2);
+            return math.max(0f, value);
+        }
+
+        /// <summary>
         /// Create a quaternion that rotates <paramref name="forward"/> toward the given
         /// direction. Simplified version of Unity's <c>Quaternion.LookRotation</c>.
         /// </summary>

--- a/VelorenPort/World.Tests/MapArrayTests.cs
+++ b/VelorenPort/World.Tests/MapArrayTests.cs
@@ -1,0 +1,27 @@
+using System;
+using VelorenPort.World.Util;
+using Xunit;
+
+namespace World.Tests;
+
+public class MapArrayTests
+{
+    private enum TestEnum { A, B, C }
+
+    [Fact]
+    public void Indexing_Works()
+    {
+        var map = new MapArray<TestEnum, int>(0);
+        map[TestEnum.B] = 5;
+        Assert.Equal(5, map[TestEnum.B]);
+        Assert.Equal(0, map[TestEnum.C]);
+    }
+
+    [Fact]
+    public void EnumHelpers_Work()
+    {
+        int idx = EnumIndex.IndexFromEnum(TestEnum.C);
+        Assert.Equal(2, idx);
+        Assert.Equal(TestEnum.B, EnumIndex.EnumFromIndex<TestEnum>(1));
+    }
+}

--- a/VelorenPort/World.Tests/MapVecTests.cs
+++ b/VelorenPort/World.Tests/MapVecTests.cs
@@ -1,0 +1,22 @@
+using VelorenPort.World.Util;
+using Xunit;
+
+namespace World.Tests;
+
+public class MapVecTests
+{
+    [Fact]
+    public void Get_ReturnsDefaultWhenMissing()
+    {
+        var mv = new MapVec<int, int>(0);
+        Assert.Equal(0, mv.Get(5));
+    }
+
+    [Fact]
+    public void Set_StoresValue()
+    {
+        var mv = new MapVec<string, int>(-1);
+        mv.Set("hello", 42);
+        Assert.Equal(42, mv["hello"]);
+    }
+}

--- a/VelorenPort/World.Tests/MathUtilTests.cs
+++ b/VelorenPort/World.Tests/MathUtilTests.cs
@@ -1,0 +1,16 @@
+using VelorenPort.CoreEngine;
+using Xunit;
+
+namespace World.Tests;
+
+public class MathUtilTests
+{
+    [Fact]
+    public void CloseFast_BehavesLikeClamp()
+    {
+        float v1 = MathUtil.CloseFast(0f, 0f, 1f, 1);
+        Assert.Equal(1f, v1, 3);
+        float v2 = MathUtil.CloseFast(2f, 0f, 1f, 1);
+        Assert.Equal(0f, v2, 3);
+    }
+}

--- a/VelorenPort/World/Src/Site/Economy/Market.cs
+++ b/VelorenPort/World/Src/Site/Economy/Market.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using VelorenPort.NativeMath;
 using VelorenPort.CoreEngine;
+using VelorenPort.World.Util;
 
 namespace VelorenPort.World.Site.Economy;
 
@@ -12,14 +13,14 @@ namespace VelorenPort.World.Site.Economy;
 [Serializable]
 public class Market
 {
-    public Dictionary<Good, float> Prices { get; } = new();
-    public Dictionary<Good, float> Demand { get; } = new();
+    public MapVec<Good, float> Prices { get; } = new(1f);
+    public MapVec<Good, float> Demand { get; } = new(0f);
 
     /// <summary>Current price of a good or 1 if unknown.</summary>
-    public float GetPrice(Good good) => Prices.TryGetValue(good, out var p) ? p : 1f;
+    public float GetPrice(Good good) => Prices[good];
 
     /// <summary>Current demand for a good.</summary>
-    public float GetDemand(Good good) => Demand.TryGetValue(good, out var d) ? d : 0f;
+    public float GetDemand(Good good) => Demand[good];
 
     /// <summary>Add to the demand for the given good.</summary>
     public void AddDemand(Good good, float amount)

--- a/VelorenPort/World/Src/UnitChooser.cs
+++ b/VelorenPort/World/Src/UnitChooser.cs
@@ -1,6 +1,7 @@
 using System;
 using VelorenPort.NativeMath;
 using VelorenPort.CoreEngine;
+using VelorenPort.World.Util;
 
 namespace VelorenPort.World
 {
@@ -9,7 +10,7 @@ namespace VelorenPort.World
     /// <c>UnitChooser</c> from the Rust project.
     /// </summary>
     [Serializable]
-    public struct UnitChooser
+    public struct UnitChooser : Util.ISampler<uint, (int2, int2)>
     {
         private readonly RandomPerm _perm;
 

--- a/VelorenPort/World/Src/Util/MapArray.cs
+++ b/VelorenPort/World/Src/Util/MapArray.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+
+namespace VelorenPort.World.Util;
+
+/// <summary>
+/// Simple array indexed by an enum type. Rough translation of Rust's
+/// <c>map_array</c> utilities.
+/// </summary>
+public class MapArray<TEnum, TValue> where TEnum : Enum
+{
+    private readonly TValue[] _data;
+
+    public MapArray(TValue defaultValue)
+    {
+        var values = Enum.GetValues<TEnum>();
+        _data = new TValue[values.Length];
+        for (int i = 0; i < _data.Length; i++)
+            _data[i] = defaultValue;
+    }
+
+    public TValue this[TEnum key]
+    {
+        get => _data[Convert.ToInt32(key)];
+        set => _data[Convert.ToInt32(key)] = value;
+    }
+
+    public IEnumerable<(TEnum Key, TValue Value)> Items()
+    {
+        foreach (TEnum e in Enum.GetValues<TEnum>())
+            yield return (e, this[e]);
+    }
+}
+
+/// <summary>Helper functions for mapping between enums and indices.</summary>
+public static class EnumIndex
+{
+    public static int IndexFromEnum<TEnum>(TEnum value) where TEnum : Enum
+        => Array.IndexOf(Enum.GetValues<TEnum>(), value);
+
+    public static TEnum EnumFromIndex<TEnum>(int index) where TEnum : Enum
+    {
+        var arr = Enum.GetValues<TEnum>();
+        return (TEnum)arr.GetValue(index)!;
+    }
+}

--- a/VelorenPort/World/Src/Util/MapVec.cs
+++ b/VelorenPort/World/Src/Util/MapVec.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+
+namespace VelorenPort.World.Util;
+
+/// <summary>
+/// Deterministic dictionary with a default value, translated from Rust's
+/// <c>MapVec</c>.
+/// </summary>
+public class MapVec<TKey, TValue> where TKey : notnull
+{
+    private readonly Dictionary<TKey, TValue> _entries = new();
+    private readonly TValue _default;
+
+    public MapVec(TValue defaultValue)
+    {
+        _default = defaultValue;
+    }
+
+    public static MapVec<TKey, TValue> FromList(IEnumerable<(TKey Key, TValue Value)> entries, TValue defaultValue)
+    {
+        var map = new MapVec<TKey, TValue>(defaultValue);
+        foreach (var (k, v) in entries)
+            map._entries[k] = v;
+        return map;
+    }
+
+    public TValue Get(TKey key) => _entries.TryGetValue(key, out var v) ? v : _default;
+
+    public TValue GetOrCreate(TKey key)
+    {
+        if (!_entries.TryGetValue(key, out var v))
+        {
+            v = _default;
+            _entries[key] = v;
+        }
+        return v;
+    }
+
+    public void Set(TKey key, TValue value) => _entries[key] = value;
+
+    public IEnumerable<(TKey Key, TValue Value)> Items()
+    {
+        foreach (var kv in _entries)
+            yield return (kv.Key, kv.Value);
+    }
+
+    public MapVec<TKey, TOut> Map<TOut>(System.Func<TKey, TValue, TOut> f, TOut defaultValue)
+    {
+        var result = new MapVec<TKey, TOut>(defaultValue);
+        foreach (var kv in _entries)
+            result.Set(kv.Key, f(kv.Key, kv.Value));
+        return result;
+    }
+
+    public TValue this[TKey key]
+    {
+        get => Get(key);
+        set => Set(key, value);
+    }
+}

--- a/VelorenPort/World/Src/Util/Sampler.cs
+++ b/VelorenPort/World/Src/Util/Sampler.cs
@@ -1,0 +1,17 @@
+namespace VelorenPort.World.Util;
+
+/// <summary>
+/// Generic sampler interface mirroring Rust's <c>Sampler</c> trait.
+/// </summary>
+public interface ISampler<in TIndex, out TSample>
+{
+    TSample Get(TIndex index);
+}
+
+/// <summary>
+/// Mutable sampler interface comparable to Rust's <c>SamplerMut</c>.
+/// </summary>
+public interface ISamplerMut<TIndex, TSample>
+{
+    TSample Get(TIndex index);
+}


### PR DESCRIPTION
## Summary
- add `ISampler` interface and util containers `MapVec` and `MapArray`
- port `close_fast` to `MathUtil`
- implement `ISampler` in `UnitChooser`
- use `MapVec` in economy `Market`
- add tests for new utilities

## Testing
- `dotnet test VelorenPort.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619ed51aa08328aaf00232ebf1b051