### PR TITLE
Add scheduler metrics for averages and timeouts

### DIFF
--- a/VelorenPort/Network.Tests/SchedulerTimeoutTests.cs
+++ b/VelorenPort/Network.Tests/SchedulerTimeoutTests.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading.Tasks;
+using VelorenPort.Network;
+
+namespace Network.Tests;
+
+public class SchedulerTimeoutTests
+{
+    [Fact]
+    public async Task LongRunningTasksIncrementTimeoutCounter()
+    {
+        var metrics = new Metrics(Pid.NewPid());
+        var scheduler = new Scheduler(metrics, maxWorkers: 1, autoScale: false,
+            taskTimeout: TimeSpan.FromMilliseconds(30));
+
+        scheduler.Schedule(async () => await Task.Delay(10));
+        scheduler.Schedule(async () => await Task.Delay(50));
+        scheduler.Schedule(async () => await Task.Delay(60));
+
+        await scheduler.StopAsync(drain: true);
+
+        Assert.Equal(2, scheduler.TimeoutCount);
+    }
+}

--- a/VelorenPort/Network/Src/Metrics.cs
+++ b/VelorenPort/Network/Src/Metrics.cs
@@ -94,6 +94,12 @@ namespace VelorenPort.Network
         private readonly Counter _schedulerTaskTimeouts = MetricsCreator.CreateCounter(
             "network_scheduler_task_timeouts_total",
             "Number of scheduler tasks that exceeded the configured timeout");
+        private readonly Gauge _schedulerAvgWait = MetricsCreator.CreateGauge(
+            "network_scheduler_avg_wait_seconds",
+            "Average time tasks spend waiting in the scheduler queue");
+        private readonly Gauge _schedulerAvgDuration = MetricsCreator.CreateGauge(
+            "network_scheduler_avg_duration_seconds",
+            "Average execution time of scheduler tasks in seconds");
         private readonly Gauge _schedulerWorkerUtilization = MetricsCreator.CreateGauge(
             "network_scheduler_worker_utilization",
             "Ratio of active workers to worker limit");
@@ -410,6 +416,12 @@ namespace VelorenPort.Network
 
         public void SchedulerLatency(double seconds)
             => _schedulerLatency.Set(seconds);
+
+        public void SchedulerAverageWait(double seconds)
+            => _schedulerAvgWait.Set(seconds);
+
+        public void SchedulerAverageDuration(double seconds)
+            => _schedulerAvgDuration.Set(seconds);
 
         public void StreamRtt(Pid pid, Sid stream, double ms)
         {


### PR DESCRIPTION
## Summary
- track scheduler timeout count and average timings
- export new metrics through `Metrics`
- test long running scheduler tasks increment timeout counter

## Testing
- `dotnet test VelorenPort/Network.Tests/Network.Tests.csproj` *(fails: UdpHandshakeStream overrides and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861a1d1d40c8328803ae0b91f2b69e0