### PR TITLE
Add priority queue and cancellation to SlowJobPool

### DIFF
--- a/VelorenPort/CoreEngine.Tests/SlowJobPoolPriorityTests.cs
+++ b/VelorenPort/CoreEngine.Tests/SlowJobPoolPriorityTests.cs
@@ -1,0 +1,55 @@
+using VelorenPort.CoreEngine;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreEngine.Tests;
+
+public class SlowJobPoolPriorityTests
+{
+    [Fact]
+    public async Task HigherPriorityRunsFirst()
+    {
+        var pool = new SlowJobPool(1);
+        pool.Configure("a", _ => 1);
+        var order = new List<int>();
+        var start1 = new TaskCompletionSource();
+        var finish1 = new TaskCompletionSource();
+        pool.Spawn("a", ct => { order.Add(1); start1.SetResult(); finish1.Task.Wait(); }, priority:1);
+        await start1.Task;
+        var t2Done = new TaskCompletionSource();
+        var t3Done = new TaskCompletionSource();
+        pool.Spawn("a", ct => { order.Add(2); t2Done.SetResult(); }, priority:1);
+        pool.Spawn("a", ct => { order.Add(3); t3Done.SetResult(); }, priority:0);
+        finish1.SetResult();
+        await Task.WhenAll(t2Done.Task, t3Done.Task);
+        Assert.Equal(new[] {1,3,2}, order);
+    }
+
+    [Fact]
+    public async Task CancelRunning_SignalsToken()
+    {
+        var pool = new SlowJobPool(1);
+        pool.Configure("a", _ => 1);
+        var tcs = new TaskCompletionSource();
+        bool canceled = false;
+        var handle = pool.Spawn("a", ct =>
+        {
+            try
+            {
+                while (!ct.IsCancellationRequested)
+                    Thread.Sleep(5);
+                canceled = true;
+            }
+            finally
+            {
+                tcs.SetResult();
+            }
+        });
+        await Task.Delay(20);
+        var res = pool.CancelRunning(handle);
+        await tcs.Task;
+        Assert.True(res);
+        Assert.True(canceled);
+    }
+}

