### PR TITLE
Implement economy stages and trading routes

### DIFF
--- a/VelorenPort/World.Tests/CaravanRouteTests.cs
+++ b/VelorenPort/World.Tests/CaravanRouteTests.cs
@@ -29,11 +29,33 @@ public class CaravanRouteTests
         var idB = index.Sites.Insert(siteB);
         siteA.Production.SetRate(new Good.Wood(), 2f);
         var route = new CaravanRoute(new[] { idA, idB });
-        route.Goods[new Good.Wood()] = 1f;
+        if (GoodIndex.TryFromGood(new Good.Wood(), out var gi))
+            route.Goods[gi] = 1f;
         index.CaravanRoutes.Add(route);
         var sim = new WorldSim(0, new int2(8,8));
         for (int i = 0; i < 3; i++)
             sim.Tick(index, 1f);
         Assert.True(siteB.Economy.GetStock(new Good.Wood()) > 0f);
+    }
+
+    [Fact]
+    public void Tick_MultiSiteRouteTransfersGoods()
+    {
+        var index = new WorldIndex(0);
+        var siteA = new Site.Site { Position = int2.zero };
+        var siteB = new Site.Site { Position = new int2(2,0) };
+        var siteC = new Site.Site { Position = new int2(4,0) };
+        var idA = index.Sites.Insert(siteA);
+        var idB = index.Sites.Insert(siteB);
+        var idC = index.Sites.Insert(siteC);
+        siteA.Economy.Produce(new Good.Stone(), 3f);
+        var route = new CaravanRoute(new[] { idA, idB, idC });
+        if (GoodIndex.TryFromGood(new Good.Stone(), out var gi))
+            route.Goods[gi] = 1f;
+        index.CaravanRoutes.Add(route);
+        var sim = new WorldSim(0, new int2(8,8));
+        for (int i = 0; i < 4; i++)
+            sim.Tick(index, 1f);
+        Assert.True(siteC.Economy.GetStock(new Good.Stone()) > 0f);
     }
 }

--- a/VelorenPort/World.Tests/CivEconTests.cs
+++ b/VelorenPort/World.Tests/CivEconTests.cs
@@ -42,7 +42,8 @@ public class CivEconTests
             EconomyStage.TickSites,
             EconomyStage.DistributeOrders,
             EconomyStage.TradeAtSites,
-            EconomyStage.UpdateMarkets
+            EconomyStage.UpdateMarkets,
+            EconomyStage.UpdatePopulation
         }, stages);
     }
 }

--- a/VelorenPort/World.Tests/CivEconTests.cs
+++ b/VelorenPort/World.Tests/CivEconTests.cs
@@ -36,6 +36,13 @@ public class CivEconTests
         index.EconomyContext.Tick(index, 1f);
 
         var stages = index.EconomyContext.StageHistory.Select(s => s.Stage).ToArray();
-        Assert.Equal(new[] { EconomyStage.Deliveries, EconomyStage.TickSites, EconomyStage.UpdateMarkets }, stages);
+        Assert.Equal(new[]
+        {
+            EconomyStage.Deliveries,
+            EconomyStage.TickSites,
+            EconomyStage.DistributeOrders,
+            EconomyStage.TradeAtSites,
+            EconomyStage.UpdateMarkets
+        }, stages);
     }
 }

--- a/VelorenPort/World.Tests/PopulationEventTests.cs
+++ b/VelorenPort/World.Tests/PopulationEventTests.cs
@@ -14,7 +14,7 @@ public class PopulationEventTests
         var site = new Site { Position = int2.zero };
         var id = index.Sites.Insert(site);
         site.Economy.Produce(new Good.Food(), 5f);
-        EconomySim.UpdatePopulation(index, 1f);
+        EconomySim.UpdatePopulation(index, 1f, new EconomyContext());
         Assert.Single(index.PopulationEvents);
         Assert.Equal(PopulationEventType.Birth, index.PopulationEvents[0].Type);
     }

--- a/VelorenPort/World.Tests/TradingFlowTests.cs
+++ b/VelorenPort/World.Tests/TradingFlowTests.cs
@@ -46,4 +46,25 @@ public class TradingFlowTests
         Assert.Contains(index.EconomyContext.Events, e => e.Phase == EconomyContext.TradePhase.Collect);
         Assert.NotEmpty(index.EconomyContext.StageHistory);
     }
