### PR TITLE
Implement site generation validations

### DIFF
--- a/VelorenPort/World/Src/Site/Stats/SiteGenerationStats.cs
+++ b/VelorenPort/World/Src/Site/Stats/SiteGenerationStats.cs
@@ -60,6 +60,7 @@ namespace VelorenPort.World.Site.Stats
         private readonly Dictionary<GenStatEventKind, uint> _events = new();
 
         public IReadOnlyDictionary<GenStatEventKind, uint> Events => _events;
+        public IReadOnlyDictionary<GenStatPlotKind, GenPlot> Stats => _stats;
 
         public GenSite(GenStatSiteKind kind, string name)
         {
@@ -97,6 +98,175 @@ namespace VelorenPort.World.Site.Stats
             }
             foreach (var ev in _events)
                 yield return $"{ev.Key}: {ev.Value}";
+        }
+
+        private void AtLeast(uint count, GenStatPlotKind plotKind, GenPlot plot, List<string> errors)
+        {
+            if (plot.Successful < count)
+                errors.Add($"  {Kind} {Name} {plotKind}: {plot.Successful}/{plot.Attempts} GenError: expected at least {count}");
+        }
+
+        private void AtMost(uint count, GenStatPlotKind plotKind, GenPlot plot, List<string> errors)
+        {
+            if (plot.Successful > count)
+                errors.Add($"  {Kind} {Name} {plotKind}: {plot.Successful}/{plot.Attempts} GenError: expected at most {count}");
+        }
+
+        private void ShouldNotBeZero(GenStatPlotKind plotKind, GenPlot plot, List<string> warnings)
+        {
+            if (plot.Successful == 0)
+                warnings.Add($"  {Kind} {Name} {plotKind}: {plot.Successful}/{plot.Attempts} GenWarn: should not be zero");
+        }
+
+        private void SuccessRate(float rate, GenStatPlotKind plotKind, GenPlot plot, List<string> warnings)
+        {
+            if ((float)plot.Successful / plot.Attempts < rate)
+                warnings.Add($"  {Kind} {Name} {plotKind}: GenWarn: success rate less than {rate} ({plot.Successful}/{plot.Attempts})");
+        }
+
+        public void Validate(List<string> errors, List<string> warnings)
+        {
+            foreach (var kv in _stats)
+            {
+                var kind = kv.Key;
+                var plot = kv.Value;
+                switch (Kind)
+                {
+                    case GenStatSiteKind.Terracotta:
+                        switch (kind)
+                        {
+                            case GenStatPlotKind.InitialPlaza:
+                                AtLeast(1, kind, plot, errors);
+                                break;
+                            case GenStatPlotKind.Plaza:
+                                ShouldNotBeZero(kind, plot, warnings);
+                                break;
+                            case GenStatPlotKind.House:
+                                AtLeast(1, kind, plot, errors);
+                                SuccessRate(0.1f, kind, plot, warnings);
+                                break;
+                            case GenStatPlotKind.Yard:
+                                ShouldNotBeZero(kind, plot, warnings);
+                                break;
+                        }
+                        break;
+                    case GenStatSiteKind.Myrmidon:
+                        switch (kind)
+                        {
+                            case GenStatPlotKind.InitialPlaza:
+                                AtLeast(1, kind, plot, errors);
+                                break;
+                            case GenStatPlotKind.Plaza:
+                                ShouldNotBeZero(kind, plot, warnings);
+                                break;
+                            case GenStatPlotKind.House:
+                                AtLeast(1, kind, plot, errors);
+                                SuccessRate(0.1f, kind, plot, warnings);
+                                break;
+                        }
+                        break;
+                    case GenStatSiteKind.City:
+                        switch (kind)
+                        {
+                            case GenStatPlotKind.InitialPlaza:
+                                AtLeast(1, kind, plot, errors);
+                                break;
+                            case GenStatPlotKind.Plaza:
+                                ShouldNotBeZero(kind, plot, warnings);
+                                break;
+                            case GenStatPlotKind.Workshop:
+                                AtLeast(1, kind, plot, errors);
+                                break;
+                            case GenStatPlotKind.House:
+                                AtLeast(1, kind, plot, errors);
+                                SuccessRate(0.2f, kind, plot, warnings);
+                                break;
+                        }
+                        break;
+                    case GenStatSiteKind.CliffTown:
+                        switch (kind)
+                        {
+                            case GenStatPlotKind.InitialPlaza:
+                                AtLeast(1, kind, plot, errors);
+                                break;
+                            case GenStatPlotKind.Plaza:
+                                ShouldNotBeZero(kind, plot, warnings);
+                                break;
+                            case GenStatPlotKind.House:
+                                AtLeast(5, kind, plot, errors);
+                                SuccessRate(0.5f, kind, plot, warnings);
+                                break;
+                            case GenStatPlotKind.AirshipDock:
+                                ShouldNotBeZero(kind, plot, warnings);
+                                SuccessRate(0.1f, kind, plot, warnings);
+                                break;
+                        }
+                        break;
+                    case GenStatSiteKind.SavannahTown:
+                        switch (kind)
+                        {
+                            case GenStatPlotKind.InitialPlaza:
+                                AtLeast(1, kind, plot, errors);
+                                break;
+                            case GenStatPlotKind.Plaza:
+                                ShouldNotBeZero(kind, plot, warnings);
+                                break;
+                            case GenStatPlotKind.Workshop:
+                                AtLeast(1, kind, plot, errors);
+                                break;
+                            case GenStatPlotKind.House:
+                                AtLeast(1, kind, plot, errors);
+                                SuccessRate(0.5f, kind, plot, warnings);
+                                break;
+                            case GenStatPlotKind.AirshipDock:
+                                ShouldNotBeZero(kind, plot, warnings);
+                                break;
+                        }
+                        break;
+                    case GenStatSiteKind.CoastalTown:
+                        switch (kind)
+                        {
+                            case GenStatPlotKind.InitialPlaza:
+                                AtLeast(1, kind, plot, errors);
+                                break;
+                            case GenStatPlotKind.Plaza:
+                                ShouldNotBeZero(kind, plot, warnings);
+                                break;
+                            case GenStatPlotKind.Workshop:
+                                AtLeast(1, kind, plot, errors);
+                                break;
+                            case GenStatPlotKind.House:
+                                AtLeast(1, kind, plot, errors);
+                                SuccessRate(0.5f, kind, plot, warnings);
+                                break;
+                            case GenStatPlotKind.AirshipDock:
+                                ShouldNotBeZero(kind, plot, warnings);
+                                AtMost(1, kind, plot, errors);
+                                break;
+                        }
+                        break;
+                    case GenStatSiteKind.DesertCity:
+                        switch (kind)
+                        {
+                            case GenStatPlotKind.InitialPlaza:
+                                AtLeast(1, kind, plot, errors);
+                                break;
+                            case GenStatPlotKind.Plaza:
+                                ShouldNotBeZero(kind, plot, warnings);
+                                break;
+                            case GenStatPlotKind.MultiPlot:
+                                AtLeast(1, kind, plot, errors);
+                                break;
+                            case GenStatPlotKind.Temple:
+                                ShouldNotBeZero(kind, plot, warnings);
+                                break;
+                            case GenStatPlotKind.AirshipDock:
+                                ShouldNotBeZero(kind, plot, warnings);
+                                break;
+                        }
+                        break;
+                }
+            }
         }
     }
 
