### PR TITLE
Validate credentials format and role checks

### DIFF
--- a/VelorenPort/Network.Tests/RustServerProtocolTests.cs
+++ b/VelorenPort/Network.Tests/RustServerProtocolTests.cs
@@ -39,4 +39,49 @@ public class RustServerProtocolTests
         await net.ShutdownAsync();
         await RustServerHarness.StopServerAsync(server);
     }
+
+    [Fact]
+    public void RejectsInvalidCredentials()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            _ = new Participant(
+                Pid.NewPid(),
+                new ConnectAddr.Mpsc(0),
+                Guid.NewGuid(),
+                null,
+                null,
+                null,
+                null,
+                HandshakeFeatures.None,
+                default,
+                null,
+                new ClientType.Game(),
+                new Credentials("not-a-guid"),
+                null);
+        });
+    }
+
+    [Fact]
+    public void RejectsInsufficientRole()
+    {
+        var creds = new Credentials(Guid.NewGuid().ToString());
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            _ = new Participant(
+                Pid.NewPid(),
+                new ConnectAddr.Mpsc(0),
+                Guid.NewGuid(),
+                null,
+                null,
+                null,
+                null,
+                HandshakeFeatures.None,
+                default,
+                null,
+                new ClientType.SilentSpectator(),
+                creds,
+                null);
+        });
+    }
 }

--- a/VelorenPort/Network/Src/Credentials.cs
+++ b/VelorenPort/Network/Src/Credentials.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace VelorenPort.Network {
     /// <summary>
     /// Simple credential container used during participant creation.
@@ -5,6 +7,6 @@ namespace VelorenPort.Network {
     public readonly struct Credentials {
         public string Value { get; }
         public Credentials(string value) { Value = value; }
-        public bool IsValid => !string.IsNullOrEmpty(Value);
+        public bool IsValid => Guid.TryParse(Value, out _);
     }
 }

--- a/VelorenPort/Network/Src/Participant.cs
+++ b/VelorenPort/Network/Src/Participant.cs
@@ -86,9 +86,9 @@ namespace VelorenPort.Network {
             Credentials = credentials ?? new Credentials(string.Empty);
             RoleRequirement = roleRequirement;
             if (!Credentials.IsValid)
-                throw new InvalidOperationException("Invalid credentials");
+                throw new InvalidOperationException("Invalid credential format");
             if (!ClientType.IsValidForRole(roleRequirement))
-                throw new InvalidOperationException("Client type not permitted for this role");
+                throw new InvalidOperationException("Insufficient admin role");
             _bandwidth = 0f;
             Secret = secret;
             _tcpClient = tcpClient;


### PR DESCRIPTION
## Summary
- verify that credentials are GUIDs
- reject connections with invalid credentials or insufficient role
- add tests checking constructor validation

## Testing
- `dotnet test VelorenPort/VelorenPort.sln -c Release` *(fails: CS0115 errors in UdpHandshakeStream)*

------
https://chatgpt.com/codex/tasks/task_e_6861a1d08f148328a6e4f95c5c6c75bd