### PR TITLE
Add wildlife density and resource simulation

### DIFF
--- a/VelorenPort/World.Tests/WildlifeBehaviourTests.cs
+++ b/VelorenPort/World.Tests/WildlifeBehaviourTests.cs
@@ -53,4 +53,22 @@ public class WildlifeBehaviourTests
         var (chunk2, sup2) = TerrainGenerator.GenerateChunkWithSupplement(int2.zero, noise);
         Assert.Equal(sup1.ResourceDeposits.Count, sup2.ResourceDeposits.Count);
     }
+
+    [Fact]
+    public void WorldSim_TickUpdatesResourceAmounts()
+    {
+        var index = new WorldIndex(0);
+        var sim = new WorldSim(0, new int2(1, 1));
+        var (chunk, sup) = index.Map.GetOrGenerateWithSupplement(int2.zero, index.Noise);
+        sup.ResourceDeposits.Clear();
+        var dep = new ResourceDeposit(new int3(0, 0, 0), BlockKind.GlowingRock, 1f);
+        sup.ResourceDeposits.Add(dep);
+        sim.Tick(index, 1f);
+        Assert.True(sup.ResourceDeposits[0].Amount > 1f);
+
+        sup.WildlifeEntities.Add(new WildlifeEntity(new int3(0, 0, 0), FaunaKind.Rabbit));
+        float before = sup.ResourceDeposits[0].Amount;
+        sim.Tick(index, 1f);
+        Assert.True(sup.ResourceDeposits[0].Amount < before);
+    }
 }

--- a/VelorenPort/World/Src/Layer/WildlifeLayer.cs
+++ b/VelorenPort/World/Src/Layer/WildlifeLayer.cs
@@ -1,9 +1,22 @@
+using System;
+using System.Collections.Generic;
 using VelorenPort.NativeMath;
+using static VelorenPort.NativeMath.math;
 
 namespace VelorenPort.World.Layer;
 
 public static class WildlifeLayer
 {
+    public delegate float DensityFunc(LayerContext ctx, float3 wpos, int top);
+
+    private static readonly Dictionary<FaunaKind, DensityFunc> DensityFuncs = new()
+    {
+        { FaunaKind.Wolf, (ctx, pos, _) => math.saturate(ctx.Noise.Wildlife(pos * 0.12f) - 0.8f) },
+        { FaunaKind.Bear, (ctx, pos, _) => ctx.Noise.Cave(pos * 0.05f) > 0.7f ? 0.05f : 0f },
+        { FaunaKind.Deer, (ctx, pos, _) => ctx.Noise.Tree(pos * 0.07f) > 0.8f ? 0.3f : 0f },
+        { FaunaKind.Rabbit, (ctx, pos, _) => ctx.Supplement.ResourceDeposits.Exists(d => !d.Depleted && math.length((float3)d.Position - pos) < 3f) ? 0.5f : 0.05f }
+    };
+
     public static void Apply(LayerContext ctx, Chunk chunk)
     {
         for (int x = 0; x < Chunk.Size.x; x++)
@@ -25,20 +38,24 @@ public static class WildlifeLayer
                 chunk.Position.x * Chunk.Size.x + x,
                 chunk.Position.y * Chunk.Size.y + y,
                 top + 1);
-            float n = ctx.Noise.Wildlife(wpos * 0.15f);
-            if (n > 0.85f)
+
+            foreach (var (kind, func) in DensityFuncs)
             {
-                FaunaKind kind = (FaunaKind)((int)(n * 10) % 4 + 1);
-                var spawn = new FaunaSpawn((int3)wpos, kind);
-                chunk.AddWildlife(spawn);
-                ctx.Supplement.Wildlife.Add(spawn);
-                ctx.Supplement.WildlifeEntities.Add(new WildlifeEntity(spawn.Position, spawn.Kind));
+                float prob = func(ctx, wpos, top) * 0.1f;
+                if (ctx.Rng.NextDouble() < prob)
+                {
+                    var spawn = new FaunaSpawn((int3)wpos, kind);
+                    chunk.AddWildlife(spawn);
+                    ctx.Supplement.Wildlife.Add(spawn);
+                    ctx.Supplement.WildlifeEntities.Add(new WildlifeEntity(spawn.Position, spawn.Kind));
+                    break;
+                }
             }
         }
 
         foreach (var deposit in ctx.Supplement.ResourceDeposits)
         {
-            if (deposit.Depleted || ctx.Rng.NextDouble() > 0.25)
+            if (deposit.Depleted || deposit.Amount <= 0f || ctx.Rng.NextDouble() > 0.25)
                 continue;
             int3 pos = deposit.Position + new int3(0, 0, 1);
             var spawn = new FaunaSpawn(pos, FaunaKind.Rabbit);

--- a/VelorenPort/World/Src/ResourceDeposit.cs
+++ b/VelorenPort/World/Src/ResourceDeposit.cs
@@ -12,14 +12,30 @@ namespace VelorenPort.World
         public int3 Position { get; set; }
         public BlockKind Kind { get; set; }
         public bool Depleted { get; private set; }
+        public float Amount { get; private set; }
 
-        public ResourceDeposit(int3 position, BlockKind kind)
+        public ResourceDeposit(int3 position, BlockKind kind, float amount = 10f)
         {
             Position = position;
             Kind = kind;
             Depleted = false;
+            Amount = amount;
         }
 
-        public void MarkDepleted() => Depleted = true;
+        public void MarkDepleted()
+        {
+            Depleted = true;
+            Amount = 0f;
+        }
+
+        public void Produce(float amt) => Amount += amt;
+
+        public void Consume(float amt)
+        {
+            if (Depleted) return;
+            Amount = Math.Max(0f, Amount - amt);
+            if (Amount <= 0f)
+                MarkDepleted();
+        }
     }
 }

