### PR TITLE
Port tile utilities and add tests

### DIFF
--- a/VelorenPort/World.Tests/CivGeneratorTests.cs
+++ b/VelorenPort/World.Tests/CivGeneratorTests.cs
@@ -23,8 +23,8 @@ public class CivGeneratorTests
         var (world, index) = World.Empty();
         CivGenerator.Generate(world, index, 1);
         var site = index.Sites.Items[0];
-        Assert.Equal(Site.TileKind.Plaza, site.Tiles.Get(int2.zero).Kind);
-        Assert.Equal(Site.TileKind.Road, site.Tiles.Get(new int2(1, 0)).Kind);
+        Assert.Equal(TileKindTag.Plaza, site.Tiles.Get(int2.zero).Kind.Tag);
+        Assert.Equal(TileKindTag.Road, site.Tiles.Get(new int2(1, 0)).Kind.Tag);
 
         foreach (var plot in site.Plots)
         {
@@ -34,7 +34,7 @@ public class CivGeneratorTests
             while (cur.x != 0)
             {
                 cur.x += cur.x > 0 ? -1 : 1;
-                if (site.Tiles.Get(cur).Kind == Site.TileKind.Road)
+                if (site.Tiles.Get(cur).Kind.Tag == TileKindTag.Road)
                 {
                     connected = true;
                     break;
@@ -45,7 +45,7 @@ public class CivGeneratorTests
                 while (cur.y != 0)
                 {
                     cur.y += cur.y > 0 ? -1 : 1;
-                    if (site.Tiles.Get(cur).Kind == Site.TileKind.Road)
+                    if (site.Tiles.Get(cur).Kind.Tag == TileKindTag.Road)
                     {
                         connected = true;
                         break;

--- a/VelorenPort/World.Tests/DirTests.cs
+++ b/VelorenPort/World.Tests/DirTests.cs
@@ -18,4 +18,18 @@ public class DirTests
         var dir = Dir3.X.RotateAxisCw(Dir3.Z);
         Assert.Equal(Dir3.Y, dir);
     }
+
+    [Fact]
+    public void RelativeTo_ComposesDirections()
+    {
+        var dir = Dir.X.RelativeTo(Dir.Y);
+        Assert.Equal(Dir.NegY, dir);
+    }
+
+    [Fact]
+    public void FromZMat3_RotatesUpVector()
+    {
+        float3 v = math.mul(Dir.Y.FromZMat3(), new float3(0, 0, 1));
+        Assert.Equal(new float3(0, -1, 0), v);
+    }
 }

--- a/VelorenPort/World.Tests/SettlementGeneratorTests.cs
+++ b/VelorenPort/World.Tests/SettlementGeneratorTests.cs
@@ -13,8 +13,8 @@ public class SettlementGeneratorTests
         var rng = new System.Random(1);
         var stats = new SitesGenMeta(1);
         var site = SiteGenerator.Generate(rng, SiteKind.CliffTown, int2.zero, stats);
-        Assert.Equal(TileKind.Plaza, site.Tiles.Get(int2.zero).Kind);
-        Assert.Equal(TileKind.Road, site.Tiles.Get(new int2(1,0)).Kind);
+        Assert.Equal(TileKindTag.Plaza, site.Tiles.Get(int2.zero).Kind.Tag);
+        Assert.Equal(TileKindTag.Road, site.Tiles.Get(new int2(1,0)).Kind.Tag);
         Assert.True(site.Plots.Count > 0);
     }
 

--- a/VelorenPort/World.Tests/SiteGradientTests.cs
+++ b/VelorenPort/World.Tests/SiteGradientTests.cs
@@ -1,0 +1,24 @@
+using VelorenPort.World.Site.Util;
+using VelorenPort.CoreEngine;
+using VelorenPort.NativeMath;
+
+namespace World.Tests;
+
+public class SiteGradientTests
+{
+    [Fact]
+    public void Sample_ReturnsInterpolatedColor()
+    {
+        var g = new Gradient(float3.zero, 10f, Shape.Point, (new Rgb8(0,0,0), new Rgb8(100,0,0)));
+        var col = g.Sample(new float3(5f, 0f, 0f));
+        Assert.Equal((byte)50, col.R);
+    }
+
+    [Fact]
+    public void Repeat_WrapsDistance()
+    {
+        var g = new Gradient(float3.zero, 10f, Shape.Point, (new Rgb8(0,0,0), new Rgb8(100,0,0))).WithRepeat(WrapMode.Repeat);
+        var col = g.Sample(new float3(25f, 0f, 0f));
+        Assert.Equal((byte)50, col.R);
+    }
+}

--- a/VelorenPort/World.Tests/TileKindTests.cs
+++ b/VelorenPort/World.Tests/TileKindTests.cs
@@ -8,8 +8,8 @@ public class TileKindTests
     [Fact]
     public void EnumIndices_AreStable()
     {
-        Assert.Equal(0, EnumIndex.IndexFromEnum(TileKind.Empty));
-        Assert.Equal(3, EnumIndex.IndexFromEnum(TileKind.Plaza));
-        Assert.Equal(TileKind.Bridge, EnumIndex.EnumFromIndex<TileKind>(13));
+        Assert.Equal(0, EnumIndex.IndexFromEnum(TileKindTag.Empty));
+        Assert.Equal(3, EnumIndex.IndexFromEnum(TileKindTag.Plaza));
+        Assert.Equal(TileKindTag.Bridge, EnumIndex.EnumFromIndex<TileKindTag>(13));
     }
 }

--- a/VelorenPort/World.Tests/TilePlacementTests.cs
+++ b/VelorenPort/World.Tests/TilePlacementTests.cs
@@ -1,0 +1,17 @@
+using VelorenPort.World.Site;
+using VelorenPort.World.Site.Tile;
+using VelorenPort.NativeMath;
+
+namespace World.Tests;
+
+public class TilePlacementTests
+{
+    [Fact]
+    public void ApplyTemplate_PlacesTilesAtOrigin()
+    {
+        var grid = new TileGrid();
+        var tmpl = PlotTemplates.Templates[PlotKind.Plaza];
+        grid.ApplyTemplate(int2.zero, tmpl);
+        Assert.Equal(TileKind.Plaza, grid.Get(int2.zero).Kind);
+    }
+}

--- a/VelorenPort/World.Tests/TileSpriteTests.cs
+++ b/VelorenPort/World.Tests/TileSpriteTests.cs
@@ -1,0 +1,24 @@
+using VelorenPort.World.Site.Util;
+using VelorenPort.NativeMath;
+
+namespace World.Tests;
+
+public class TileSpriteTests
+{
+    [Fact]
+    public void TwoBy_SetsCorrectBounds()
+    {
+        var t = Tileable2.TwoBy(3, new int3(0,0,0), Dir.X);
+        Assert.Equal(new int2(-1,-1), t.Bounds.Min);
+        Assert.Equal(new int2(1,0), t.Bounds.Max);
+    }
+
+    [Fact]
+    public void Rotation_AffectsSideLookup()
+    {
+        var t = Tileable2.Empty().WithRotation(Dir.Y);
+        var block = new VelorenPort.World.Block();
+        t = t.WithSide(Dir.X, block);
+        Assert.Equal(block, t.Side(Dir.NegY));
+    }
+}

--- a/VelorenPort/World/Src/BlockSpriteExtensions.cs
+++ b/VelorenPort/World/Src/BlockSpriteExtensions.cs
@@ -1,0 +1,12 @@
+using VelorenPort.CoreEngine.comp.terrain;
+
+namespace VelorenPort.World {
+    /// <summary>Placeholder extension to attach a sprite to a block.</summary>
+    public static class BlockSpriteExtensions {
+        public static Block WithSprite(this Block block, SpriteKind sprite)
+        {
+            var data = block.Data;
+            return new Block(block.Kind, (byte)sprite, data[1], data[2]);
+        }
+    }
+}

--- a/VelorenPort/World/Src/Site/Tile/Tile.cs
+++ b/VelorenPort/World/Src/Site/Tile/Tile.cs
@@ -1,77 +1,123 @@
 using System;
+using VelorenPort.NativeMath;
+using VelorenPort.World.Site.Util;
+using VelorenPort.World.Sim;
 
-namespace VelorenPort.World.Site.Tile {
-    /// <summary>
-    /// Simplified representation of a site tile. This mirrors part of
-    /// `world/src/site/tile.rs` and is used by generators to mark
-    /// terrain for roads, buildings and similar structures.
-    /// </summary>
-    [Serializable]
-    public class Tile {
-        public TileKind Kind { get; set; } = TileKind.Empty;
+namespace VelorenPort.World.Site.Tile;
 
-        /// <summary>
-        /// Optional identifier of a plot this tile belongs to. The full plot
-        /// system has not been ported yet so this is simply a numeric ID.
-        /// </summary>
-        public ulong? PlotId { get; set; } = null;
+/// <summary>
+/// Representation of a site tile mirroring <c>world/src/site/tile.rs</c>.
+/// </summary>
+[Serializable]
+public class Tile
+{
+    public TileKind Kind { get; set; } = TileKind.Empty;
 
-        /// <summary>
-        /// If set, the tile altitude should be forced to this value during
-        /// generation.
-        /// </summary>
-        public int? HardAlt { get; set; } = null;
+    /// <summary>Optional identifier of the plot this tile belongs to.</summary>
+    public ulong? PlotId { get; set; } = null;
 
-        public static Tile Empty => new Tile { Kind = TileKind.Empty };
+    /// <summary>Forced altitude if specified.</summary>
+    public int? HardAlt { get; set; } = null;
 
-        public static Tile Free(TileKind kind) => new Tile { Kind = kind };
+    public static Tile Empty => new Tile { Kind = TileKind.Empty };
+    public static Tile Free(TileKind kind) => new Tile { Kind = kind };
 
-        public bool IsEmpty => Kind == TileKind.Empty;
-        public bool IsNatural => Kind == TileKind.Empty || Kind == TileKind.Hazard;
-        public bool IsRoad => Kind is TileKind.Plaza or TileKind.Road or TileKind.Path;
-        public bool IsBuilding => Kind is TileKind.Building or TileKind.Castle or TileKind.Wall;
-    }
-
-    /// <summary>Tile category used when marking site layouts.</summary>
-    [Serializable]
-    public enum TileKind {
-        Empty,
-        Hazard,
-        Field,
-        Plaza,
-        Road,
-        Path,
-        Building,
-        Castle,
-        Wall,
-        Tower,
-        Keep,
-        Gate,
-        GnarlingFortification,
-        Bridge,
-        AdletStronghold,
-        DwarvenMine,
-    }
-
-    /// <summary>Type of hazardous tile.</summary>
-    [Serializable]
-    public enum HazardKind {
-        Water,
-        Hill,
-    }
-
-    /// <summary>Type of castle keep used by <see cref="TileKind.Keep"/>.</summary>
-    [Serializable]
-    public enum KeepKind {
-        Middle,
-        Corner,
-        Wall,
-    }
-
-    /// <summary>Roof decoration for towers.</summary>
-    [Serializable]
-    public enum RoofKind {
-        Parapet,
-        Pyramid,
-    }
+    public bool IsEmpty => Kind.Tag == TileKindTag.Empty;
+    public bool IsNatural => Kind.Tag == TileKindTag.Empty || Kind.Tag == TileKindTag.Hazard;
+    public bool IsRoad => Kind.Tag is TileKindTag.Plaza or TileKindTag.Road or TileKindTag.Path;
+    public bool IsBuilding => Kind.Tag is TileKindTag.Building or TileKindTag.Castle or TileKindTag.Wall;
 }
+
+/// <summary>Discriminant for <see cref="TileKind"/>.</summary>
+[Serializable]
+public enum TileKindTag
+{
+    Empty,
+    Hazard,
+    Field,
+    Plaza,
+    Road,
+    Path,
+    Building,
+    Castle,
+    Wall,
+    Tower,
+    Keep,
+    Gate,
+    GnarlingFortification,
+    Bridge,
+    AdletStronghold,
+    DwarvenMine,
+}
+
+[Serializable]
+public struct RoadData
+{
+    public ushort A;
+    public ushort B;
+    public ushort W;
+}
+
+[Serializable]
+public struct PathData
+{
+    public float2 ClosestPos;
+    public Path Path;
+}
+
+/// <summary>
+/// Tile category with variant data.
+/// </summary>
+[Serializable]
+public struct TileKind
+{
+    public TileKindTag Tag;
+    public HazardKind? Hazard;
+    public RoadData? Road;
+    public PathData? Path;
+    public Dir? WallDir;
+    public RoofKind? Roof;
+    public KeepKind? Keep;
+
+    private TileKind(TileKindTag tag)
+    {
+        Tag = tag;
+        Hazard = null;
+        Road = null;
+        Path = null;
+        WallDir = null;
+        Roof = null;
+        Keep = null;
+    }
+
+    public static TileKind Empty => new TileKind(TileKindTag.Empty);
+    public static TileKind Field => new TileKind(TileKindTag.Field);
+    public static TileKind Plaza => new TileKind(TileKindTag.Plaza);
+    public static TileKind Building => new TileKind(TileKindTag.Building);
+    public static TileKind Castle => new TileKind(TileKindTag.Castle);
+    public static TileKind Gate => new TileKind(TileKindTag.Gate);
+    public static TileKind GnarlingFortification => new TileKind(TileKindTag.GnarlingFortification);
+    public static TileKind Bridge => new TileKind(TileKindTag.Bridge);
+    public static TileKind AdletStronghold => new TileKind(TileKindTag.AdletStronghold);
+    public static TileKind DwarvenMine => new TileKind(TileKindTag.DwarvenMine);
+
+    public static TileKind HazardTile(HazardKind kind) => new TileKind(TileKindTag.Hazard) { Hazard = kind };
+    public static TileKind RoadTile(ushort a, ushort b, ushort w) => new TileKind(TileKindTag.Road) { Road = new RoadData { A = a, B = b, W = w } };
+    public static TileKind PathTile(float2 pos, Path path) => new TileKind(TileKindTag.Path) { Path = new PathData { ClosestPos = pos, Path = path } };
+    public static TileKind WallTile(Dir dir) => new TileKind(TileKindTag.Wall) { WallDir = dir };
+    public static TileKind TowerTile(RoofKind roof) => new TileKind(TileKindTag.Tower) { Roof = roof };
+    public static TileKind KeepTile(KeepKind keep) => new TileKind(TileKindTag.Keep) { Keep = keep };
+}
+
+/// <summary>Type of hazardous tile.</summary>
+[Serializable]
+public enum HazardKind { Water, Hill }
+
+/// <summary>Type of castle keep used by <see cref="TileKindTag.Keep"/>.</summary>
+[Serializable]
+public enum KeepKind { Middle, Corner, Wall }
+
+/// <summary>Roof decoration for towers.</summary>
+[Serializable]
+public enum RoofKind { Parapet, Pyramid }
+

--- a/VelorenPort/World/Src/Site/Util/Dir.cs
+++ b/VelorenPort/World/Src/Site/Util/Dir.cs
@@ -180,6 +180,54 @@ namespace VelorenPort.World.Site.Util
             Dir.Y => 4,
             _ => 0,
         };
+
+        public static int SelectAabr(this Dir dir, Aabr aabr) => dir switch
+        {
+            Dir.X => aabr.Max.x,
+            Dir.NegX => aabr.Min.x,
+            Dir.Y => aabr.Max.y,
+            _ => aabr.Min.y,
+        };
+
+        public static int2 SelectAabrWith(this Dir dir, Aabr aabr, int2 other) => dir switch
+        {
+            Dir.X => new int2(aabr.Max.x, other.y),
+            Dir.NegX => new int2(aabr.Min.x, other.y),
+            Dir.Y => new int2(other.x, aabr.Max.y),
+            _ => new int2(other.x, aabr.Min.y),
+        };
+
+        public static (Aabr first, Aabr second) SplitAabrOffset(this Dir dir, Aabr aabr, int offset)
+        {
+            return dir switch
+            {
+                Dir.X => (new Aabr(aabr.Min, new int2(aabr.Min.x + offset, aabr.Max.y)),
+                            new Aabr(new int2(aabr.Min.x + offset, aabr.Min.y), aabr.Max)),
+                Dir.Y => (new Aabr(aabr.Min, new int2(aabr.Max.x, aabr.Min.y + offset)),
+                            new Aabr(new int2(aabr.Min.x, aabr.Min.y + offset), aabr.Max)),
+                Dir.NegX =>
+                {
+                    var res = Dir.X.SplitAabrOffset(aabr, aabr.Max.x - offset);
+                    return (res.second, res.first);
+                },
+                _ =>
+                {
+                    var res = Dir.Y.SplitAabrOffset(aabr, aabr.Max.y - offset);
+                    return (res.second, res.first);
+                }
+            };
+        }
+
+        public static Aabr ExtendAabr(this Dir dir, Aabr aabr, int amount)
+        {
+            int2 off = dir.ToVec2() * amount;
+            return dir.IsPositive()
+                ? new Aabr(aabr.Min, aabr.Max + off)
+                : new Aabr(aabr.Min + off, aabr.Max);
+        }
+
+        public static Aabr TrimAabr(this Dir dir, Aabr aabr, int amount)
+            => (-dir).ExtendAabr(aabr, -amount);
     }
 
     /// <summary>Three-dimensional directions.</summary>
