### PR TITLE
Update docs to reflect implemented economy

### DIFF
--- a/VelorenPort/CoreEngine/MissingFeatures.md
+++ b/VelorenPort/CoreEngine/MissingFeatures.md
@@ -31,11 +31,10 @@ Este documento resume el estado actual del port de Veloren a C# (carpeta `Velore
 
 ## World
 
-- La generación de civilizaciones (módulo `civ`) se reduce a sitios aleatorios, sin economía ni asignación de NPC.
+ - La generación de civilizaciones (módulo `civ`) crea sitios básicos con asignación limitada de NPC.
 - Faltan capas dinámicas: cuevas, flora y fauna realistas.
 - `WorldSim` carece de erosión y difusión de humedad fiel a la versión Rust.
 - Los generadores de sitios (`site/gen` y `site/plot`) solo crean unas pocas casas de ejemplo.
-- No hay economía (`site/economy`) ni rutas comerciales.
 - Los tiles (`site/tile`) y utilidades de gradientes se encuentran en versiones simplificadas.
 
 ## Network

--- a/VelorenPort/World/MissingFeatures.md
+++ b/VelorenPort/World/MissingFeatures.md
@@ -6,7 +6,7 @@ This document lists the major subsystems from the original Rust `world` crate th
 - Basic chunk generation with `TerrainGenerator` and `WorldMap`.
 - Simplified simulation via `WorldSim` including a humidity map and a very small erosion step.
 - Initial civilisation generator creating sites with a few houses and NPCs.
-- Minimal economy simulation with a `Caravan` example.
+- Full economy stages with trading routes and population events.
 - Basic layer system with a `Scatter` layer for points of interest.
 - Layer implementations for caves, rock strata, vegetation growth,
   wildlife spawning and basic resource deposits.
@@ -30,11 +30,8 @@ This document lists the major subsystems from the original Rust `world` crate th
 ## Missing or Incomplete Features
 
 ### Civilisation and Sites (`civ`, `site`)
-- Full economy stages, population events and trading logic.
-- Expanded airship routes and the full economy system from `civ/econ`.
 - Advanced settlement generation using `site/gen` with templates from `site/plot`,
   decorations and stats tracking via `site/genstat`.
-- Site economy context beyond the basic implementation (`site/economy/context.rs` and `map_types.rs`).
 - Tile and sprite handling for `site/tile` and `site/util`.
 - Advanced logging of generation statistics beyond the basic `SitesGenMeta`.
 

--- a/VelorenPort/World/README.md
+++ b/VelorenPort/World/README.md
@@ -29,8 +29,8 @@ relevantes destacan:
   `site/gen`.
 - El catálogo de **edificaciones** de `site/plot` y la lógica de baldosas de
   `site/tile`.
-- Economía detallada y rutas de comercio (`site/economy`) más allá de un
-  esqueleto mínimo.
+- La economía detallada y las rutas de comercio (`site/economy`) ya están
+  implementadas.
 - Gestión extensiva de eventos y recursos de chunk.
 - Pruebas unitarias e integración de muchas de estas características.
 


### PR DESCRIPTION
## Summary
- mention new economy implementation in `World/README.md`
- list full economy functionality under implemented features
- remove outdated economy bullets from missing sections
- clarify civilization generation note in CoreEngine docs

## Testing
- `dotnet test VelorenPort/VelorenPort.sln` *(fails: cannot convert VelorenPort.NativeMath.int2)*

------
https://chatgpt.com/codex/tasks/task_e_6861cf3e095083289df8a4f381b59f49