### PR TITLE
Add GuardTower plot and stats query

### DIFF
--- a/VelorenPort/World.Tests/CivGeneratorTests.cs
+++ b/VelorenPort/World.Tests/CivGeneratorTests.cs
@@ -121,4 +121,21 @@ public class CivGeneratorTests
         CivGenerator.Generate(world, index, 1);
         Assert.NotEmpty(index.DecorationEvents);
     }
+
+    [Fact]
+    public void Generate_WithStats_CountsSitesAndPlotVariety()
+    {
+        var (world, index) = World.Empty();
+        var stats = new SitesGenMeta(99);
+        CivGenerator.Generate(world, index, 2, stats);
+
+        Assert.Equal(2, stats.SiteCount);
+        Assert.Equal(2, index.Sites.Items.Count);
+
+        var kinds = index.PlotEvents.Select(e => e.Kind).Distinct().ToList();
+        Assert.True(kinds.Count > 1);
+
+        foreach (var name in stats.SiteNames)
+            Assert.True(stats.GetEventCount(name, GenStatEventKind.PopulationBirth) > 0);
+    }
 }

--- a/VelorenPort/World/Src/Site/Plot.cs
+++ b/VelorenPort/World/Src/Site/Plot.cs
@@ -42,6 +42,7 @@ namespace VelorenPort.World.Site
         Adlet,
         Haniwa,
         GiantTree,
+        GuardTower,
         CliffTower,
         CliffTownAirshipDock,
         Sahagin,

--- a/VelorenPort/World/Src/Site/Stats/SiteGenerationStats.cs
+++ b/VelorenPort/World/Src/Site/Stats/SiteGenerationStats.cs
@@ -277,6 +277,8 @@ namespace VelorenPort.World.Site.Stats
     {
         private readonly Dictionary<string, GenSite> _sites = new();
         public uint Seed { get; }
+        public int SiteCount => _sites.Count;
+        public IEnumerable<string> SiteNames => _sites.Keys;
 
         public SitesGenMeta(uint seed)
         {


### PR DESCRIPTION
## Summary
- add missing `GuardTower` plot to `PlotKind`
- expose site count and names in `SitesGenMeta`
- test site stats collection

## Testing
- `dotnet test VelorenPort/VelorenPort.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861cb4b88fc8328bab4394a77a59ae0