@@ -302,5 +350,52 @@ namespace VelorenPort.World.Site.Util
             (Dir3.Y or Dir3.NegY, Dir3.Y or Dir3.NegY) => Dir3.X,
             _ => Dir3.Y,
         };
+
+        public static int SelectAabb(this Dir3 dir, Aabb aabb) => dir switch
+        {
+            Dir3.X => aabb.Max.x,
+            Dir3.NegX => aabb.Min.x,
+            Dir3.Y => aabb.Max.y,
+            Dir3.NegY => aabb.Min.y,
+            Dir3.Z => aabb.Max.z,
+            _ => aabb.Min.z,
+        };
+
+        public static int3 SelectAabbWith(this Dir3 dir, Aabb aabb, int3 other) => dir switch
+        {
+            Dir3.X => new int3(aabb.Max.x, other.y, other.z),
+            Dir3.NegX => new int3(aabb.Min.x, other.y, other.z),
+            Dir3.Y => new int3(other.x, aabb.Max.y, other.z),
+            Dir3.NegY => new int3(other.x, aabb.Min.y, other.z),
+            Dir3.Z => new int3(other.x, other.y, aabb.Max.z),
+            _ => new int3(other.x, other.y, aabb.Min.z),
+        };
+
+        public static (Aabb first, Aabb second) SplitAabbOffset(this Dir3 dir, Aabb aabb, int offset)
+        {
+            return dir switch
+            {
+                Dir3.X => (new Aabb(aabb.Min, new int3(aabb.Min.x + offset, aabb.Max.y, aabb.Max.z)),
+                            new Aabb(new int3(aabb.Min.x + offset, aabb.Min.y, aabb.Min.z), aabb.Max)),
+                Dir3.Y => (new Aabb(aabb.Min, new int3(aabb.Max.x, aabb.Min.y + offset, aabb.Max.z)),
+                            new Aabb(new int3(aabb.Min.x, aabb.Min.y + offset, aabb.Min.z), aabb.Max)),
+                Dir3.Z => (new Aabb(aabb.Min, new int3(aabb.Max.x, aabb.Max.y, aabb.Min.z + offset)),
+                            new Aabb(new int3(aabb.Min.x, aabb.Min.y, aabb.Min.z + offset), aabb.Max)),
+                Dir3.NegX => { var res = Dir3.X.SplitAabbOffset(aabb, aabb.Max.x - offset); return (res.second, res.first); },
+                Dir3.NegY => { var res = Dir3.Y.SplitAabbOffset(aabb, aabb.Max.y - offset); return (res.second, res.first); },
+                _ => { var res = Dir3.Z.SplitAabbOffset(aabb, aabb.Max.z - offset); return (res.second, res.first); }
+            };
+        }
+
+        public static Aabb ExtendAabb(this Dir3 dir, Aabb aabb, int amount)
+        {
+            int3 off = dir.ToVec3() * amount;
+            return dir.IsPositive()
+                ? new Aabb(aabb.Min, aabb.Max + off)
+                : new Aabb(aabb.Min + off, aabb.Max);
+        }
+
+        public static Aabb TrimAabb(this Dir3 dir, Aabb aabb, int amount)
+            => (-dir).ExtendAabb(aabb, -amount);
     }
 }