--- a/VelorenPort/World/Src/WildlifeEntity.cs
+++ b/VelorenPort/World/Src/WildlifeEntity.cs
@@ -67,7 +67,7 @@ namespace VelorenPort.World
                 float dist = math.length((float3)dep.Position - (float3)Position);
                 if (dist <= 1.5f)
                 {
-                    dep.MarkDepleted();
+                    dep.Consume(0.2f);
                     deposits[i] = dep;
                     break;
                 }

--- a/VelorenPort/World/Src/WorldSim.cs
+++ b/VelorenPort/World/Src/WorldSim.cs
@@ -367,6 +367,29 @@ namespace VelorenPort.World
         {
             index.EconomyContext.Tick(index, dt);
             Tick(dt);
+            UpdateResourcesAndWildlife(index, dt);
+        }
+
+        private void UpdateResourcesAndWildlife(WorldIndex index, float dt)
+        {
+            foreach (var chunk in index.Map.Chunks)
+            {
+                var sup = index.Map.GetSupplement(chunk.Position);
+                if (sup == null) continue;
+
+                for (int i = 0; i < sup.WildlifeEntities.Count; i++)
+                    sup.WildlifeEntities[i].Tick(dt, sup.ResourceDeposits);
+
+                for (int i = 0; i < sup.ResourceDeposits.Count; i++)
+                {
+                    var dep = sup.ResourceDeposits[i];
+                    if (!dep.Depleted)
+                    {
+                        dep.Produce(0.1f * dt);
+                        sup.ResourceDeposits[i] = dep;
+                    }
+                }
+            }
         }
 
 


### PR DESCRIPTION
## Summary
- expand wildlife layer with density functions
- track resource deposit amounts
- update wildlife behavior to consume resources
- simulate resource production and wildlife updates each tick
- test resource amount changes after ticks

## Testing
- `dotnet test VelorenPort/VelorenPort.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861cb50e8508328998a1f31e0efd79b