--- a/VelorenPort/CoreEngine/Src/slowjob/SlowJobPool.cs
+++ b/VelorenPort/CoreEngine/Src/slowjob/SlowJobPool.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace VelorenPort.CoreEngine {
@@ -18,7 +19,9 @@ namespace VelorenPort.CoreEngine {
         private class QueueItem {
             public ulong Id;
             public string Name = string.Empty;
-            public Action Task = null!;
+            public int Priority;
+            public Action<CancellationToken> Task = null!;
+            public CancellationTokenSource? Cts;
         }
 
         public struct SlowJob {
@@ -28,7 +31,7 @@ namespace VelorenPort.CoreEngine {
 
         private readonly int _globalLimit;
         private readonly Dictionary<string, Config> _configs = new();
-        private readonly Dictionary<string, Queue<QueueItem>> _queue = new();
+        private readonly Dictionary<string, PriorityQueue<QueueItem, int>> _queue = new();
         private int _running;
         private ulong _nextId;
 
@@ -43,17 +46,20 @@ namespace VelorenPort.CoreEngine {
             int limit = Math.Max(1, limitFunc(_globalLimit));
             _configs[name] = new Config { Limit = limit, Running = 0 };
             if (!_queue.ContainsKey(name))
-                _queue[name] = new Queue<QueueItem>();
+                _queue[name] = new PriorityQueue<QueueItem, int>();
         }
 
         /// <summary>
         /// Queue a job to be executed when resources are available.
         /// </summary>
-        public SlowJob Spawn(string name, Action job) {
+        public SlowJob Spawn(string name, Action job, int priority = 0)
+            => Spawn(name, _ => job(), priority);
+
+        public SlowJob Spawn(string name, Action<CancellationToken> job, int priority = 0) {
             if (!_configs.ContainsKey(name))
                 throw new InvalidOperationException($"Job '{name}' not configured");
-            var item = new QueueItem { Id = _nextId++, Name = name, Task = job };
-            _queue[name].Enqueue(item);
+            var item = new QueueItem { Id = _nextId++, Name = name, Task = job, Priority = priority };
+            _queue[name].Enqueue(item, priority);
             SpawnQueued();
             return new SlowJob { Name = name, Id = item.Id };
         }
@@ -61,12 +67,15 @@ namespace VelorenPort.CoreEngine {
         /// <summary>
         /// Attempt to run a job immediately; returns false if limits would be exceeded.
         /// </summary>
-        public bool TryRun(string name, Action job, out SlowJob handle) {
+        public bool TryRun(string name, Action job, out SlowJob handle, int priority = 0)
+            => TryRun(name, _ => job(), out handle, priority);
+
+        public bool TryRun(string name, Action<CancellationToken> job, out SlowJob handle, int priority = 0) {
             if (!CanSpawn(name)) {
                 handle = default;
                 return false;
             }
-            handle = SpawnInternal(name, job);
+            handle = SpawnInternal(name, job, priority);
             return true;
         }
 
@@ -76,36 +85,43 @@ namespace VelorenPort.CoreEngine {
             return cfg.Running < cfg.Limit;
         }
 
-        private SlowJob SpawnInternal(string name, Action job) {
-            var item = new QueueItem { Id = _nextId++, Name = name, Task = job };
+        private SlowJob SpawnInternal(string name, Action<CancellationToken> job, int priority) {
+            var item = new QueueItem { Id = _nextId++, Name = name, Task = job, Priority = priority };
             StartItem(item);
             return new SlowJob { Name = name, Id = item.Id };
         }
 
         private void SpawnQueued() {
             foreach (var (name, q) in _queue) {
-                while (q.Count > 0 && CanSpawn(name)) {
-                    StartItem(q.Dequeue());
+                while (q.TryPeek(out var item, out _) && CanSpawn(name)) {
+                    q.TryDequeue(out item!, out _);
+                    StartItem(item);
                 }
             }
         }
+
+        private readonly Dictionary<ulong, CancellationTokenSource> _runningTokens = new();
 
         private void StartItem(QueueItem item) {
             var cfg = _configs[item.Name];
             cfg.Running++;
             _running++;
             _configs[item.Name] = cfg;
+            var cts = new CancellationTokenSource();
+            item.Cts = cts;
+            _runningTokens[item.Id] = cts;
             Task.Run(() => {
-                try { item.Task(); } finally { Finish(item.Name); }
-            });
+                try { item.Task(cts.Token); } finally { Finish(item.Name, item.Id); }
+            }, cts.Token);
         }
 
-        private void Finish(string name) {
+        private void Finish(string name, ulong id) {
             if (_configs.TryGetValue(name, out var cfg)) {
                 cfg.Running = Math.Max(0, cfg.Running - 1);
                 _configs[name] = cfg;
             }
             _running = Math.Max(0, _running - 1);
+            _runningTokens.Remove(id);
             SpawnQueued();
         }
 
@@ -120,17 +136,29 @@ namespace VelorenPort.CoreEngine {
         /// </summary>
         public bool Cancel(SlowJob job) {
             if (_queue.TryGetValue(job.Name, out var q)) {
-                var arr = q.ToArray();
-                q.Clear();
+                var items = new List<QueueItem>();
                 bool removed = false;
-                foreach (var item in arr) {
+                while (q.TryDequeue(out var item, out _)) {
                     if (!removed && item.Id == job.Id) {
                         removed = true;
                         continue;
                     }
-                    q.Enqueue(item);
+                    items.Add(item);
                 }
+                foreach (var it in items)
+                    q.Enqueue(it, it.Priority);
                 return removed;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Attempt to cancel a running job.
+        /// </summary>
+        public bool CancelRunning(SlowJob job) {
+            if (_runningTokens.Remove(job.Id, out var cts)) {
+                cts.Cancel();
+                return true;
             }
             return false;
         }
@@ -138,14 +166,14 @@ namespace VelorenPort.CoreEngine {
         /// <summary>
         /// Spawn an asynchronous job and get a task that completes when done.
         /// </summary>
-        public Task SpawnAsync(string name, Func<Task> job)
+        public Task SpawnAsync(string name, Func<Task> job, int priority = 0)
         {
             var tcs = new TaskCompletionSource();
-            Spawn(name, async () =>
+            Spawn(name, async _ =>
             {
                 await job();
                 tcs.SetResult();
-            });
+            }, priority);
             return tcs.Task;
         }
     }


### PR DESCRIPTION
## Summary
- extend `SlowJobPool` with a priority-based queue using `PriorityQueue`
- track running job tokens and implement `CancelRunning`
- add tests for priority scheduling and cancellation behaviour

## Testing
- `dotnet test CoreEngine.Tests/CoreEngine.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68619ef11fcc83288d7465e08802fa9a