@@ -156,8 +326,16 @@ namespace VelorenPort.World.Site.Stats
             foreach (var site in _sites.Values)
             {
                 lines.Add(site.Header);
+                var errors = new List<string>();
+                var warnings = new List<string>();
+                site.Validate(errors, warnings);
                 foreach (var line in site.FormatStats(verbose))
                     lines.Add($"  {line}");
+                foreach (var err in errors)
+                    lines.Add(err);
+                if (verbose)
+                    foreach (var warn in warnings)
+                        lines.Add(warn);
             }
 
             var output = string.Join(Environment.NewLine, lines);

--- a/VelorenPort/World/Src/Site/Util/Dir.cs
+++ b/VelorenPort/World/Src/Site/Util/Dir.cs
@@ -159,6 +159,36 @@ namespace VelorenPort.World.Site.Util
             _ => 6,
         };
 
+        public static (Aabr first, Aabr second) SplitAabrOffset(this Dir dir, Aabr aabr, int offset)
+        {
+            return dir switch
+            {
+                Dir.X =>
+                    (new Aabr(aabr.Min, new int2(aabr.Min.x + offset, aabr.Max.y)),
+                     new Aabr(new int2(aabr.Min.x + offset, aabr.Min.y), aabr.Max)),
+                Dir.Y =>
+                    (new Aabr(aabr.Min, new int2(aabr.Max.x, aabr.Min.y + offset)),
+                     new Aabr(new int2(aabr.Min.x, aabr.Min.y + offset), aabr.Max)),
+                Dir.NegX =>
+                    (new Aabr(new int2(aabr.Max.x - offset, aabr.Min.y), aabr.Max),
+                     new Aabr(aabr.Min, new int2(aabr.Max.x - offset, aabr.Max.y))),
+                _ =>
+                    (new Aabr(new int2(aabr.Min.x, aabr.Max.y - offset), aabr.Max),
+                     new Aabr(aabr.Min, new int2(aabr.Max.x, aabr.Max.y - offset))),
+            };
+        }
+
+        public static Aabr ExtendAabr(this Dir dir, Aabr aabr, int amount)
+        {
+            int2 offset = dir.ToVec2() * amount;
+            return dir.IsPositive()
+                ? new Aabr(aabr.Min, aabr.Max + offset)
+                : new Aabr(aabr.Min + offset, aabr.Max);
+        }
+
+        public static Aabr TrimAabr(this Dir dir, Aabr aabr, int amount)
+            => dir.Opposite().ExtendAabr(aabr, -amount);
+
         public static (Dir dir, int rest)? FromSpriteOri(int ori)
         {
             Dir dir = ori / 2 switch
@@ -302,5 +332,41 @@ namespace VelorenPort.World.Site.Util
             (Dir3.Y or Dir3.NegY, Dir3.Y or Dir3.NegY) => Dir3.X,
             _ => Dir3.Y,
         };