+
+    [Fact]
+    public void TradingRoute_RecordsTradeEvents()
+    {
+        var (world, index) = World.World.Empty();
+        var siteA = new Site { Position = int2.zero };
+        var siteB = new Site { Position = new int2(4, 0) };
+        var idA = index.Sites.Insert(siteA);
+        var idB = index.Sites.Insert(siteB);
+        var route = new CaravanRoute(new[] { idA, idB });
+        if (GoodIndex.TryFromGood(new Good.Wood(), out var gi))
+            route.Goods[gi] = 1f;
+        index.CaravanRoutes.Add(route);
+        siteA.Economy.Produce(new Good.Wood(), 2f);
+
+        world.Tick(1f);
+
+        Assert.Contains(index.EconomyContext.Events, e => e.Phase == EconomyContext.TradePhase.Plan);
+        Assert.Contains(index.EconomyContext.Events, e => e.Phase == EconomyContext.TradePhase.Execute);
+        Assert.Contains(index.EconomyContext.Events, e => e.Phase == EconomyContext.TradePhase.Collect);
+    }
 }

--- a/VelorenPort/World/Src/Civ/Econ.cs
+++ b/VelorenPort/World/Src/Civ/Econ.cs
@@ -14,6 +14,7 @@ namespace VelorenPort.World.Civ
         DistributeOrders,
         TradeAtSites,
         UpdateMarkets,
+        UpdatePopulation,
     }
 
     [Serializable]

--- a/VelorenPort/World/Src/Site/Economy.cs
+++ b/VelorenPort/World/Src/Site/Economy.cs
@@ -107,7 +107,7 @@ namespace VelorenPort.World.Site {
         }
 
         /// <summary>Advance population counts and record events.</summary>
-        public static void UpdatePopulation(WorldIndex index, float dt)
+        public static void UpdatePopulation(WorldIndex index, float dt, EconomyContext? ctx = null)
         {
             foreach (var (id, site) in index.Sites.Enumerate())
             {
@@ -120,13 +120,17 @@ namespace VelorenPort.World.Site {
                     var npc = new Npc(uid) { Name = Site.NameGen.Generate(new Random((int)uid.Value)), Home = new SiteId(id.Value) };
                     var npcId = index.Npcs.Insert(npc);
                     site.Population.Add(npcId);
-                    index.PopulationEvents.Add(new PopulationEvent(PopulationEventType.Birth, npcId, id));
+                    var ev = new PopulationEvent(PopulationEventType.Birth, npcId, id);
+                    index.PopulationEvents.Add(ev);
+                    ctx?.PopulationEvents.Add(ev);
                 }
                 else if (population > 0 && food < population * 0.25f)
                 {
                     var npcId = site.Population[^1];
                     site.Population.RemoveAt(site.Population.Count - 1);
-                    index.PopulationEvents.Add(new PopulationEvent(PopulationEventType.Death, npcId, id));
+                    var ev = new PopulationEvent(PopulationEventType.Death, npcId, id);
+                    index.PopulationEvents.Add(ev);
+                    ctx?.PopulationEvents.Add(ev);
                 }
             }
         }