--- a/VelorenPort/World/Src/Site/Util/Gradient.cs
+++ b/VelorenPort/World/Src/Site/Util/Gradient.cs
@@ -1,0 +1,99 @@
+using System;
+using VelorenPort.CoreEngine;
+using VelorenPort.NativeMath;
+
+namespace VelorenPort.World.Site.Util;
+
+/// <summary>
+/// Gradient utilities used by plot templates. Mirrors the functionality of
+/// <c>world/src/site/util/gradient.rs</c>.
+/// </summary>
+public enum WrapMode
+{
+    Clamp,
+    Repeat,
+    PingPong,
+}
+
+static class WrapModeExt
+{
+    public static float Sample(this WrapMode mode, float t)
+    {
+        return mode switch
+        {
+            WrapMode.Clamp => math.clamp(t, 0f, 1f),
+            WrapMode.Repeat => PositiveFrac(t),
+            WrapMode.PingPong => 1f - 2f * math.abs(PositiveFrac(t / 2f) - 0.5f),
+            _ => t
+        };
+    }
+
+    private static float PositiveFrac(float x)
+    {
+        float f = x - math.floor(x);
+        return f >= 0f ? f : f + 1f;
+    }
+}
+
+/// <summary>Shape for gradient sampling.</summary>
+public readonly struct Shape
+{
+    public enum Kind { Point, Plane, Line }
+
+    public readonly Kind Type;
+    public readonly float3 Vec;
+
+    private Shape(Kind type, float3 vec)
+    {
+        Type = type;
+        Vec = math.normalizesafe(vec, new float3(0, 1, 0));
+    }
+
+    public static Shape Point => new Shape(Kind.Point, float3.zero);
+    public static Shape Plane(float3 normal) => new Shape(Kind.Plane, normal);
+    public static Shape Line(float3 dir) => new Shape(Kind.Line, dir);
+}
+
+/// <summary>Simple color gradient helper.</summary>
+[Serializable]
+public struct Gradient
+{
+    public float3 Center;
+    public float Size;
+    public Shape Shape;
+    public WrapMode Repeat;
+    public (Rgb8, Rgb8) Colors;
+
+    public Gradient(float3 center, float size, Shape shape, (Rgb8, Rgb8) colors)
+    {
+        Center = center;
+        Size = size;
+        Shape = shape;
+        Repeat = WrapMode.Clamp;
+        Colors = colors;
+    }
+
+    public Gradient WithRepeat(WrapMode mode)
+    {
+        Repeat = mode;
+        return this;
+    }
+
+    /// <summary>Sample a color from this gradient.</summary>
+    public Rgb8 Sample(float3 pos)
+    {
+        float dist = Shape.Type switch
+        {
+            Shape.Kind.Point => math.distance(pos, Center) / Size,
+            Shape.Kind.Plane => math.dot(pos - Center, Shape.Vec) / Size,
+            Shape.Kind.Line => math.length((pos - Center) - math.dot(pos - Center, Shape.Vec) * Shape.Vec) / Size,
+            _ => 0f,
+        };
+        float t = Repeat.Sample(dist);
+        byte r = (byte)math.round(math.lerp(Colors.Item1.R, Colors.Item2.R, t));
+        byte g = (byte)math.round(math.lerp(Colors.Item1.G, Colors.Item2.G, t));
+        byte b = (byte)math.round(math.lerp(Colors.Item1.B, Colors.Item2.B, t));
+        return new Rgb8(r, g, b);
+    }
+}
+