+
+        public static (Aabb first, Aabb second) SplitAabbOffset(this Dir3 dir, Aabb aabb, int offset)
+        {
+            return dir switch
+            {
+                Dir3.X =>
+                    (new Aabb(aabb.Min, new int3(aabb.Min.x + offset, aabb.Max.y, aabb.Max.z)),
+                     new Aabb(new int3(aabb.Min.x + offset, aabb.Min.y, aabb.Min.z), aabb.Max)),
+                Dir3.Y =>
+                    (new Aabb(aabb.Min, new int3(aabb.Max.x, aabb.Min.y + offset, aabb.Max.z)),
+                     new Aabb(new int3(aabb.Min.x, aabb.Min.y + offset, aabb.Min.z), aabb.Max)),
+                Dir3.Z =>
+                    (new Aabb(aabb.Min, new int3(aabb.Max.x, aabb.Max.y, aabb.Min.z + offset)),
+                     new Aabb(new int3(aabb.Min.x, aabb.Min.y, aabb.Min.z + offset), aabb.Max)),
+                Dir3.NegX =>
+                    (new Aabb(new int3(aabb.Max.x - offset, aabb.Min.y, aabb.Min.z), aabb.Max),
+                     new Aabb(aabb.Min, new int3(aabb.Max.x - offset, aabb.Max.y, aabb.Max.z))),
+                Dir3.NegY =>
+                    (new Aabb(new int3(aabb.Min.x, aabb.Max.y - offset, aabb.Min.z), aabb.Max),
+                     new Aabb(aabb.Min, new int3(aabb.Max.x, aabb.Max.y - offset, aabb.Max.z))),
+                _ =>
+                    (new Aabb(new int3(aabb.Min.x, aabb.Min.y, aabb.Max.z - offset), aabb.Max),
+                     new Aabb(aabb.Min, new int3(aabb.Max.x, aabb.Max.y, aabb.Max.z - offset))),
+            };
+        }
+
+        public static Aabb ExtendAabb(this Dir3 dir, Aabb aabb, int amount)
+        {
+            int3 offset = dir.ToVec3() * amount;
+            return dir.IsPositive()
+                ? new Aabb(aabb.Min, aabb.Max + offset)
+                : new Aabb(aabb.Min + offset, aabb.Max);
+        }
+
+        public static Aabb TrimAabb(this Dir3 dir, Aabb aabb, int amount)
+            => dir.Opposite().ExtendAabb(aabb, -amount);
     }
 }


### PR DESCRIPTION
## Summary
- implement plot validation helpers for min/max/success rate checking
- expose stats and run validations when logging
- add Aabr/Aabb helper utilities in Dir orientation helpers

## Testing
- `dotnet test VelorenPort/VelorenPort.sln --no-build` *(fails: `dotnet` not found)*


------
https://chatgpt.com/codex/tasks/task_e_6861c2c8b8f883289c18c607fd07cc99