--- a/VelorenPort/World/Src/Site/Economy.cs
+++ b/VelorenPort/World/Src/Site/Economy.cs
@@ -76,6 +76,31 @@ namespace VelorenPort.World.Site {
         public static void AddTradingRoute(WorldIndex index, TradingRoute route)
             => index.TradingRoutes.Add(route);
 
+        /// <summary>
+        /// Simulate trading along predefined caravan routes.
+        /// </summary>
+        public static void SimulateTradingRoutes(WorldIndex index, float dt)
+        {
+            foreach (var route in index.CaravanRoutes)
+            {
+                if (route.Sites.Count < 2) continue;
+                for (int i = 0; i < route.Sites.Count - 1; i++)
+                {
+                    var from = index.Sites[route.Sites[i]];
+                    var to = index.Sites[route.Sites[i + 1]];
+                    foreach (var (gidx, rate) in route.Goods.Iterate())
+                    {
+                        if (rate <= 0f) continue;
+                        var good = gidx.ToGood();
+                        float avail = from.Economy.GetStock(good);
+                        float amount = MathF.Min(rate * dt, avail);
+                        if (amount > 0f)
+                            TradeGoods(from, to, good, amount);
+                    }
+                }
+            }
+        }
+
         /// <summary>Advance population counts and record events.</summary>
         public static void UpdatePopulation(WorldIndex index, float dt)
         {

--- a/VelorenPort/World/Src/Site/Economy/CaravanRoute.cs
+++ b/VelorenPort/World/Src/Site/Economy/CaravanRoute.cs
@@ -11,7 +11,7 @@ namespace VelorenPort.World.Site.Economy;
 public class CaravanRoute
 {
     public List<Store<Site>.Id> Sites { get; } = new();
-    public Dictionary<Good, float> Goods { get; } = new();
+    public GoodMap<float> Goods { get; } = GoodMap<float>.FromDefault(0f);
 
     public CaravanRoute() { }
 

--- a/VelorenPort/World/Src/Site/Economy/Context.cs
+++ b/VelorenPort/World/Src/Site/Economy/Context.cs
@@ -40,6 +40,7 @@ public class EconomyContext
     public Dictionary<Store<Site>.Id, Metrics> SiteMetrics { get; } = new();
     public List<TradeEvent> Events { get; } = new();
     public List<StageEvent> StageHistory { get; } = new();
+    public List<PopulationEvent> PopulationEvents { get; } = new();
 
     private void LogStage(EconomyStage stage)
         => StageHistory.Add(new StageEvent(stage, Time));
@@ -62,7 +63,7 @@ public class EconomyContext
         LogStage(EconomyStage.UpdateMarkets);
         EconomySim.UpdateMarkets(index);
         LogStage(EconomyStage.UpdatePopulation);
-        EconomySim.UpdatePopulation(index, dt);
+        EconomySim.UpdatePopulation(index, dt, this);
         foreach (var (id, site) in index.Sites.Enumerate())
         {
             var dict = MarketPrices.GetValueOrDefault(id);

--- a/VelorenPort/World/Src/Site/Economy/Context.cs
+++ b/VelorenPort/World/Src/Site/Economy/Context.cs
@@ -61,6 +61,7 @@ public class EconomyContext
 
         LogStage(EconomyStage.UpdateMarkets);
         EconomySim.UpdateMarkets(index);
+        LogStage(EconomyStage.UpdatePopulation);
         EconomySim.UpdatePopulation(index, dt);
         foreach (var (id, site) in index.Sites.Enumerate())
         {

--- a/VelorenPort/World/Src/Site/Economy/Context.cs
+++ b/VelorenPort/World/Src/Site/Economy/Context.cs
@@ -54,7 +54,7 @@ public class EconomyContext
         EconomySim.SimulateEconomy(index, dt);
 
         LogStage(EconomyStage.DistributeOrders);
-        EconomySim.SimulateTradingRoutes(index, dt);
+        EconomySim.SimulateTradingRoutes(index, dt, this);
 
         LogStage(EconomyStage.TradeAtSites);
         // trade executed within SimulateTradingRoutes for simplicity

--- a/VelorenPort/World/Src/Site/Economy/Context.cs
+++ b/VelorenPort/World/Src/Site/Economy/Context.cs
@@ -53,6 +53,12 @@ public class EconomyContext
         LogStage(EconomyStage.TickSites);
         EconomySim.SimulateEconomy(index, dt);
 
+        LogStage(EconomyStage.DistributeOrders);
+        EconomySim.SimulateTradingRoutes(index, dt);
+
+        LogStage(EconomyStage.TradeAtSites);
+        // trade executed within SimulateTradingRoutes for simplicity
+
         LogStage(EconomyStage.UpdateMarkets);
         EconomySim.UpdateMarkets(index);
         EconomySim.UpdatePopulation(index, dt);

--- a/VelorenPort/World/Src/Site/Economy/Environment.cs
+++ b/VelorenPort/World/Src/Site/Economy/Environment.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+
+namespace VelorenPort.World.Site.Economy;
+
+/// <summary>
+/// Utility for long term economy simulations. Only writes a CSV of site stocks
+/// similar to the Rust implementation's environment struct.
+/// </summary>
+public class Environment : IDisposable
+{
+    private readonly StreamWriter? _csv;
+
+    public Environment(string? csvPath = null)
+    {
+        if (!string.IsNullOrEmpty(csvPath))
+        {
+            _csv = new StreamWriter(File.Open(csvPath, FileMode.Create, FileAccess.Write));
+        }
+    }
+
+    public void WriteCsvHeader(string siteName)
+    {
+        _csv?.WriteLine($"Site,{siteName}");
+    }
+
+    public void Record(GoodMap<float> stocks)
+    {
+        if (_csv == null) return;
+        for (int i = 0; i < GoodIndex.LENGTH; i++)
+        {
+            var gi = GoodIndex.FromInt(i);
+            _csv.Write($"{stocks[gi]},");
+        }
+        _csv.WriteLine();
+    }
+
+    public void Dispose()
+    {
+        _csv?.Dispose();
+    }
+}
+

--- a/VelorenPort/World/Src/Site/Economy/FullEconomy.cs
+++ b/VelorenPort/World/Src/Site/Economy/FullEconomy.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using VelorenPort.CoreEngine;
+
+namespace VelorenPort.World.Site.Economy;
+
+/// <summary>
+/// Extended economy data ported from the Rust implementation. This class
+/// exposes population, stock tracking and neighbor information. Only a
+/// lightweight subset of the original logic is implemented.
+/// </summary>
+[Serializable]
+public class FullEconomy
+{
+    /// <summary>Approximate population count.</summary>
+    public float Population { get; set; } = 32f;
+
+    /// <summary>Per-good stock values.</summary>
+    public GoodMap<float> Stocks { get; } = GoodMap<float>.FromDefault(0f);
+
+    /// <summary>Current surplus of each good.</summary>
+    public GoodMap<float> Surplus { get; } = GoodMap<float>.FromDefault(0f);
+
+    /// <summary>Change rate of each good.</summary>
+    public GoodMap<float> MarginalSurplus { get; } = GoodMap<float>.FromDefault(0f);
+
+    /// <summary>Per-profession labor ratios.</summary>
+    public LaborMap<float> Labors { get; } = LaborMap<float>.FromDefault(0f);
+
+    /// <summary>Yield per labor per year.</summary>
+    public LaborMap<float> Yields { get; } = LaborMap<float>.FromDefault(0f);
+
+    /// <summary>Natural resources around the site.</summary>
+    public NaturalResources Resources { get; } = new();
+
+    /// <summary>Known neighbors for trade.</summary>
+    public List<NeighborInformation> Neighbors { get; } = new();
+
+    /// <summary>Outgoing trade orders.</summary>
+    public Dictionary<Store<Site>.Id, List<TradeOrder>> Orders { get; } = new();
+
+    /// <summary>Pending deliveries to this site.</summary>
+    public Dictionary<Store<Site>.Id, List<TradeDelivery>> Deliveries { get; } = new();
+
+    /// <summary>Update stock decay and replenish natural resources.</summary>
+    public void Tick(float dt)
+    {
+        foreach (var (gidx, _))
+            Stocks[gidx] = Math.Max(0f, Stocks[gidx] - Cache.Instance.DecayRate[gidx] * dt);
+        Replenish(dt);
+    }
+
+    /// <summary>Add natural resources from a chunk.</summary>
+    public void AddChunk(SimChunk chunk)
+    {
+        Resources.AddChunk(chunk);
+    }
+
+    /// <summary>Refill stocks based on long term resource averages.</summary>
+    public void Replenish(float dt)
+    {
+        foreach (var (gidx, ch) in Resources.ChunksPerResource.Iterate())
+        {
+            float yield = Resources.AverageYieldPerChunk[gidx] * ch;
+            Stocks[gidx] = Math.Max(Stocks[gidx], yield * dt);
+        }
+    }
+
+    /// <summary>Plan trade with neighbors based on surplus and missing goods.</summary>
+    public void PlanTradeForSite(Store<Site>.Id self)
+    {
+        foreach (var n in Neighbors)
+        {
+            var order = new TradeOrder(self, new GoodMap<float>());
+            foreach (var (gidx, amount) in Surplus.Iterate())
+            {
+                if (amount < 0f)
+                {
+                    order.Amount[gidx] = -amount;
+                }
+            }
+            if (!Orders.ContainsKey(n.Id))
+                Orders[n.Id] = new List<TradeOrder>();
+            Orders[n.Id].Add(order);
+        }
+    }
+
+    /// <summary>Execute orders arriving from neighbors.</summary>
+    public void TradeAtSite(Store<Site>.Id self)
+    {
+        if (!Deliveries.TryGetValue(self, out var list))
+            return;
+        foreach (var del in list)
+        {
+            foreach (var (gidx, amount) in del.Amount.Iterate())
+            {
+                Stocks[gidx] += amount;
+            }
+        }
+        Deliveries.Remove(self);
+    }
+}
+
+/// <summary>Information about a nearby site.</summary>
+[Serializable]
+public record NeighborInformation(Store<Site>.Id Id);
+
+/// <summary>Outgoing trade request.</summary>
+[Serializable]
+public record TradeOrder(Store<Site>.Id Customer, GoodMap<float> Amount);
+
+/// <summary>Incoming trade delivery.</summary>
+[Serializable]
+public record TradeDelivery(Store<Site>.Id Supplier, GoodMap<float> Amount);
+
+/// <summary>Natural resource tracking around a site.</summary>
+[Serializable]
+public class NaturalResources
+{
+    public List<AreaResources> PerArea { get; } = new();
+    public GoodMap<float> ChunksPerResource { get; } = GoodMap<float>.FromDefault(0f);
+    public GoodMap<float> AverageYieldPerChunk { get; } = GoodMap<float>.FromDefault(0f);
+
+    public void AddChunk(SimChunk chunk)
+    {
+        var area = new AreaResources();
+        area.Chunks += 1;
+        PerArea.Add(area);
+    }
+}
+
+/// <summary>Aggregated resource data for a distance bucket.</summary>
+[Serializable]
+public class AreaResources
+{
+    public GoodMap<float> ResourceSum { get; } = GoodMap<float>.FromDefault(0f);
+    public GoodMap<float> ResourceChunks { get; } = GoodMap<float>.FromDefault(0f);
+    public uint Chunks { get; set; } = 0;
+}
+
+/// <summary>Map keyed by Labor enumeration.</summary>
+[Serializable]
+public class LaborMap<T> where T : struct
+{
+    private readonly Dictionary<Labor, T> _data = new();
+
+    public T this[Labor labor]
+    {
+        get => _data.TryGetValue(labor, out var v) ? v : default;
+        set => _data[labor] = value;
+    }
+
+    public static LaborMap<T> FromDefault(T value)
+    {
+        var map = new LaborMap<T>();
+        foreach (Labor l in Enum.GetValues(typeof(Labor)))
+            map._data[l] = value;
+        return map;
+    }
+}
+
+/// <summary>Subset of professions used by the economy.</summary>
+[Serializable]
+public enum Labor
+{
+    Farmer,
+    Hunter,
+    Blacksmith,
+    Alchemist,
+    Merchant,
+    Guard,
+    Everyone
+}
+

--- a/VelorenPort/World/Src/World.cs
+++ b/VelorenPort/World/Src/World.cs
@@ -133,8 +133,6 @@ namespace VelorenPort.World
         /// <summary>Advance the simulation by the specified delta time.</summary>
         public void Tick(float dt)
         {
-            Index.EconomyContext.Tick(Index, dt);
-
             Sim.Tick(Index, dt);
         }
 

--- a/VelorenPort/World/Src/WorldSim.cs
+++ b/VelorenPort/World/Src/WorldSim.cs
@@ -365,7 +365,6 @@ namespace VelorenPort.World
         {
             index.EconomyContext.Tick(index, dt);
             Tick(dt);
-            EconomySim.SimulateTradingRoutes(index, dt);
         }
 
 

--- a/VelorenPort/World/Src/WorldSim.cs
+++ b/VelorenPort/World/Src/WorldSim.cs
@@ -363,32 +363,11 @@ namespace VelorenPort.World
         /// </summary>
         public void Tick(WorldIndex index, float dt)
         {
+            index.EconomyContext.Tick(index, dt);
             Tick(dt);
-            ExchangeGoods(index, dt);
+            EconomySim.SimulateTradingRoutes(index, dt);
         }
 
-        private void ExchangeGoods(WorldIndex index, float dt)
-        {
-            foreach (var (_, site) in index.Sites.Enumerate())
-                site.Production.Produce(site.Economy, dt);
-
-            foreach (var route in index.CaravanRoutes)
-            {
-                if (route.Sites.Count < 2) continue;
-                for (int i = 0; i < route.Sites.Count - 1; i++)
-                {
-                    var from = index.Sites[route.Sites[i]];
-                    var to = index.Sites[route.Sites[i + 1]];
-                    foreach (var kv in route.Goods)
-                    {
-                        float avail = from.Economy.GetStock(kv.Key);
-                        float move = Math.Min(kv.Value * dt, avail);
-                        if (move > 0f)
-                            Site.EconomySim.TradeGoods(from, to, kv.Key, move);
-                    }
-                }
-            }
-        }
 
         public float[,] GetAltitudeMap(int2 cpos, int radius)
         {


### PR DESCRIPTION
## Summary
- extend `EconomyContext.Tick` with all economy stages
- add `SimulateTradingRoutes` to `EconomySim`
- refactor `CaravanRoute` to use `GoodMap`
- drive economy from `WorldSim.Tick`
- update tests for new stages and trading route logic

## Testing
- `dotnet test VelorenPort/VelorenPort.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861ad0da23c8328bc55ab6cb3e0adc5