### PR TITLE
Move tile and gradient utilities

### DIFF
--- a/VelorenPort/World.Tests/GradientTests.cs
+++ b/VelorenPort/World.Tests/GradientTests.cs
@@ -1,4 +1,4 @@
-using VelorenPort.World.Site.Util;
+using VelorenPort.World.Util;
 using VelorenPort.CoreEngine;
 using VelorenPort.NativeMath;
 

--- a/VelorenPort/World.Tests/TileKindTests.cs
+++ b/VelorenPort/World.Tests/TileKindTests.cs
@@ -1,0 +1,15 @@
+using VelorenPort.World.Site.Tile;
+using VelorenPort.World.Util;
+
+namespace World.Tests;
+
+public class TileKindTests
+{
+    [Fact]
+    public void EnumIndices_AreStable()
+    {
+        Assert.Equal(0, EnumIndex.IndexFromEnum(TileKind.Empty));
+        Assert.Equal(3, EnumIndex.IndexFromEnum(TileKind.Plaza));
+        Assert.Equal(TileKind.Bridge, EnumIndex.EnumFromIndex<TileKind>(13));
+    }
+}

--- a/VelorenPort/World/Src/ColumnGen.cs
+++ b/VelorenPort/World/Src/ColumnGen.cs
@@ -4,6 +4,7 @@ using static VelorenPort.NativeMath.math;
 using VelorenPort.CoreEngine;
 using VelorenPort.World.Sim;
 
+using VelorenPort.World.Util;
 namespace VelorenPort.World {
     /// <summary>
     /// Handles sampling of world columns for terrain and object generation.
@@ -13,6 +14,7 @@ namespace VelorenPort.World {
     public class ColumnGen {
         private readonly WorldSim _sim;
 
+        private static readonly Gradient BiomeGradient = new Gradient(new float3(0,0,0), 1f, Shape.Point, (new Rgb8(34,139,34), new Rgb8(210,180,140)));
         public ColumnGen(WorldSim sim) {
             _sim = sim;
         }
@@ -40,7 +42,8 @@ namespace VelorenPort.World {
             float warpFactor = math.saturate(waterDist / 64f);
 
             float marble = _sim.Noise.CaveFbm(new float3(wpos.x * 0.05f, wpos.y * 0.05f, chunk.Alt * 0.1f));
-            float3 baseCol = new float3(0.2f, 0.5f, 0.2f);
+            var bc = BiomeGradient.Sample(new float3(chunk.Temp, 0f, 0f));
+            float3 baseCol = new float3(bc.R / 255f, bc.G / 255f, bc.B / 255f);
             baseCol += marble * 0.1f;
             var surfColor = new Rgb<float>(baseCol.x, baseCol.y, baseCol.z);
             var subColor = new Rgb<float>(baseCol.x * 0.6f, baseCol.y * 0.5f, baseCol.z * 0.5f);

--- a/VelorenPort/World/Src/Site/PlotTemplates.cs
+++ b/VelorenPort/World/Src/Site/PlotTemplates.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using VelorenPort.NativeMath;
 
+using VelorenPort.World.Site.Tile;
 namespace VelorenPort.World.Site
 {
     /// <summary>

--- a/VelorenPort/World/Src/Site/Site.cs
+++ b/VelorenPort/World/Src/Site/Site.cs
@@ -4,6 +4,7 @@ using VelorenPort.NativeMath;
 using VelorenPort.CoreEngine;
 using VelorenPort.World.Site.Economy;
 
+using VelorenPort.World.Site.Tile;
 namespace VelorenPort.World.Site {
     /// <summary>
     /// Basic site representation with a minimal economy model.

--- a/VelorenPort/World/Src/Site/SiteGenerator.cs
+++ b/VelorenPort/World/Src/Site/SiteGenerator.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using VelorenPort.NativeMath;
 using VelorenPort.World.Site.Stats;
 
+using VelorenPort.World.Site.Tile;
 namespace VelorenPort.World.Site;
 
 /// <summary>

--- a/VelorenPort/World/Src/Site/Tile/Tile.cs
+++ b/VelorenPort/World/Src/Site/Tile/Tile.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace VelorenPort.World.Site {
+namespace VelorenPort.World.Site.Tile {
     /// <summary>
     /// Simplified representation of a site tile. This mirrors part of
     /// `world/src/site/tile.rs` and is used by generators to mark

--- a/VelorenPort/World/Src/Site/Tile/TileGrid.cs
+++ b/VelorenPort/World/Src/Site/Tile/TileGrid.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using VelorenPort.NativeMath;
 using VelorenPort.CoreEngine;
 
-namespace VelorenPort.World.Site {
+namespace VelorenPort.World.Site.Tile {
     /// <summary>
     /// Sparse grid storing tiles around a site. Implements a small subset of the
     /// Rust <c>TileGrid</c> used for town generation.

--- a/VelorenPort/World/Src/Util/Gradient.cs
+++ b/VelorenPort/World/Src/Util/Gradient.cs
@@ -2,7 +2,7 @@ using System;
 using VelorenPort.CoreEngine;
 using VelorenPort.NativeMath;
 
-namespace VelorenPort.World.Site.Util;
+namespace VelorenPort.World.Util;
 
 /// <summary>
 /// Wrapping behavior when sampling beyond the gradient range.


### PR DESCRIPTION
## Summary
- move site tile utilities under `World/Src/Site/Tile`
- move gradient utilities to `World/Src/Util`
- apply gradient when sampling columns
- update tests and add TileKind enum checks

## Testing
- `dotnet build VelorenPort/World/World.csproj` *(fails: Random ambiguity and other compile errors)*
- `dotnet test VelorenPort/World.Tests/World.Tests.csproj` *(fails to build project)*


------
https://chatgpt.com/codex/tasks/task_e_6861a359a594832888f82e53c64647b0