--- a/VelorenPort/World/Src/Site/Util/Sprites.cs
+++ b/VelorenPort/World/Src/Site/Util/Sprites.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using VelorenPort.NativeMath;
+
+namespace VelorenPort.World.Site.Util {
+    /// <summary>
+    /// Helper struct for placing tileable sprite blocks on a 2D plane.
+    /// This is a partial port of <c>world/src/site/util/sprites.rs</c>
+    /// used by some plot templates. Many sprite features are not yet
+    /// implemented but the structure mirrors the original API so the
+    /// ported templates can compile.
+    /// </summary>
+    [Serializable]
+    public class Tileable2 {
+        private int alt;
+        private Aabr bounds;
+        private World.Block center;
+        private readonly Dictionary<Dir, World.Block> side;
+        private readonly Dictionary<Dir, World.Block> corner;
+        private Dir rotation;
+
+        public Tileable2() {
+            alt = 0;
+            bounds = new Aabr(int2.zero, int2.zero);
+            center = World.Block.Air;
+            side = new Dictionary<Dir, World.Block>{
+                [Dir.X] = World.Block.Air,
+                [Dir.NegX] = World.Block.Air,
+                [Dir.Y] = World.Block.Air,
+                [Dir.NegY] = World.Block.Air
+            };
+            corner = new Dictionary<Dir, World.Block>{
+                [Dir.X] = World.Block.Air,
+                [Dir.NegX] = World.Block.Air,
+                [Dir.Y] = World.Block.Air,
+                [Dir.NegY] = World.Block.Air
+            };
+            rotation = Dir.X;
+        }
+
+        public static Tileable2 Empty() => new Tileable2();
+
+        public static Tileable2 TwoBy(int len, int3 pos, Dir dir) {
+            return Empty().WithRotation(dir)
+                .WithCenterSize(pos, new int2(len, 2));
+        }
+
+        public Tileable2 WithCenterSize(int3 centerPos, int2 size) {
+            int2 extentMin = (size - 1) / 2;
+            int2 extentMax = size / 2;
+            var rot = rotation;
+            bounds = new Aabr(
+                centerPos.xy - rot.Vec2(extentMin.x, extentMin.y),
+                centerPos.xy + rot.Vec2(extentMax.x, extentMax.y));
+            alt = centerPos.z;
+            return this;
+        }
+
+        public Tileable2 WithBounds(Aabr b) { bounds = b; return this; }
+        public Tileable2 WithAlt(int a) { alt = a; return this; }
+        public Tileable2 WithCenter(World.Block block) { center = block; return this; }
+        public Tileable2 WithCenterSprite(World.SpriteKind sprite) => WithCenter(center.WithSprite(sprite));
+        public Tileable2 WithSide(Dir dir, World.Block block) { side[dir] = block; return this; }
+        public Tileable2 WithSideSprite(World.SpriteKind sprite)
+        {
+            foreach (var key in new[] { Dir.X, Dir.NegX, Dir.Y, Dir.NegY })
+                side[key] = side[key].WithSprite(sprite);
+            return this;
+        }
+        public Tileable2 WithSideDir(Dir dir, World.SpriteKind sprite)
+        {
+            side[dir] = side[dir].WithSprite(sprite);
+            return this;
+        }
+        public Tileable2 WithSideAxis(Dir axis, World.SpriteKind sprite)
+        {
+            WithSideDir(axis, sprite);
+            WithSideDir(axis.Opposite(), sprite);
+            return this;
+        }
+        public Tileable2 WithCorner(Dir dir, World.Block block) { corner[dir] = block; return this; }
+        public Tileable2 WithCornerSprite(World.SpriteKind sprite)
+        {
+            foreach (var key in new[] { Dir.X, Dir.NegX, Dir.Y, Dir.NegY })
+                corner[key] = corner[key].WithSprite(sprite);
+            return this;
+        }
+        public Tileable2 WithCornerDir(Dir dir, World.Block block) { corner[dir] = block; return this; }
+        public Tileable2 WithCornerSpriteDir(Dir dir, World.SpriteKind sprite)
+        {
+            corner[dir] = corner[dir].WithSprite(sprite);
+            return this;
+        }
+        public Tileable2 WithCornerSide(Dir axis, World.Block block)
+        {
+            WithCorner(axis, block);
+            WithCorner(axis.RotatedCcw(), block);
+            return this;
+        }
+        public Tileable2 WithCornerSpriteSide(Dir axis, World.SpriteKind sprite)
+        {
+            WithCornerSpriteDir(axis, sprite);
+            WithCornerSpriteDir(axis.RotatedCcw(), sprite);
+            return this;
+        }
+        public Tileable2 WithRotation(Dir dir) { rotation = dir; return this; }
+
+        public int Alt => alt;
+        public Aabr Bounds => bounds;
+        public int2 Size => bounds.Max - bounds.Min + 1;
+        public Dir Rotation => rotation;
+        public World.Block Center => center;
+        public World.Block Side(Dir dir) => side[dir.RelativeTo(rotation)];
+        public World.Block Corner(Dir dir) => corner[dir.RelativeTo(rotation)];
+    }
+}


### PR DESCRIPTION
## Summary
- port tile struct with variant data
- add sprite helpers and orientation utilities
- implement sprite extension for blocks
- update tests to use new tile API

## Testing
- `dotnet test VelorenPort/World.Tests/World.Tests.csproj -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861bd0c9b5483288dcbb66d383b85c4